### PR TITLE
Update shadowsocksr

### DIFF
--- a/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -368,7 +368,8 @@ start_redir() {
 			fi
 		fi
 	fi
-	
+	add_cron
+
 	return $?
 }
 
@@ -487,8 +488,6 @@ EOF
 	fi
 	start_server	
 	start_local
-
-	add_cron
 	
 	if [ $(uci_get_by_type global monitor_enable) = 1 ] ;then
 	let total_count=server_count+redir_tcp+redir_udp+tunnel_enable+kcp_enable_flag+local_enable+pdnsd_enable_flag+switch_enable


### PR DESCRIPTION
修改add_cron位置,防止服务关闭后,计划任务依然存在的问题。