### PR TITLE
fix  po2lmo path error

### DIFF
--- a/package/lean/luci-app-ssr-plus/Makefile
+++ b/package/lean/luci-app-ssr-plus/Makefile
@@ -2,9 +2,9 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ssr-plus
 PKG_VERSION:=1
-PKG_RELEASE:=43
+PKG_RELEASE:=44
 
-PO2LMO:=$(BUILD_DIR)/luci-base/po2lmo
+PO2LMO:=$(STAGING_DIR_HOSTPKG)/bin/po2lmo
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/package/lean/luci-app-ssr-plus/Makefile
+++ b/package/lean/luci-app-ssr-plus/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ssr-plus
 PKG_VERSION:=1
-PKG_RELEASE:=44
+PKG_RELEASE:=56
 
 PO2LMO:=$(STAGING_DIR_HOSTPKG)/bin/po2lmo
 
@@ -20,12 +20,16 @@ config PACKAGE_$(PKG_NAME)_INCLUDE_V2ray
 	bool "Include V2ray"
 	default n
 	
-config PACKAGE_$(PKG_NAME)_INCLUDE_kcptun
+config PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun
 	bool "Include Kcptun"
 	default n
 	
 config PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Server
 	bool "Include ShadowsocksR Server"
+	default n
+	
+config PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Socks
+	bool "Include ShadowsocksR Socks and Tunnel"
 	default n
 	
 endmenu
@@ -40,8 +44,9 @@ define Package/luci-app-ssr-plus
 	DEPENDS:=+shadowsocksr-libev-alt +ipset +ip-full +iptables-mod-tproxy +dnsmasq-full +coreutils +coreutils-base64 +bash +pdnsd-alt +wget \
             +PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks:shadowsocks-libev-ss-redir \
             +PACKAGE_$(PKG_NAME)_INCLUDE_V2ray:v2ray \
-            +PACKAGE_$(PKG_NAME)_INCLUDE_kcptun:kcptun \
-            +PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Server:shadowsocksr-libev-server
+            +PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun:kcptun \
+            +PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Server:shadowsocksr-libev-server \
+            +PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Socks:shadowsocksr-libev-ssr-local
 endef
 
 define Build/Prepare


### PR DESCRIPTION
修复po2lmo路径错误，只测试了K3[编译环境](https://gl.tossp.com:1443/zh/lede-k3/-/jobs/6759)

```
install -d -m0755 /builds/zh/lede-k3/build_dir/target-arm_cortex-a9_musl_eabi/luci-app-ssr-plus-1/.pkgdir/luci-app-ssr-plus/usr/lib/lua/luci/i18n
/builds/zh/lede-k3/build_dir/target-arm_cortex-a9_musl_eabi/luci-base/po2lmo ./po/zh-cn/ssr-plus.po /builds/zh/lede-k3/build_dir/target-arm_cortex-a9_musl_eabi/luci-app-ssr-plus-1/.pkgdir/luci-app-ssr-plus/usr/lib/lua/luci/i18n/ssr-plus.zh-cn.lmo
bash: /builds/zh/lede-k3/build_dir/target-arm_cortex-a9_musl_eabi/luci-base/po2lmo: No such file or directory
make[3]: *** [/builds/zh/lede-k3/build_dir/target-arm_cortex-a9_musl_eabi/luci-app-ssr-plus-1/.pkgdir/luci-app-ssr-plus.installed] Error 127
make[3]: Leaving directory `/builds/zh/lede-k3/package/lean/luci-app-ssr-plus'
time: package/lean/luci-app-ssr-plus/compile#0.13#0.05#0.34
```