### PR TITLE
vlmcsd 使用自带的 uci 配置，不修改 /etc/dnsmasq.conf

### DIFF
--- a/package/lean/luci-app-vlmcsd/luasrc/controller/vlmcsd.lua
+++ b/package/lean/luci-app-vlmcsd/luasrc/controller/vlmcsd.lua
@@ -13,7 +13,7 @@ end
 
 function act_status()
   local e={}
-  e.running=luci.sys.call("pgrep vlmcsd >/dev/null")==0
+  e.running=nixio.fs.access("/var/run/vlmcsd.pid")
   luci.http.prepare_content("application/json")
   luci.http.write_json(e)
 end

--- a/package/lean/luci-app-vlmcsd/po/zh-cn/vlmcsd.zh-cn.po
+++ b/package/lean/luci-app-vlmcsd/po/zh-cn/vlmcsd.zh-cn.po
@@ -7,10 +7,10 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 msgid "vlmcsd config"
-msgstr "KMS服务器设置"
+msgstr "KMS 服务器设置"
 
 msgid "KMS Server"
-msgstr "KMS服务器"
+msgstr "KMS 服务器"
 
 msgid "Basic Setting"
 msgstr "基本设置"

--- a/package/lean/luci-app-vlmcsd/root/etc/init.d/vlmcsd
+++ b/package/lean/luci-app-vlmcsd/root/etc/init.d/vlmcsd
@@ -1,38 +1,58 @@
 #!/bin/sh /etc/rc.common
 # Copyright (c) 2011-2015 OpenWrt.org
 
+PIDFILE=/var/run/vlmcsd.pid
 START=90
 
-get_config()
-{
+get_config() {
 	config_get_bool enabled $1 enabled 0
 	config_get autoactivate $1 autoactivate 1
 }
 
-start(){
-  config_load vlmcsd
-	config_foreach get_config vlmcsd
-	[ $enabled -eq 0 ] && exit 0
-  /usr/bin/vlmcsd -i /etc/vlmcsd.ini -L 0.0.0.0:1688
-  
-  HOSTNAME=`uci get system.@system[0].hostname`
-	host_name=$(awk -F ',' '/^[ \t]*srv-host=_vlmcs\._tcp/{print $2}' /etc/dnsmasq.conf)
-	
-	echo $HOSTNAME
-	echo $host_name
-	
-  if [ "$HOSTNAME" != "$host_name" ];then
-				sed -i '/^[ \t]*srv-host=_vlmcs\._tcp/d' /etc/dnsmasq.conf
-				sed -i '$a\srv-host=_vlmcs\._tcp,'"$HOSTNAME"','"1688"',0,100' /etc/dnsmasq.conf
-				/etc/init.d/dnsmasq restart
-  fi
-	
-	echo "KMS Server has started."
+add_vlmcs_entry() {
+	local new_hostname="$1"
+
+	uci -q batch <<-EOF >/dev/null
+		add dhcp srvhost
+		set dhcp.@srvhost[-1].srv=_vlmcs._tcp
+		set dhcp.@srvhost[-1].target=$new_hostname
+		set dhcp.@srvhost[-1].port=1688
+		set dhcp.@srvhost[-1].class=0
+		set dhcp.@srvhost[-1].weight=100
+		commit dhcp
+	EOF
+
+	/etc/init.d/dnsmasq restart
+	exit 0
 }
 
-stop(){
-		pid=`pgrep /usr/bin/vlmcsd`
-		kill -9 $pid
+start() {
+	config_load vlmcsd
+	config_foreach get_config vlmcsd
+	[ $enabled -eq 0 ] && exit 0
+	/usr/bin/vlmcsd -i /etc/vlmcsd.ini -L 0.0.0.0:1688 -p $PIDFILE
+	echo "KMS Server has started."
+
+	if [ $autoactivate -eq 1 ]; then
+		local HOSTNAME=`uci get system.@system[0].hostname`
+
+		local index=$(uci -q show dhcp |grep "].srv='_vlmcs._tcp'") \
+			|| add_vlmcs_entry $HOSTNAME
+		index=${index#*[}
+		index=${index%]*}
+
+		local host_name=$(uci -q get dhcp.@srvhost[$index].target)
+
+		if [ "$HOSTNAME" != "$host_name" ]; then
+			uci delete dhcp.@srvhost[$index]
+			add_vlmcs_entry $HOSTNAME
+		fi
+	fi
+}
+
+stop() {
+		pid=`cat $PIDFILE`
+		kill $pid || kill -9 $pid
 		echo "KMS Server has stopped."
 }
 

--- a/package/lean/luci-app-vlmcsd/root/etc/uci-defaults/luci-app-vlmcsd
+++ b/package/lean/luci-app-vlmcsd/root/etc/uci-defaults/luci-app-vlmcsd
@@ -7,15 +7,5 @@ uci -q batch <<-EOF >/dev/null
 	commit ucitrack
 EOF
 
-uci delete firewall.kms
-uci add firewall rule 
-uci rename firewall.@rule[-1]="kms"
-uci set firewall.@rule[-1].name="kms"
-uci set firewall.@rule[-1].target="ACCEPT"
-uci set firewall.@rule[-1].src="wan"
-uci set firewall.@rule[-1].proto="tcp"
-uci set firewall.@rule[-1].dest_port="1688"
-uci commit firewall
-
 rm -f /tmp/luci-indexcache
 exit 0


### PR DESCRIPTION
修复”自动激活局域网客户端“不能关闭的问题
使用 pid 文件
禁止默认外网访问，有需要的自行开放端口