### PR TITLE
autocore: remove bc and lm-sensors dependencies + remove TARGET_x86 limit + improve init script + add stop script

### DIFF
--- a/package/lean/autocore/Makefile
+++ b/package/lean/autocore/Makefile
@@ -9,19 +9,21 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=autocore
 PKG_VERSION:=1
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
+PKG_MAINTAINER:=Lean
 
 include $(INCLUDE_DIR)/package.mk
 
 define Package/autocore
-  TITLE:=x86/x64 auto core loadbalance script.
-  MAINTAINER:=Lean
-  DEPENDS:=@TARGET_x86 +bc +lm-sensors
+	SECTION:=utils
+	CATEGORY:=Utilities
+	TITLE:=Multicore load-balancing script
+	PKGARCH:=all
 endef
 
 define Package/autocore/description
-A usb autoconfig hotplug script.
+ An autoconfig hotplug script that improves network performance by using Receive Packet Steering (RPS) and Receive Flow Steering (RFS).
 endef
 
 define Build/Compile

--- a/package/lean/autocore/files/autocore
+++ b/package/lean/autocore/files/autocore
@@ -5,31 +5,55 @@ START=99
 
 start()
 {
-  rfc=4096  
-  cc=$(grep -c processor /proc/cpuinfo)  
-  rsfe=$(echo $cc*$rfc | bc)  
-  sysctl -w net.core.rps_sock_flow_entries=$rsfe  
-  for fileRps in $(ls /sys/class/net/eth*/queues/rx-*/rps_cpus)  
-  do
-      echo $cc > $fileRps  
-  done
-        
-  for fileRfc in $(ls /sys/class/net/eth*/queues/rx-*/rps_flow_cnt)  
-  do
-      echo $rfc > $fileRfc  
-  done
-
-  for fileRps in $(ls /sys/class/net/eth*/queues/tx-*/xps_cpus)  
-  do
-      echo $cc > $fileRps  
-  done
-  
-  a=$(cat /proc/cpuinfo | grep name | cut -f2 -d: | uniq)
-  b=$(echo -n ' x ')
-  c=$(cat /proc/cpuinfo | grep 'processor' | wc -l)
-  f=${a}${b}${c}
-  echo $f > /tmp/sysinfo/model
+	rfc=4096
+	cc=$(grep -c processor /proc/cpuinfo)
+	
+	if [ $cc -lt 2 ]; then
+		echo "No need to enable RPC/RFC on a single-core platform."
+		exit 1
+	fi
+	
+	rsfe=$((rfc * cc))
+	sysctl -w net.core.rps_sock_flow_entries=$rsfe
+	for fileRps in $(ls /sys/class/net/eth*/queues/rx-*/rps_cpus)
+	do
+		echo $cc > $fileRps
+	done
+	
+	for fileRfc in $(ls /sys/class/net/eth*/queues/rx-*/rps_flow_cnt)
+	do
+		echo $rfc > $fileRfc
+	done
+	
+	for fileRps in $(ls /sys/class/net/eth*/queues/tx-*/xps_cpus)
+	do
+		echo $cc > $fileRps
+	done
+	
+	a=$(cat /proc/cpuinfo | grep name | cut -f2 -d: | uniq)
+	b=$(echo -n ' x ')
+	c=$(grep -c processor /proc/cpuinfo)
+	f=${a}${b}${c}
+	echo $f > /tmp/sysinfo/model
 }
 
+stop()
+{
+	sysctl -w net.core.rps_sock_flow_entries=0
+	for fileRps in $(ls /sys/class/net/eth*/queues/rx-*/rps_cpus)
+	do
+		echo 0 > $fileRps
+	done
 
+	for fileRfc in $(ls /sys/class/net/eth*/queues/rx-*/rps_flow_cnt)
+	do
+		echo 0 > $fileRfc
+	done
 
+	for fileRps in $(ls /sys/class/net/eth*/queues/tx-*/xps_cpus)
+	do
+		echo 0 > $fileRps
+	done
+
+	rm -f /tmp/sysinfo/model
+}


### PR DESCRIPTION
Remove bc dependency and use shell built-in function to do multiplication.

The script can run on almost all platforms, and has been proved to be effective in improving the network performance on Newifi D1(ramips, MT7621), so remove TARGET_x86 limit and let all other multicore platforms enjoy the optimization.

Compile tested: ramips, Newifi D1, OpenWRT trunk

Signed-off-by: Fushan Wen <qydwhotmail@gmail.com>