### PR TITLE
luci-ssr-plus: optimize subscribe group and node identity method

### DIFF
--- a/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.sh
+++ b/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.sh
@@ -16,6 +16,8 @@ echo_date(){
 
 Server_Update() {
     local uci_set="uci -q set $name.$1."
+    ${uci_set}grouphashkey="$ssr_grouphashkey"
+    ${uci_set}hashkey="$ssr_hashkey"
     ${uci_set}alias="[$ssr_group] $ssr_remarks"
     ${uci_set}auth_enable="0"
     ${uci_set}switch_enable="1"
@@ -35,6 +37,7 @@ Server_Update() {
     ${uci_set}kcp_port="0"
     ${uci_set}kcp_param="--nocomp"
     
+	if [ "$ssr_type" = "v2ray" ]; then
     #v2ray
     ${uci_set}alter_id="$ssr_alter_id"
     ${uci_set}vmess_id="$ssr_vmess_id"
@@ -44,6 +47,7 @@ Server_Update() {
     ${uci_set}ws_host="$ssr_ws_host"
     ${uci_set}ws_path="$ssr_ws_path"
     ${uci_set}tls="$ssr_tls"
+	fi
 }
 
 name=shadowsocksr
@@ -58,6 +62,8 @@ do
 	echo_date "开始下载订阅链接到本地临时文件，请稍等..."
 	subscribe_data=$(wget-ssl --user-agent="User-Agent: Mozilla" --no-check-certificate -T 3 -O- ${subscribe_url[o]})
 	curl_code=$?
+	# 计算group的hashkey
+	ssr_grouphashkey=$(echo "${subscribe_url[o]}" | md5sum | cut -d ' ' -f1)
 	if [ ! $curl_code -eq 0 ];then
 		echo_date "下载订阅成功..."
 		echo_date "开始解析节点信息..."
@@ -99,9 +105,10 @@ do
 					curr_ssr=$(uci show $name | grep @servers | grep -c server=)
 					for ((x=0;x<$curr_ssr;x++)) # 循环已有服务器信息，匹配当前订阅群组
 					do
-						temp_alias=$(uci -q get $name.@servers[$x].alias | grep "\[$ssr_group\]")
-						[ -n "$temp_alias" ] && temp_host_o[${#temp_host_o[@]}]=$(uci get $name.@servers[$x].server)
+						temp_alias=$(uci -q get $name.@servers[$x].grouphashkey | grep "$ssr_grouphashkey")
+						[ -n "$temp_alias" ] && temp_host_o[${#temp_host_o[@]}]=$(uci get $name.@servers[$x].hashkey)
 					done
+
 					for ((x=0;x<$subscribe_max;x++)) # 循环链接
 					do
 						[ ${#subscribe_max_x[@]} -eq 0 ] && temp_x=$x || temp_x=${subscribe_max_x[x]}
@@ -109,6 +116,9 @@ do
 						if [[ "$result" != "" ]]
 						then
 							temp_info=$(urlsafe_b64decode ${ssr_url[temp_x]//ssr:\/\//}) # 解码 SSR 链接
+							# 计算hashkey
+							ssr_hashkey=$(echo "$temp_info" | md5sum | cut -d ' ' -f1)
+
 
 							info=${temp_info///?*/}
 							temp_info_array=(${info//:/ })
@@ -141,6 +151,9 @@ do
 				done
 			else
 				temp_info=$(urlsafe_b64decode ${ssr_url[temp_x]//vmess:\/\//}) # 解码 Vmess 链接
+				# 计算hashkey
+				ssr_hashkey=$(echo "$temp_info" | md5sum | cut -d ' ' -f1)
+
 				ssr_type="v2ray"
 				json_load "$temp_info"
 				json_get_var ssr_host add
@@ -157,14 +170,17 @@ do
 				
 			fi
 
+			if [ -z "ssr_remarks" ]; then # 没有备注的话则生成一个
+				ssr_remarks="$ssr_host:$ssr_port";
+			fi
 
-			uci_name_tmp=$(uci show $name | grep -w $ssr_host | awk -F . '{print $2}')
+			uci_name_tmp=$(uci show $name | grep -w "$ssr_hashkey" | awk -F . '{print $2}')
 			if [ -z "$uci_name_tmp" ]; then # 判断当前服务器信息是否存在
 				uci_name_tmp=$(uci add $name servers)
 				subscribe_n=$(($subscribe_n + 1))
 			fi
 			Server_Update $uci_name_tmp
-			subscribe_x=$subscribe_x$ssr_host" "
+			subscribe_x=$subscribe_x$ssr_hashkey" "
 			ssrtype=$(echo $ssr_type | tr '[a-z]' '[A-Z]')
 			echo_date "$ssrtype节点：【$ssr_remarks】"
 			


### PR DESCRIPTION
优化分组和节点的唯一标识方法，大体的规则是:

1. 对于组: 使用订阅地址的hash值作为分组id
2. 对于节点: 使用订阅节点的所有值的hash值作为节点id

该改进解决了以下问题:
1. 某些订阅服务没有返回分组信息（比如v2ray）的时候，默认分组为default，从而导致分组失败的时候将其他订阅服务的节点一并进行判断的问题。
2. 对于同组内的节点，可能存在server相同而端口不同或者局部参数不同的情况，单纯判断server会导致同server节点被覆盖的问题。
3. 修正非v2ray类型的订阅却保存了v2ray订阅信息的问题