### PR TITLE
修正v2ray订阅更新问题

### DIFF
--- a/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.sh
+++ b/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.sh
@@ -41,7 +41,6 @@ Server_Update() {
     #v2ray
     ${uci_set}alter_id="$ssr_alter_id"
     ${uci_set}vmess_id="$ssr_vmess_id"
-    ${uci_set}type="$ssr_security"
     ${uci_set}transport="$ssr_transport"
     ${uci_set}tcp_guise="$ssr_tcp_guise"
     ${uci_set}ws_host="$ssr_ws_host"


### PR DESCRIPTION
${uci_set}type为服务器节点类型，固定为v2ray，不应该取ssr_security字段。