### PR TITLE
CI:  upload firmwares only

### DIFF
--- a/.github/workflows/openwrt-ci.yml
+++ b/.github/workflows/openwrt-ci.yml
@@ -211,8 +211,8 @@ jobs:
         run: |
           rm -rf ./artifact/
           mkdir -p ./artifact/
-          find ./bin/targets/ -name "*combined*img*" | xargs -i mv -f {} ./
-          find ./bin/targets/ -name "*sysupgrade*bin*" | xargs -i mv -f {} ./
+          find ./bin/targets/ -name "*combined*img*" | xargs -i mv -f {} ./artifact/
+          find ./bin/targets/ -name "*sysupgrade*bin*" | xargs -i mv -f {} ./artifact/
 
       - name: Upload artifact
         uses: actions/upload-artifact@master

--- a/.github/workflows/openwrt-ci.yml
+++ b/.github/workflows/openwrt-ci.yml
@@ -195,7 +195,7 @@ jobs:
           sed -i 's/^[ \t]*//g' ./.config
           make defconfig
 
-      - name: Download package source code
+      - name: Make download
         run: |
           make download -j8
           find dl -size -1024c -exec ls -l {} \;
@@ -206,8 +206,16 @@ jobs:
           echo -e "$(nproc) thread build."
           make -j$(nproc) V=s
 
-      - name : Upload artifact
+
+      - name: Assemble artifact
+        run: |
+          rm -rf ./artifact/
+          mkdir -p ./artifact/
+          find ./bin/targets/ -name "*combined*img*" | xargs -i mv -f {} ./
+          find ./bin/targets/ -name "*sysupgrade*bin*" | xargs -i mv -f {} ./
+
+      - name: Upload artifact
         uses: actions/upload-artifact@master
         with:
           name: OpenWrt firmware
-          path: bin/targets
+          path: ./artifact/


### PR DESCRIPTION
在此之前是上传整个`/bin/targets/`并打包, 导致下载的文件很大, 而绝大部分普通用户只需要固件本身. 

国内的网络环境并不适合下载GitHub上的大文件, 现在改成只上传编译好的完整固件, 体积缩小了好几倍. 并且匹配了其他平台的固件格式, 为以后可能加进去的多平台编译做准备. 

- 6个小时完全可以同时编译三个平台, 大雕觉得有必要部署多平台编译吗?
- CI文件里的注释部分太过冗长, 对程序实际运行又没什么用, 而且可能会对不懂代码的小白造成误导. 现在已经有了针对性的教程, 这些又臭又长的山炮注释大雕觉得要不要删掉?