### PR TITLE
修复tl-wdr6500 v6 无线

### DIFF
--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -144,6 +144,11 @@ case "$FIRMWARE" in
 	archer-c58-v1)
 		ath10kcal_extract "art" 20480 12064
 		;;
+	tl-wdr6500-v6)
+		ath10kcal_extract "art" 8192 12064
+		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
+			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
+		;;
 	esac
 	;;
 *)

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -15,6 +15,9 @@ case "$board" in
 	archer-c58-v1)
 		echo $(macaddr_add $(mtd_get_mac_binary mac 8)  $(($PHYNBR - 1)) ) > /sys${DEVPATH}/macaddress
 		;;
+	tl-wdr6500-v6)
+		echo $(macaddr_add $(mtd_get_mac_binary art 2061)  $(($PHYNBR - 2)) ) > /sys${DEVPATH}/macaddress
+		;;
 	*)
 		;;
 esac

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wdr6500-v6.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wdr6500-v6.c
@@ -1,12 +1,20 @@
 /*
  *  TP-LINK TL-WDR6500 v6
  *
+ *  Copyright (C) 2015 Weijie Gao <hackpascal@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 as published
+ *  by the Free Software Foundation.
  */
+
 #include <linux/pci.h>
 #include <linux/gpio.h>
 #include <linux/platform_device.h>
+
 #include <asm/mach-ath79/ath79.h>
 #include <asm/mach-ath79/ar71xx_regs.h>
+
 #include "common.h"
 #include "dev-eth.h"
 #include "dev-ap9x-pci.h"
@@ -17,24 +25,31 @@
 #include "dev-wmac.h"
 #include "machtypes.h"
 #include "pci.h"
+
 #define TL_WDR6500_V6_GPIO_LED_SYS	21
 #define TL_WDR6500_V6_GPIO_LED_WAN	18
 #define TL_WDR6500_V6_GPIO_LED_LAN1	17
 #define TL_WDR6500_V6_GPIO_LED_LAN2	16
 #define TL_WDR6500_V6_GPIO_LED_LAN3	15
 #define TL_WDR6500_V6_GPIO_LED_LAN4	14
+
 #define TL_WDR6500_V6_GPIO_BTN_RESET	1
+
 #define TL_WDR6500_V6_KEYS_POLL_INTERVAL	20	/* msecs */
 #define TL_WDR6500_V6_KEYS_DEBOUNCE_INTERVAL	(3 * TL_WDR6500_V6_KEYS_POLL_INTERVAL)
+
 #define TL_WDR6500_V6_WMAC_CALDATA_OFFSET	0x1000
-#define TL_WDR6500_V6_PCIE_CALDATA_OFFSET	0x5000
+#define TL_WDR6500_V6_PCIE_CALDATA_OFFSET	0x2000
+
 static const char *tl_wdr6500_v6_part_probes[] = {
 	"tp-link-64k",
 	NULL,
 };
+
 static struct flash_platform_data tl_wdr6500_v6_flash_data = {
 	.part_probes	= tl_wdr6500_v6_part_probes,
 };
