### PR TITLE
mt76: update to the latest version for mac80211

### DIFF
--- a/package/kernel/mt76/Makefile
+++ b/package/kernel/mt76/Makefile
@@ -8,9 +8,9 @@ PKG_LICENSE_FILES:=
 
 PKG_SOURCE_URL:=https://github.com/openwrt/mt76
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_DATE:=2019-07-13
-PKG_SOURCE_VERSION:=410923fa24de770c042ea816cff6c18b9b184a2d
-PKG_MIRROR_HASH:=0f546ba43bb8212ec7851ac22f5d0d32e8dddb1b893aa6d0209c48488122df04
+PKG_SOURCE_DATE:=2019-10-10
+PKG_SOURCE_VERSION:=d3a589586d1b1d9e1422e31f642a500ff0195f20
+PKG_MIRROR_HASH:=46df12037db0d3438cb0ae97cded24a6562502d5cbd2d6d6d4e72ca807b0407e
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_BUILD_PARALLEL:=1
@@ -246,12 +246,12 @@ define KernelPackage/mt7603/install
 endef
 
 define KernelPackage/mt7615e/install
-	$(INSTALL_DIR) $(1)/lib/firmware
+	$(INSTALL_DIR) $(1)/lib/firmware/mediatek
 	cp \
 		$(PKG_BUILD_DIR)/firmware/mt7615_cr4.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7615_n9.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7615_rom_patch.bin \
-		$(1)/lib/firmware
+		$(1)/lib/firmware/mediatek
 endef
 
 $(eval $(call KernelPackage,mt76-core))


### PR DESCRIPTION
修正在最新mac80211版本下MTK设备无线驱动编译问题