### PR TITLE
flowoffload: enable BBR by default in x86 which no wireless device

### DIFF
--- a/package/lean/luci-app-flowoffload/Makefile
+++ b/package/lean/luci-app-flowoffload/Makefile
@@ -9,7 +9,7 @@ LUCI_TITLE:=LuCI support for Flow Offload
 LUCI_DEPENDS:=+kmod-ipt-offload +pdnsd-alt +kmod-tcp-bbr @!LINUX_3_18 @!LINUX_4_9
 LUCI_PKGARCH:=all
 PKG_VERSION:=1.0
-PKG_RELEASE:=13
+PKG_RELEASE:=14
 
 include $(TOPDIR)/feeds/luci/luci.mk
 

--- a/package/lean/luci-app-flowoffload/root/etc/uci-defaults/flowoffload
+++ b/package/lean/luci-app-flowoffload/root/etc/uci-defaults/flowoffload
@@ -10,4 +10,10 @@ uci -q batch <<-EOF >/dev/null
 	commit ucitrack
 EOF
 
+if [ $(uname -m | grep 'x86') != "" ] && [ -n $(uci show wireless) ]
+then
+	uci set flowoffload.@flow[0].bbr=1
+	uci commit flowoffload
+fi
+
 exit 0


### PR DESCRIPTION
在**没有无线设备**的软路由中默认开启 BBR.