### PR TITLE
luci-app-familycloud: fix git tracking issue

### DIFF
--- a/package/lean/luci-app-familycloud/Makefile
+++ b/package/lean/luci-app-familycloud/Makefile
@@ -10,7 +10,7 @@ LUCI_DEPENDS:=+coreutils +coreutils-nohup +libreadline +libcurl +libopenssl +bas
 LUCI_PKGARCH:=all
 PKG_NAME:=luci-app-familycloud
 PKG_VERSION:=1
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 include $(TOPDIR)/feeds/luci/luci.mk
 

--- a/package/lean/luci-app-familycloud/root/etc/uci-defaults/familycloud
+++ b/package/lean/luci-app-familycloud/root/etc/uci-defaults/familycloud
@@ -7,5 +7,10 @@ uci -q batch <<-EOF >/dev/null
 	commit ucitrack
 EOF
 
+touch /tmp/config.json
+
+ln -s /tmp/config.json /usr/share/familycloud/CloudDisk/config.json
+
 rm -f /tmp/luci-indexcache
+
 exit 0

--- a/package/lean/luci-app-familycloud/root/usr/share/familycloud/CloudDisk/config.json
+++ b/package/lean/luci-app-familycloud/root/usr/share/familycloud/CloudDisk/config.json
@@ -1,1 +1,0 @@
-/tmp/config.json


### PR DESCRIPTION
库文件树下存在这个文件:\
`/package/lean/luci-app-familycloud/root/usr/share/familycloud/CloudDisk/config.json`\
这个文件其实是一个软链接, 但是在本地库所在的文件系统中并没有这个链接指向的`/tmp/config.json`.\
因而Git无法追踪这个文件, 但是在远程库中这个软链接文件本身又的确存在, 所以会导致GitHub提示如下错误:

![QQ截图20191019062344](https://user-images.githubusercontent.com/37098748/67134504-1590ff00-f245-11e9-9cce-1644d1e78dc0.png)

这个错误可以在[这个页面](https://github.com/coolsnowwolf/lede/settings) (只有lean本人可以访问) `GitHub Pages`一栏看到.

解决方法: 删除这个问题文件并改为在软件包安装时创建该软链接.
