### PR TITLE
luci-app-flowoffload: enable BBR by default in x86 which no wireless device

### DIFF
--- a/package/lean/luci-app-flowoffload/root/etc/uci-defaults/flowoffload
+++ b/package/lean/luci-app-flowoffload/root/etc/uci-defaults/flowoffload
@@ -10,4 +10,10 @@ uci -q batch <<-EOF >/dev/null
 	commit ucitrack
 EOF
 
+if [ $(uname -m | grep 'x86') != "" ] && [ -n $(uci show wireless) ]
+then
+	uci set flowoffload.@flow[0].bbr=1
+	uci commit flowoffload
+fi
+
 exit 0


### PR DESCRIPTION
在没有无线设备的软路由中默认开启 BBR. 