### PR TITLE
ramips: XiaoYu-C5 fix to 512MB

### DIFF
--- a/target/linux/ramips/dts/mt7621_xiaoyu_xy-c5.dts
+++ b/target/linux/ramips/dts/mt7621_xiaoyu_xy-c5.dts
@@ -17,6 +17,11 @@
 		label-mac-device = &ethernet;
 	};
 
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
+	};
+
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};


### PR DESCRIPTION
From https://github.com/coolsnowwolf/lede/commit/d28f568be2dd7cce276bb9ec98838a8f4bbcf58c ，fixed issues (https://github.com/coolsnowwolf/lede/issues/2361).