### PR TITLE
fixed compile trojan problems on arm64

### DIFF
--- a/package/lean/luci-app-ssr-plus/Makefile
+++ b/package/lean/luci-app-ssr-plus/Makefile
@@ -26,10 +26,6 @@ config PACKAGE_$(PKG_NAME)_INCLUDE_Trojan
 	bool "Include Trojan"
 	default y if x86_64
 	
-config PACKAGE_$(PKG_NAME)_INCLUDE_V2ray
-	bool "Include V2ray"
-	default y if x86_64
-	
 config PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun
 	bool "Include Kcptun"
 	default n

--- a/package/lean/openssl1.1/Makefile
+++ b/package/lean/openssl1.1/Makefile
@@ -92,7 +92,7 @@ OPENSSL_OPTIONS += no-whirlpool
 
 OPENSSL_OPTIONS += no-deprecated
 
-TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS)) -O3
+TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS)) -O0 -g3
 
 
 
@@ -120,7 +120,8 @@ define Build/Configure
 
 endef
 
-TARGET_CFLAGS += $(FPIC) -ffunction-sections -fdata-sections
+#$(FPIC)
+TARGET_CFLAGS += -ffunction-sections -fdata-sections
 TARGET_LDFLAGS += -Wl,--gc-sections
 
 define Build/Compile


### PR DESCRIPTION
根据 https://github.com/trojan-gfw/trojan/issues/127#issuecomment-555415538 改了下makefile，以便编译arm64平台。