### PR TITLE
Update V2ray-core

### DIFF
--- a/package/lean/v2ray/Makefile
+++ b/package/lean/v2ray/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v2ray
-PKG_VERSION:=v3.26
+PKG_VERSION:=v3.33
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
 ifeq ($(ARCH),x86_64)


### PR DESCRIPTION
update v2ray v3.33 v2ray-croe 3.33修正了可能引起的kcp断流现象，建议更新。