### PR TITLE
优化ssr-switch单一节点下的ss重启

### DIFF
--- a/package/lean/luci-app-ssr-plus/root/usr/bin/ssr-switch
+++ b/package/lean/luci-app-ssr-plus/root/usr/bin/ssr-switch
@@ -33,7 +33,7 @@ uci_get_by_type() {
 DEFAULT_SERVER=$(uci_get_by_type global global_server)
 CURRENT_SERVER=$DEFAULT_SERVER
 
-#ÅÐ¶Ï´úÀíÊÇ·ñÕý³£
+#åˆ¤æ–­ä»£ç†æ˜¯å¦æ­£å¸¸
 check_proxy() {
 /usr/bin/ssr-check www.google.com  80 $switch_time 1
 if [ "$?" == "0" ]; then
@@ -41,7 +41,7 @@ if [ "$?" == "0" ]; then
 else
  /usr/bin/ssr-check www.baidu.com  80 $switch_time 1
  if [ "$?" == "0" ]; then
- #goole²»Í¨baiduÍ¨Ôò²»Õý³£
+ #gooleä¸é€šbaidué€šåˆ™ä¸æ­£å¸¸
  return 1
  else
  return 2
@@ -95,7 +95,7 @@ return 1
 fi
 
 }
-#Ñ¡Ôñ¿ÉÓÃµÄ´úÀí
+#é€‰æ‹©å¯ç”¨çš„ä»£ç†
 select_proxy() {
 
 config_load $NAME
@@ -106,33 +106,33 @@ config_foreach search_proxy servers
 
 }
 
-#ÇÐ»»´úÀí
+#åˆ‡æ¢ä»£ç†
 switch_proxy() {
 /etc/init.d/shadowsocksr restart $1
 return 0
 }
 
 start() {
-#²»Ö§³ÖkcptunÆôÓÃÊ±µÄÇÐ»»
+#ä¸æ”¯æŒkcptunå¯ç”¨æ—¶çš„åˆ‡æ¢
 [ $(uci_get_by_name $DEFAULT_SERVER kcp_enable) = "1"  ]  && return 1
 
-while [ "1" = "1" ]  #ËÀÑ­»·
+while [ "1" = "1" ]  #æ­»å¾ªçŽ¯
 do 
    sleep $cycle_time
    
    LOGTIME=$(date "+%Y-%m-%d %H:%M:%S")
     
    
-   #ÅÐ¶Ïµ±Ç°´úÀíÊÇ·ñÎªÈ±Ê¡·þÎñÆ÷
+   #åˆ¤æ–­å½“å‰ä»£ç†æ˜¯å¦ä¸ºç¼ºçœæœåŠ¡å™¨
    if [ "$CURRENT_SERVER" != "$DEFAULT_SERVER" ] ;then
    #echo "not default proxy"
    echo "$(date "+%Y-%m-%d %H:%M:%S") Current server is not default Main server, try to switch back." >> /tmp/ssrplus.log
 
-     #¼ì²éÈ±Ê¡·þÎñÆ÷ÊÇ·ñÕý³£
+     #æ£€æŸ¥ç¼ºçœæœåŠ¡å™¨æ˜¯å¦æ­£å¸¸
      if test_proxy $DEFAULT_SERVER  ;then
        #echo "switch to default proxy"
        echo "$(date "+%Y-%m-%d %H:%M:%S") Main server is avilable." >> /tmp/ssrplus.log
-       #È±Ê¡·þÎñÆ÷Õý³££¬ÇÐ»»»ØÀ´
+       #ç¼ºçœæœåŠ¡å™¨æ­£å¸¸ï¼Œåˆ‡æ¢å›žæ¥
        CURRENT_SERVER=$DEFAULT_SERVER
        switch_proxy $CURRENT_SERVER 
        echo "switch to default ["$(uci_get_by_name $CURRENT_SERVER server)"] proxy!"  >> /tmp/ssrplus.log
@@ -142,18 +142,18 @@ do
      fi
     fi
 
-   #ÅÐ¶Ïµ±Ç°´úÀíÊÇ·ñÕý³£
+   #åˆ¤æ–­å½“å‰ä»£ç†æ˜¯å¦æ­£å¸¸
    check_proxy  
    current_ret=$?
   
    if [ "$current_ret" = "1" ] ;then
-     #µ±Ç°´úÀí´íÎó£¬ÅÐ¶ÏÓÐÎÞ¿ÉÓÃµÄ·þÎñÆ÷
+     #å½“å‰ä»£ç†é”™è¯¯ï¼Œåˆ¤æ–­æœ‰æ— å¯ç”¨çš„æœåŠ¡å™¨
      #echo "current error"
      echo "$(date "+%Y-%m-%d %H:%M:%S") Current server error, try to switch another server." >> /tmp/ssrplus.log
      
      select_proxy
      if [ "$ENABLE_SERVER" != nil ] ;then
-      #ÓÐÆäËû·þÎñÆ÷¿ÉÓÃ£¬½øÐÐÇÐ»»
+      #æœ‰å…¶ä»–æœåŠ¡å™¨å¯ç”¨ï¼Œè¿›è¡Œåˆ‡æ¢
       #echo $(uci_get_by_name $new_proxy server)
       echo "$(date "+%Y-%m-%d %H:%M:%S") Another server is avilable, now switching server." >> /tmp/ssrplus.log
       CURRENT_SERVER=$ENABLE_SERVER
@@ -161,7 +161,9 @@ do
       normal_flag=1
       echo "$(date "+%Y-%m-%d %H:%M:%S") ShadowsocksR server switch OK" >> /tmp/ssrplus.log
      else
-     normal_flag=0 
+      switch_proxy $CURRENT_SERVER
+      normal_flag=1 
+      echo "$(date "+%Y-%m-%d %H:%M:%S") Try restart current server." >> /tmp/ssrplus.log
      fi
    else
     normal_flag=0 


### PR DESCRIPTION
针对如下场景进行优化
1、ssr-plus仅仅设置了一个服务器节点
2、该节点使用域名地址
3、域名对应的DNS解析ip修改了

问题原因：
在存在多节点情况下，select_proxy会挑选下一个节点重启ssr服务，但是在单一节点下由于不符合if [ "$ENABLE_SERVER" != nil ] 条件，导致并不调用switch_proxy来重启服务。但是域名对应的ip已经修改了，ssr服务本身是依赖ip参数启动的，ssr服务在重启依然停留在老的ip上。

调整方式：
这个修改调整为在每次检测网络失败的情况下，就算只有一个节点，也重启ssr服务，保证ssr服务有机会切换到域名新的ip地址。
此外假如因为ssr服务本身存在一些小概率bug，也可以通过重启ssr解决。


这种情况在付费的ssr服务中很常见，因为服务商往往只提供一个域名，假如因为服务器调整（比如某个服务器ip被和谐了），服务提供商都会重新给域名绑定新的服务器(或新IP)