### PR TITLE
ipq40xx: add Hugo AC1200 support

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -26,6 +26,10 @@ ipq40xx_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0t@eth0" "5:lan" "4:wan"
 		;;
+        hugo,ac1200)
+		ucidef_add_switch "switch0" \
+                        "0t@eth0" "5:wan" "3:lan"
+		;;
 	asus,rt-acrh17|\
 	asus,rt-ac58u|\
 	avm,fritzbox-4040|\

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -151,6 +151,7 @@ case "$FIRMWARE" in
 		;;
 	compex,wpj428 |\
 	engenius,eap1300 |\
+	hugo,ac1200 |\
 	openmesh,a42 |\
 	openmesh,a62)
 		ath10kcal_extract "0:ART" 4096 12064
@@ -192,6 +193,7 @@ case "$FIRMWARE" in
 		;;
 	compex,wpj428 |\
 	engenius,eap1300 |\
+	hugo,ac1200 |\
 	openmesh,a42 |\
 	openmesh,a62)
 		ath10kcal_extract "0:ART" 20480 12064

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-hugo-ac1200.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-hugo-ac1200.dts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2019 Hugo Yuan <hugolxq@gmail.com>
+ */
+
+#include "qcom-ipq4019-hugo-ac1200.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Hugo AC1200";
+	compatible = "hugo,ac1200", "qcom,ipq4019";
+};
+
+&blsp1_spi1 {
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
+
+	flash@0 {
+		reg = <0>;
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <24000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:SBL1";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+			partition@40000 {
+				label = "0:MIBIB";
+				reg = <0x40000 0x20000>;
+				read-only;
+			};
+			partition@60000 {
+				label = "0:QSEE";
+				reg = <0x60000 0x60000>;
+				read-only;
+			};
+			partition@c0000 {
+				label = "0:CDT";
+				reg = <0xc0000 0x10000>;
+				read-only;
+			};
+			partition@d0000 {
+				label = "0:DDRPARAMS";
+				reg = <0xd0000 0x10000>;
+				read-only;
+			};
+			partition@e0000 {
+				label = "0:APPSBLENV";
+				reg = <0xe0000 0x10000>;
+				read-only;
+			};
+			partition@f0000 {
+				label = "0:APPSBL";
+				reg = <0xf0000 0x80000>;
+				read-only;
+			};
+			partition@170000 {
+				label = "0:ART";
+				reg = <0x170000 0x10000>;
+				read-only;
+			};
+			partition@180000 {
+				compatible = "denx,fit";
+				label = "firmware";
+				reg = <0x180000 0x1e80000>;
+			};
+		};
+	};
+};
+

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-hugo-ac1200.dtsi
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-hugo-ac1200.dtsi
@@ -1,0 +1,244 @@
+/* 
+ * Copyright (c) 2019 Hugo Yuan <hugolxq@gmail.com>
+ */
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+
+	model = "Hugo AC1200";
+	compatible = "qcom,ipq4019";
+
+	memory {
+		device_type = "memory";
+		reg = <0x80000000 0x10000000>; /* 256MB */
+	};
+
+	soc {
+		mdio@90000 {
+			status = "okay";
+			pinctrl-0 = <&mdio_pins>;
+			pinctrl-names = "default";
+		};
+
+		ess-psgmii@98000 {
+			status = "okay";
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			/* select hostmode */
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+			status = "okay";
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+
+		usb2: usb2@60f8800 {
+			status = "okay";
+
+			dwc3@6000000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				usb2_port1: port@1 {
+					reg = <1>;
+					#trigger-source-cells = <0>;
+				};
+			};
+		};
+
+		serial@78af000 {
+			pinctrl-0 = <&serial_0_pins>;
+			pinctrl-names = "default";
+			status = "okay";
+		};
+
+		serial@78b0000 {
+			pinctrl-0 = <&serial_1_pins>;
+			pinctrl-names = "default";
+			status = "okay";
+		};
+
+		i2c@78b7000 { /* BLSP1 QUP2 */
+			pinctrl-0 = <&i2c_0_pins>;
+			pinctrl-names = "default";
+
+			status = "okay";
+		};
+
+		usb3: usb3@8af8800 {
+			status = "okay";
+
+			dwc3@8a00000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				usb3_port1: port@1 {
+					reg = <1>;
+					#trigger-source-cells = <0>;
+				};
+
+				usb3_port2: port@2 {
+					reg = <2>;
+					#trigger-source-cells = <0>;
+				};
+			};
+		};
+
+		crypto@8e3a000 {
+			status = "okay";
+		};
+
+		watchdog@b017000 {
+			status = "okay";
+		};
+
+		ess-switch@c000000 {
+			status = "okay";
+		};
+
+		edma@c080000 {
+			status = "okay";
+		};
+
+		leds {
+			compatible = "gpio-leds";
+
+			led1 {
+				label = "ac1200:green:ctrl1";
+				gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
+				default-state = "on";
+			};
+
+			led2 {
+				label = "ac1200:red:ctrl2";
+				gpios = <&tlmm 45 GPIO_ACTIVE_LOW>;
+				default-state = "on";
+			};
+
+			led3 {
+				label = "ac1200:blue:ctrl3";
+				gpios = <&tlmm 46 GPIO_ACTIVE_LOW>;
+				default-state = "on";
+			};
+		};
+
+		keys {
+			compatible = "gpio-keys";
+
+			reset {
+				label = "reset";
+				gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+				linux,code = <KEY_RESTART>;
+			};
+		};
+	};
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&tlmm {
+	i2c_0_pins: i2c-0-pinmux {
+		mux {
+			pins = "gpio20", "gpio21";
+			function = "blsp_i2c0";
+			bias-disable;
+		};
+	};
+
+	mdio_pins: mdio_pinmux {
+		mux_1 {
+			pins = "gpio6";
+			function = "mdio";
+			bias-pull-up;
+		};
+		mux_2 {
+			pins = "gpio7";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
+	serial_0_pins: serial0-pinmux {
+		mux {
+			pins = "gpio16", "gpio17";
+			function = "blsp_uart0";
+			bias-disable;
+		};
+	};
+
+	serial_1_pins: serial1_pinmux {
+		mux {
+			pins = "gpio8", "gpio9";
+			function = "blsp_uart1";
+			bias-disable;
+		};
+	};
+
+	spi_0_pins: spi_0_pinmux {
+		pinmux {
+			function = "blsp_spi0";
+			pins = "gpio13", "gpio14", "gpio15";
+			drive-strength = <12>;
+			bias-disable;
+		};
+		pinmux_cs {
+			function = "gpio";
+			pins = "gpio12";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+};
+
+&usb3_ss_phy {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+};
+
+&usb2_hs_phy {
+	status = "okay";
+};
+
+&wifi0 {
+	status = "okay";
+};
+
+&wifi1 {
+	status = "okay";
+};

--- a/target/linux/ipq40xx/image/Makefile
+++ b/target/linux/ipq40xx/image/Makefile
@@ -289,6 +289,18 @@ define Device/qcom_ap-dk04.1-c1
 endef
 TARGET_DEVICES += qcom_ap-dk04.1-c1
 
+define Device/hugo_ac1200
+        $(call Device/FitImage)
+        DEVICE_TITLE :=  Hugo AC1200
+        BOARD_NAME := hugo_ac1200
+        DEVICE_DTS := qcom-ipq4019-hugo-ac1200
+        KERNEL_SIZE := 4096k
+        IMAGE_SIZE := 31232k
+        IMAGES := sysupgrade.bin
+        IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
+endef
+TARGET_DEVICES += hugo_ac1200
+
 define Device/zyxel_nbg6617
 	$(call Device/FitImageLzma)
 	DEVICE_DTS := qcom-ipq4018-nbg6617

--- a/target/linux/ipq40xx/patches-4.14/901-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq40xx/patches-4.14/901-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -697,7 +697,24 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -697,7 +697,25 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-apq8074-dragonboard.dtb \
  	qcom-apq8084-ifc6540.dtb \
  	qcom-apq8084-mtp.dtb \
@@ -28,6 +28,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq4019-a62.dtb \
 +	qcom-ipq4019-ap.dk04.1-c1.dtb \
 +	qcom-ipq4019-map-ac2200.dtb \
++       qcom-ipq4019-hugo-ac1200.dtb \
 +	qcom-ipq4019-rt-acrh17.dtb \
 +	qcom-ipq4028-wpj428.dtb \
 +	qcom-ipq4029-gl-b1300.dtb \

--- a/target/linux/ipq40xx/patches-4.14/999-fix-m25p-shutdown.patch
+++ b/target/linux/ipq40xx/patches-4.14/999-fix-m25p-shutdown.patch
@@ -1,0 +1,34 @@
+diff --git a/drivers/mtd/devices/m25p80.c b/drivers/mtd/devices/m25p80.c
+index 24e1ea3..b1ff69a 100644
+--- a/drivers/mtd/devices/m25p80.c
++++ b/drivers/mtd/devices/m25p80.c
+@@ -313,6 +313,21 @@ static int m25p_remove(struct spi_device *spi)
+ 	return mtd_device_unregister(&flash->spi_nor.mtd);
+ }
+ 
++static void m25p_shutdown(struct spi_device *spi)
++{
++	struct m25p	*flash = spi_get_drvdata(spi);
++
++	if ((&flash->spi_nor)->addr_width > 3) {
++		printk(KERN_INFO "m25p80: exit 4-byte address mode\n");
++		flash->command[0] = SPINOR_OP_EX4B;  // exit 4-byte address mode: 0xe9
++		spi_write(flash->spi, flash->command, 1);
++		flash->command[0] = 0x66;  // enable reset
++		spi_write(flash->spi, flash->command, 1);
++		flash->command[0] = 0x99;  // reset
++		spi_write(flash->spi, flash->command, 1);
++	}
++}
++
+ /*
+  * Do NOT add to this array without reading the following:
+  *
+@@ -387,6 +402,7 @@ static struct spi_driver m25p80_driver = {
+ 	.id_table	= m25p_ids,
+ 	.probe	= m25p_probe,
+ 	.remove	= m25p_remove,
++	.shutdown = m25p_shutdown,
+ 
+ 	/* REVISIT: many of these chips have deep power-down modes, which
+ 	 * should clearly be entered on suspend() to minimize power use.


### PR DESCRIPTION
Hugo AC1200 based on IPQ4019

Specifications:
SOC:	Qualcomm IPQ4019
DRAM:	256 MiB
FLASH:	32 MiB Macronix MX25L25635F
ETH:	Qualcomm QCA8075
WLAN:	5G + 2.4G
	* 2T2R 2.4GHz
	 - QCA4019 hw1.0 (SoC)
	* 2T2R 5 GHz
	 - QCA4019 hw1.0 (SoC)