### PR TITLE
Use standard service start/stop

### DIFF
--- a/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -255,7 +255,7 @@ server {
 }
 EOF
 
-	/usr/sbin/pdnsd -c /var/etc/pdnsd.conf -d
+	service_start /usr/sbin/pdnsd -c /var/etc/pdnsd.conf -d
 }
 
 
@@ -528,6 +528,7 @@ stop() {
 	killall -q -9 ssr-kcptun
 	killall -q -9 ssr-local
 	if [ -f /var/run/pdnsd.pid ] ;then
+    service_stop /usr/sbin/pdnsd
     kill $(cat /var/run/pdnsd.pid) >/dev/null 2>&1
   else 
     kill -9 $(ps | grep pdnsd | grep -v grep | awk '{print $1}') >/dev/null 2>&1 


### PR DESCRIPTION
Use standard service start/stop to avoid pdnsd service start/stop fail on official openwrt.

### save&apply on luci (openwrt-18.06)
##### Before patch
```
root@OpenWrt:~# netstat -anp|grep 5335
```
##### After patch
```
root@OpenWrt:~# netstat -anp|grep 5335
tcp        0      0 127.0.0.1:5335          0.0.0.0:*               LISTEN      4558/pdnsd
udp        0      0 127.0.0.1:5335          0.0.0.0:*                           4558/pdnsd
```