### PR TITLE
UnblockNeteaseMusic增加转发音源配置

### DIFF
--- a/package/lean/luci-app-unblockmusic/Makefile
+++ b/package/lean/luci-app-unblockmusic/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-unblockmusic
 PKG_VERSION:=2.2.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_LICENSE:=Apache-2.0
 

--- a/package/lean/luci-app-unblockmusic/luasrc/model/cbi/unblockmusic.lua
+++ b/package/lean/luci-app-unblockmusic/luasrc/model/cbi/unblockmusic.lua
@@ -24,4 +24,9 @@ speedtype:value("kuwo", translate("酷我音乐(高音质推荐)"))
 speedtype:value("migu", translate("咕咪音乐"))
 speedtype:value("joox", translate("JOOX音乐"))
 
+endpoint = s:option(Value, "endpoint", translate("转发音源"))
+endpoint.default = "https://music.163.com"
+endpoint.rmempty = true
+endpoint.description = translate("自定义转发音源<br />针对苹果系统设置请参考：https://github.com/nondanee/UnblockNeteaseMusic/issues/65")
+
 return mp

--- a/package/lean/luci-app-unblockmusic/root/etc/config/unblockmusic
+++ b/package/lean/luci-app-unblockmusic/root/etc/config/unblockmusic
@@ -1,8 +1,9 @@
 
 config unblockmusic
 	option enabled '0'
-	option musicapptype 'kuwo'
+	option musicapptype 'default'
 	option port '5200'
 	option enable_ipset '1'
+	option endpoint 'https://music.163.com'
 	
 

--- a/package/lean/luci-app-unblockmusic/root/etc/init.d/unblockmusic
+++ b/package/lean/luci-app-unblockmusic/root/etc/init.d/unblockmusic
@@ -6,6 +6,7 @@ STOP=10
 enable=$(uci get unblockmusic.@unblockmusic[0].enabled)
 TYPE=$(uci get unblockmusic.@unblockmusic[0].musicapptype)
 ROUTE_IP=$(uci get network.lan.ipaddr)
+ENDPOINT=$(uci get unblockmusic.@unblockmusic[0].endpoint)
 
 ipt_n="iptables -t nat"
 
@@ -56,10 +57,16 @@ start()
 	
 	[ $enable -eq "0" ] && exit 0
 	
+	endponintset="";
+	
+	if [ -n "$ENDPOINT" ]; then
+		endponintset="-e ${ENDPOINT}"
+	fi
+	
 	if [ $TYPE = "default" ]; then
-			node /usr/share/UnblockNeteaseMusic/app.js -p 5200:5201 >/tmp/unblockmusic.log 2>&1 &
+			node /usr/share/UnblockNeteaseMusic/app.js $endponintset -p 5200:5201 >/tmp/unblockmusic.log 2>&1 &
 	else
-			node /usr/share/UnblockNeteaseMusic/app.js -p 5200:5201 -o $TYPE >/tmp/unblockmusic.log 2>&1 &
+			node /usr/share/UnblockNeteaseMusic/app.js $endponintset -p 5200:5201 -o $TYPE >/tmp/unblockmusic.log 2>&1 &
 	fi
 	
 	set_firewall


### PR DESCRIPTION
解决苹果iOS和MacOS下无法使用的问题，同时也支持自定义转发域配置
参考https://github.com/nondanee/UnblockNeteaseMusic/issues/65
