### PR TITLE
mvebu: fixes commit

### DIFF
--- a/target/linux/mvebu/patches-4.14/403-net-mvneta-convert-to-phylink.patch
+++ b/target/linux/mvebu/patches-4.14/403-net-mvneta-convert-to-phylink.patch
@@ -905,7 +905,7 @@ Signed-off-by: Russell King <rmk+kernel@arm.linux.org.uk>
 +	phylink = phylink_create(dev, dn, phy_mode, &mvneta_phylink_ops);
 +	if (IS_ERR(phylink)) {
 +		err = PTR_ERR(phylink);
-+		goto err_free_stats;
++		goto err_netdev;
 +	}
 +
 +	pp->phylink = phylink;


### PR DESCRIPTION
解决mvebu编译失败的问题
引用自：https://github.com/openwrt/openwrt/commit/1e3800df1808b4a5a977c3a9651958611df51c83
err_free_stats has been deprecated. Replace with err_netdev.