### PR TITLE
Update subscribe.sh

### DIFF
--- a/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.sh
+++ b/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.sh
@@ -154,7 +154,11 @@ do
 				json_get_var ssr_ws_host host
 				json_get_var ssr_ws_path path
 				json_get_var ssr_tls tls
-				
+				if [ "$ssr_tls" == "tls" -o "$ssr_tls" == "1" ]; then
+					ssr_tls="1"
+				else
+				    ssr_tls="0"
+				fi
 			fi
 
 


### PR DESCRIPTION
部分v2ray订阅链接返回的tls参数不是0,1，可能是"tls":"tls"，因此更新节点不会勾上tls选项。
因而增加了判断