### PR TITLE
mwlwifi: Fix loading with backports v5.3

### DIFF
--- a/package/kernel/mwlwifi/Makefile
+++ b/package/kernel/mwlwifi/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mwlwifi
-PKG_RELEASE=1
+PKG_RELEASE=2
 
 PKG_LICENSE:=ISC
 PKG_LICENSE_FILES:=
@@ -100,3 +100,4 @@ $(eval $(call BuildPackage,mwlwifi-firmware-88w8864))
 $(eval $(call BuildPackage,mwlwifi-firmware-88w8897))
 $(eval $(call BuildPackage,mwlwifi-firmware-88w8964))
 $(eval $(call BuildPackage,mwlwifi-firmware-88w8997))
+

--- a/package/kernel/mwlwifi/patches/001-vendor_command_policy.patch
+++ b/package/kernel/mwlwifi/patches/001-vendor_command_policy.patch
@@ -1,0 +1,19 @@
+mac80211 from kernel 5.3 and later checks the new policy attribute.
+
+--- a/vendor_cmd.c
++++ b/vendor_cmd.c
+@@ -92,12 +92,14 @@ static const struct wiphy_vendor_command
+ 			  .subcmd = MWL_VENDOR_CMD_SET_BF_TYPE},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_NETDEV,
+ 		.doit = mwl_vendor_cmd_set_bf_type,
++		.policy = mwl_vendor_attr_policy,
+ 	},
+ 	{
+ 		.info = { .vendor_id = MRVL_OUI,
+ 			  .subcmd = MWL_VENDOR_CMD_GET_BF_TYPE},
+ 		.flags = WIPHY_VENDOR_CMD_NEED_NETDEV,
+ 		.doit = mwl_vendor_cmd_get_bf_type,
++		.policy = mwl_vendor_attr_policy,
+ 	}
+ };
+ 


### PR DESCRIPTION
解决mac80211升级到v5.3之后，mwlwifi无线无法启动
同步上游的patch
https://github.com/openwrt/openwrt/commit/0c43219a3579a5b86e8b62d603f67872329657b0