### PR TITLE
luci-app-verysync: fix wrong dependency

### DIFF
--- a/package/lean/luci-app-verysync/Makefile
+++ b/package/lean/luci-app-verysync/Makefile
@@ -6,12 +6,11 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI support for Verysync
-LUCI_DEPENDS:=+luci
+LUCI_DEPENDS:=+verysync
 LUCI_PKGARCH:=all
 PKG_VERSION:=1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 include $(TOPDIR)/feeds/luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature
-

--- a/package/lean/verysync/Makefile
+++ b/package/lean/verysync/Makefile
@@ -33,7 +33,7 @@ endif
 
 PKG_NAME:=verysync
 PKG_VERSION:=v1.2.4
-PKG_RELEASE:=2
+PKG_RELEASE:=1
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-linux-$(PKG_ARCH_VERYSYNC)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://releases-cdn.verysync.com/releases/$(PKG_VERSION)/
@@ -66,6 +66,7 @@ endef
 define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(PKG_NAME)-linux-$(PKG_ARCH_VERYSYNC)-$(PKG_VERSION)/verysync $(1)/usr/bin/verysync
+	chmod 755 $(1)/usr/bin/verysync
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/package/lean/verysync/Makefile
+++ b/package/lean/verysync/Makefile
@@ -33,7 +33,7 @@ endif
 
 PKG_NAME:=verysync
 PKG_VERSION:=v1.2.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-linux-$(PKG_ARCH_VERYSYNC)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://releases-cdn.verysync.com/releases/$(PKG_VERSION)/

--- a/package/lean/verysync/Makefile
+++ b/package/lean/verysync/Makefile
@@ -66,7 +66,6 @@ endef
 define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(PKG_NAME)-linux-$(PKG_ARCH_VERYSYNC)-$(PKG_VERSION)/verysync $(1)/usr/bin/verysync
-	chmod 755 $(1)/usr/bin/verysync
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))


### PR DESCRIPTION
软件包`luci-app-verysync`并没有和`verysync`形成依赖关系, 而是使用预置的二进制文件. 
本次提交修复了这个问题.