### PR TITLE
Fix too much ppp policies in forwarding_rule chain

### DIFF
--- a/package/lean/luci-app-pptp-server/root/etc/pptpd.include
+++ b/package/lean/luci-app-pptp-server/root/etc/pptpd.include
@@ -1,3 +1,6 @@
+iptables -D forwarding_rule -i ppp+ -j ACCEPT
+iptables -D forwarding_rule -o ppp+ -j ACCEPT
+
 iptables -A forwarding_rule -i ppp+ -j ACCEPT
 iptables -A forwarding_rule -o ppp+ -j ACCEPT
 echo 1 > /proc/sys/net/ipv4/conf/br-lan/proxy_arp


### PR DESCRIPTION
Every time restart firewall, pptpd.include will be executed. Thus two ppp policies will be added to forwarding_rule chain, resulting a very long firewall table.
Modified to delete old policies before add new ones.
P.S. according to [wiki](https://wiki.openwrt.org/doc/howto/vpn.server.pptpd) , ppp+ policies will also allow data from other ppp interfaces, including pppoe. Thus if you are using ppp (PPPoE or similar) in wan(that's what in my case), this configuration is insecure. However someone made it like [this](https://datahunter.org/openwrt_pptp).