### PR TITLE
remove the luci.model.ipkg dependency of ssrserver

### DIFF
--- a/package/lean/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/server.lua
+++ b/package/lean/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/server.lua
@@ -4,7 +4,6 @@
 local m, sec, o
 local shadowsocksr = "shadowsocksr"
 local uci = luci.model.uci.cursor()
-local ipkg = require("luci.model.ipkg")
 
 
 m = Map(shadowsocksr, translate("ShadowSocksR Server"))


### PR DESCRIPTION
我去掉这个也没有这个组件正常开启了服务器
应该是不需要这个的了
最新的luci里面也没有