### PR TITLE
fixed exists /dev/sfe_ipv6

### DIFF
--- a/package/lean/luci-app-sfe/root/etc/init.d/sfe
+++ b/package/lean/luci-app-sfe/root/etc/init.d/sfe
@@ -20,7 +20,7 @@ start(){
       if [ $ipv6 -eq 1 ];  then
         echo "ipv6"
         sfe_ipv6=$(cat /sys/sfe_ipv6/debug_dev)
-        [ -f /dev/sfe_ipv6 ] && mknod /dev/sfe_ipv6 c $sfe_ipv6 0
+        [ ! -f /dev/sfe_ipv6 ] && mknod /dev/sfe_ipv6 c $sfe_ipv6 0
       else
         echo "no ipv6"
         rm -f /dev/sfe_ipv6


### PR DESCRIPTION
如果/dev/sfe_ipv6字符设备不存在，则创建该设备