### PR TITLE
luci-theme-netgear: fix self enabled

### DIFF
--- a/package/lean/luci-theme-netgear/Makefile
+++ b/package/lean/luci-theme-netgear/Makefile
@@ -7,6 +7,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Netgear Theme
 LUCI_DEPENDS:=
+PKG_RELEASE:=2
 
 include $(TOPDIR)/feeds/luci/luci.mk
 

--- a/package/lean/luci-theme-netgear/root/etc/uci-defaults/30_luci-theme-netgear
+++ b/package/lean/luci-theme-netgear/root/etc/uci-defaults/30_luci-theme-netgear
@@ -1,7 +1,8 @@
 #!/bin/sh
 uci batch <<-EOF
-	set luci.themes.netgear=/luci-static/netgear
+	set luci.themes.Netgear=/luci-static/netgear
 	set luci.main.mediaurlbase=/luci-static/netgear
 	commit luci
 EOF
-exit 0
+exit 0 
+# ↑↑↑ DO NOT EDIT THIS LINE


### PR DESCRIPTION
### 问题:

每次重启都会自动应用`luci-theme-netgear`主题.

### 触发原因:

uci默认脚本执行错误 (退出代码`0`不合法) 造成不能正常自动删除导致每次重启都会执行脚本.

### 解决思路:

为什么`0`不合法, 这件事是个谜🤔. 脚本中所有语句都正常执行, 唯独不能正常退出. 解决这个问题也很简单, 只要在`exit 0`后面加个空格即可.
