### PR TITLE
Update genv2config.lua

### DIFF
--- a/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/genv2config.lua
+++ b/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/genv2config.lua
@@ -3,6 +3,8 @@ local json = require "luci.jsonc"
 local server_section = arg[1]
 local proto = arg[2] 
 local local_port = arg[3]
+local socks_port = local_port + 1
+local http_port = local_port + 2
 
 local server = ucursor:get_all("shadowsocksr", server_section)
 
@@ -24,6 +26,21 @@ local v2ray = {
             destOverride = { "http", "tls" }
         }
     },
+  	-- 开启 socks 和 http 代理 
+    inboundDetour = (proto == "tcp") and {
+      {
+        protocol = "socks",
+        port = socks_port,
+        settings = {
+          auth = "noauth",
+          udp = true
+        }
+      },
+      {
+        protocol = "http",
+        port = http_port	
+      }
+    } or nil,
     -- 传出连接
     outbound = {
         protocol = "vmess",

--- a/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/genv2config.lua
+++ b/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/genv2config.lua
@@ -26,7 +26,7 @@ local v2ray = {
             destOverride = { "http", "tls" }
         }
     },
-  	-- 开启 socks 和 http 代理 
+    -- 开启 socks 和 http 代理 
     inboundDetour = (proto == "tcp") and {
       {
         protocol = "socks",


### PR DESCRIPTION
v2ray默认没有开启代理端口，

给v2ray的默认端口+1开启socks代理，默认端口+2开启http代理。

方法来自 https://github.com/coolsnowwolf/lede/issues/1019