+
 static struct gpio_led tl_wdr6500_v6_leds_gpio[] __initdata = {
 	{
 		.name		= "tp-link:green:lan1",
@@ -62,6 +77,7 @@ static struct gpio_led tl_wdr6500_v6_leds_gpio[] __initdata = {
 		.active_low	= 0,
 	},
 };
+
 static struct gpio_keys_button tl_wdr6500_v6_gpio_keys[] __initdata = {
 	{
 		.desc		= "Reset button",
@@ -72,15 +88,20 @@ static struct gpio_keys_button tl_wdr6500_v6_gpio_keys[] __initdata = {
 		.active_low	= 1,
 	}
 };
+
+
 static void __init tl_ap151_setup(void)
 {
-	u8 *mac = (u8 *) KSEG1ADDR(0x1f00fc00);
-	u8 *ee = (u8 *) KSEG1ADDR(0x1fff0000);
+	u8 *mac = (u8 *) KSEG1ADDR(0x1fff080d);
+	u8 *art = (u8 *) KSEG1ADDR(0x1fff0000);
 	u8 tmpmac[ETH_ALEN];
-	ath79_register_usb();
+
 	ath79_register_m25p80(&tl_wdr6500_v6_flash_data);
+
 	ath79_setup_ar933x_phy4_switch(false, false);
+
 	ath79_register_mdio(1, 0x0);
+
 	/* WAN */
 	ath79_switch_data.phy4_mii_en = 1;
 	ath79_switch_data.phy_poll_mask = BIT(4);
@@ -89,25 +110,31 @@ static void __init tl_ap151_setup(void)
 	ath79_eth0_data.mii_bus_dev = &ath79_mdio1_device.dev;
 	ath79_init_mac(ath79_eth0_data.mac_addr, mac, 1);
 	ath79_register_eth(0);
+
 	/* LAN */
 	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
 	ath79_eth1_data.duplex = DUPLEX_FULL;
 	ath79_eth1_data.speed = SPEED_1000;
 	ath79_init_mac(ath79_eth1_data.mac_addr, mac, 0);
 	ath79_register_eth(1);
+
 	ath79_init_mac(tmpmac, mac, -1);
-	ath79_register_wmac(ee + TL_WDR6500_V6_WMAC_CALDATA_OFFSET, tmpmac);
-	ath79_register_pci();
-	ath79_register_usb();
+	ath79_register_wmac(art + TL_WDR6500_V6_WMAC_CALDATA_OFFSET, tmpmac);
+
+	ap91_pci_init(art + TL_WDR6500_V6_PCIE_CALDATA_OFFSET, NULL);
 }
+
 static void __init tl_wdr6500_v6_setup(void)
 {
 	tl_ap151_setup();
+
 	ath79_register_leds_gpio(-1, ARRAY_SIZE(tl_wdr6500_v6_leds_gpio),
 				 tl_wdr6500_v6_leds_gpio);
+
 	ath79_register_gpio_keys_polled(1, TL_WDR6500_V6_KEYS_POLL_INTERVAL,
 					ARRAY_SIZE(tl_wdr6500_v6_gpio_keys),
 					tl_wdr6500_v6_gpio_keys);
 }
+
 MIPS_MACHINE(ATH79_MACH_TL_WDR6500_V6, "TL-WDR6500-v6", "TP-LINK TL-WDR6500 v6",
 	     tl_wdr6500_v6_setup);

--- a/target/linux/ar71xx/image/tp-link.mk
+++ b/target/linux/ar71xx/image/tp-link.mk
@@ -643,12 +643,24 @@ define Device/tl-wdr6500-v2
   TPLINK_HEADER_VERSION := 2
 endef
 
+define Device/tl-wdr6500-v6
+$(Device/tplink-8mlzma)
+  DEVICE_TITLE := TP-LINK TL-WDR6500 v6
+  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca9888
+  KERNEL := kernel-bin | patch-cmdline | lzma | uImage lzma
+  KERNEL_INITRAMFS := kernel-bin | patch-cmdline | lzma | uImage lzma | tplink-v1-header
+  BOARDNAME = TL-WDR6500-v6
+  DEVICE_PROFILE = TLWDR6500V6
+  TPLINK_HWID := 0x65000006
+  TPLINK_HEADER_VERSION := 2
+endef
+
 define Device/mw4530r-v1
   $(Device/tl-wdr4300-v1)
   DEVICE_TITLE := Mercury MW4530R v1
   TPLINK_HWID := 0x45300001
 endef
-TARGET_DEVICES += tl-wdr3320-v2 tl-wdr3500-v1 tl-wdr3600-v1 tl-wdr4300-v1 tl-wdr4300-v1-il tl-wdr4310-v1 tl-wdr4900-v2 tl-wdr6500-v2 mw4530r-v1
+TARGET_DEVICES += tl-wdr3320-v2 tl-wdr3500-v1 tl-wdr3600-v1 tl-wdr4300-v1 tl-wdr4300-v1-il tl-wdr4310-v1 tl-wdr4900-v2 tl-wdr6500-v2 tl-wdr6500-v6 mw4530r-v1
 
 define Device/tl-wpa8630-v1
   $(Device/tplink-8mlzma)
@@ -1136,19 +1148,6 @@ define Device/tl-wr941n-v7
     TPLINK_HWID := 0x09410007
 endef
 TARGET_DEVICES += tl-wr941n-v7
-
-define Device/tl-wdr6500-v6
-  $(Device/tplink-8mlzma)
-  DEVICE_TITLE := TP-LINK TL-WDR6500 v6
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2
-  KERNEL := kernel-bin | patch-cmdline | lzma | uImage lzma
-  KERNEL_INITRAMFS := kernel-bin | patch-cmdline | lzma | uImage lzma | mktplinkfw-combined
-  BOARDNAME := TL-WDR6500-v6
-  DEVICE_PROFILE := TLWDR6500V6
-  TPLINK_HWID := 0x65000006
-  TPLINK_HEADER_VERSION := 2
-endef
-TARGET_DEVICES += tl-wdr6500-v6
 
 define Device/tl-wr842n-v9
   $(Device/tplink-8mlzma)


### PR DESCRIPTION
 由于tl-wdr6500 v6和tl-wdr6500 v2分区结构相异，直接用v2的代码编译出来的固件无法正常工作。
官方固件v6的art信息位于0x1c000(2.4G), 0x1d000(5G)处，mac位于0x1b80d，而v2的art位于最后64kb，0x7f1000(2.4G)，0x7f5000(5G)处，mac位于0xfc00。要对代码和art分区进行修改才能正常工作。
第一次刷固件，先将0x1b000开始的64kb复制到flash最后64kb，防止art被固件覆盖。
usb转ttl线进uboot命令行，运行以下命令改art分区
   erase 0x9f7f0000 +0x10000
   cp.b 0x80060000 0x9f01b000 0x10000
   cp.b 0x9f7f0000 0x80060000 0x10000
之后ttl刷入v2的breed(v6没有专用的breed...)，进breed刷固件。