### PR TITLE
fix the aliddns that can't add * or @

### DIFF
--- a/package/lean/luci-app-aliddns/root/usr/sbin/aliddns
+++ b/package/lean/luci-app-aliddns/root/usr/sbin/aliddns
@@ -14,7 +14,8 @@ ip=$(ifconfig $interface 2> /dev/null | grep 'inet addr' | awk '{print $2}' | cu
 
 check_aliddns() {
 #ip=`wget -qO- http://whatismyip.akamai.com/ 2>/dev/null`
-current_ip=`nslookup $aliddns_name.$aliddns_domain | grep "Address 1"|tail -n1|cut -d' ' -f3  2>/dev/null`
+#current_ip=`nslookup $aliddns_name.$aliddns_domain | grep "Address 1"|tail -n1|cut -d' ' -f3  2>/dev/null`
+current_ip=`query_recordid | sed 's/.*,"Value":"\([0-9\.]*\)",.*/\1/'`
 echo "$DATE 当前路由IP: ${ip}" >> /var/log/aliddns.log
 echo "$DATE 远程解析IP: ${current_ip}" >> /var/log/aliddns.log
 if [ "$ip" = "$current_ip" ]
@@ -55,15 +56,15 @@ get_recordid() {
 }
 
 query_recordid() {
-    send_request "DescribeSubDomainRecords" "SignatureMethod=HMAC-SHA1&SignatureNonce=$timestamp&SignatureVersion=1.0&SubDomain=$aliddns_name.$aliddns_domain&Timestamp=$timestamp"
+    send_request "DescribeSubDomainRecords" "SignatureMethod=HMAC-SHA1&SignatureNonce=$timestamp&SignatureVersion=1.0&SubDomain=$(urlencode "$aliddns_name").$aliddns_domain&Timestamp=$timestamp"
 }
 
 update_record() {
-    send_request "UpdateDomainRecord" "RR=$aliddns_name&RecordId=$1&SignatureMethod=HMAC-SHA1&SignatureNonce=$timestamp&SignatureVersion=1.0&Timestamp=$timestamp&Type=A&Value=$ip"
+    send_request "UpdateDomainRecord" "RR=$(urlencode "$aliddns_name")&RecordId=$1&SignatureMethod=HMAC-SHA1&SignatureNonce=$timestamp&SignatureVersion=1.0&Timestamp=$timestamp&Type=A&Value=$ip"
 }
 
 add_record() {
-    send_request "AddDomainRecord&DomainName=$aliddns_domain" "RR=$aliddns_name&SignatureMethod=HMAC-SHA1&SignatureNonce=$timestamp&SignatureVersion=1.0&Timestamp=$timestamp&Type=A&Value=$ip"
+    send_request "AddDomainRecord&DomainName=$aliddns_domain" "RR=$(urlencode "$aliddns_name")&SignatureMethod=HMAC-SHA1&SignatureNonce=$timestamp&SignatureVersion=1.0&Timestamp=$timestamp&Type=A&Value=$ip"
 }
 
 go_record() {

--- a/package/lean/luci-app-aliddns/root/usr/sbin/aliddns
+++ b/package/lean/luci-app-aliddns/root/usr/sbin/aliddns
@@ -15,7 +15,7 @@ ip=$(ifconfig $interface 2> /dev/null | grep 'inet addr' | awk '{print $2}' | cu
 check_aliddns() {
 #ip=`wget -qO- http://whatismyip.akamai.com/ 2>/dev/null`
 #current_ip=`nslookup $aliddns_name.$aliddns_domain | grep "Address 1"|tail -n1|cut -d' ' -f3  2>/dev/null`
-current_ip=`query_recordid | sed 's/.*,"Value":"\([0-9\.]*\)",.*/\1/'`
+current_ip=`echo $query_result | sed 's/.*,"Value":"\([0-9\.]*\)",.*/\1/'`
 echo "$DATE 当前路由IP: ${ip}" >> /var/log/aliddns.log
 echo "$DATE 远程解析IP: ${current_ip}" >> /var/log/aliddns.log
 if [ "$ip" = "$current_ip" ]
@@ -70,7 +70,7 @@ add_record() {
 go_record() {
 if [ "$aliddns_record_id" = "" ]
 then
-    aliddns_record_id=`query_recordid | get_recordid`
+    aliddns_record_id=`echo $query_result | get_recordid`
 fi
 if [ "$aliddns_record_id" = "" ]
 then
@@ -120,6 +120,7 @@ if [ "$aliddns_enable" != "1" ]; then
     echo "$DATE : aliddns没有开启！" >> /var/log/aliddns.log
   else
     clean_log
+    query_result=$(query_recordid)
     check_aliddns
     go_record
     add_aliddns_cru  


### PR DESCRIPTION
add urlencode for $aliddns_name,fix the aliddns  that can't add universal parse * or primary domain name @
the current_ip use "query_recordid" instead of "nslookup" and add query_result to replicate "query_recordid"