### PR TITLE
ipq40xx: update r619ac source code

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -118,6 +118,10 @@ case "$FIRMWARE" in
 	openmesh,a62)
 		ath10kcal_extract "0:ART" 36864 12064
 		;;
+	p2w,r619ac |\
+	p2w,r619ac-128m)
+		ath10kcal_extract "ART" 36864 12064
+		;;
 	esac
 	;;
 "ath10k/pre-cal-ahb-a000000.wifi.bin")

--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-r619ac.dtsi
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-r619ac.dtsi
@@ -6,7 +6,6 @@
 #include <dt-bindings/soc/qcom,tcsr.h>
 
 / {
-
 	aliases {
 		led-boot = &led_sys;
 		led-failsafe = &led_sys;
@@ -81,6 +80,8 @@
 
 	leds {
 		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
 
 		led_sys: sys {
 			label = "r619ac:blue:sys";
@@ -199,7 +200,6 @@
 &sdhci {
 	pinctrl-0 = <&sd_0_pins>;
 	pinctrl-names = "default";
-	cd-gpios = <&tlmm 22 GPIO_ACTIVE_LOW>;
 	vqmmc-supply = <&vqmmc>;
 	status = "okay";
 };
@@ -231,12 +231,6 @@
 			function = "sdio";
 			drive-strength = <16>;
 		};
-
-		mux_3 {
-			pins = "gpio32";
-			function = "gpio";
-			output-low;
-		};
 	};
 
 	serial_0_pins: serial0-pinmux {
@@ -244,6 +238,29 @@
 			pins = "gpio16", "gpio17";
 			function = "blsp_uart0";
 			bias-disable;
+		};
+	};
+
+	led_pins: led_pinmux {
+		mux {
+			pins = "gpio32", "gpio39", "gpio50";
+			function = "gpio";
+			bias-pull-up;
+			output-low;
+		};
+
+		mux_1 {
+			pins = "gpio52";
+			function = "gpio";
+			bias-pull-up;
+			output-high;
+		};
+
+		mux_2 {
+			pins = "gpio61";
+			function = "gpio";
+			bias-pull-down;
+			output-high;
 		};
 	};
 };

--- a/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4019-r619ac.dtsi
+++ b/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4019-r619ac.dtsi
@@ -179,6 +179,20 @@
 	};
 };
 
+&pcie0 {
+	status = "okay";
+	perst-gpio = <&tlmm 4 GPIO_ACTIVE_LOW>;
+	wake-gpio = <&tlmm 40 GPIO_ACTIVE_HIGH>;
+
+	/* Free slot for use */
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+	};
+};
+
 &qpic_bam {
 	status = "okay";
 };
@@ -186,7 +200,6 @@
 &sdhci {
 	pinctrl-0 = <&sd_0_pins>;
 	pinctrl-names = "default";
-	cd-gpios = <&tlmm 22 GPIO_ACTIVE_LOW>;
 	vqmmc-supply = <&vqmmc>;
 	status = "okay";
 };

--- a/target/linux/ipq40xx/patches-4.14/854-add-sdhci-reset-implementation.patch
+++ b/target/linux/ipq40xx/patches-4.14/854-add-sdhci-reset-implementation.patch
@@ -1,0 +1,57 @@
+From: Georgi Djakov <georgi.djakov@linaro.org>
+Date: Mon, 28 Nov 2016 19:39:20 +0200
+Subject: [PATCH v2] mmc: sdhci-msm: Add sdhci_reset() implementation
+
+Signed-off-by: Georgi Djakov <georgi.djakov@linaro.org>
+---
+
+drivers/mmc/host/sdhci-msm.c | 29 ++++++++++++++++++++++++++++-
+1 file changed, 28 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/host/sdhci-msm.c b/drivers/mmc/host/sdhci-msm.c
+index 32879b845b75..157ae07f9309 100644
+--- a/drivers/mmc/host/sdhci-msm.c
++++ b/drivers/mmc/host/sdhci-msm.c
+@@ -1117,6 +1117,33 @@ static void sdhci_msm_set_clock(struct sdhci_host *host, unsigned int clock)
+ 	__sdhci_msm_set_clock(host, clock);
+ }
+ 
++void sdhci_msm_reset(struct sdhci_host *host, u8 mask)
++{
++	unsigned long timeout = 100;
++
++	sdhci_writeb(host, mask, SDHCI_SOFTWARE_RESET);
++
++	if (mask & SDHCI_RESET_ALL) {
++		host->clock = 0;
++
++		/*
++		 * SDHCI_RESET_ALL triggers the PWR IRQ
++		 * and we need to handle it here.
++		 */
++		sdhci_msm_voltage_switch(host);
++	}
++
++	while (sdhci_readb(host, SDHCI_SOFTWARE_RESET) & mask) {
++		if (timeout == 0) {
++			pr_err("%s: Reset 0x%x never completed.\n",
++			       mmc_hostname(host->mmc), (int)mask);
++			return;
++		}
++		timeout--;
++		mdelay(1);
++	}
++}
++
+ static void sdhci_msm_write_w(struct sdhci_host *host, u16 val, int reg)
+ {
+	struct sdhci_pltfm_host *pltfm_host = sdhci_priv(host);
+@@ -1148,7 +1174,7 @@ static const struct of_device_id sdhci_msm_dt_match[] = {
+ MODULE_DEVICE_TABLE(of, sdhci_msm_dt_match);
+ 
+ static const struct sdhci_ops sdhci_msm_ops = {
+-	.reset = sdhci_reset,
++	.reset = sdhci_msm_reset,
+	.set_clock = sdhci_set_clock,
+	.get_min_clock = sdhci_msm_get_min_clock,
+	.get_max_clock = sdhci_msm_get_max_clock,

--- a/target/linux/ipq40xx/patches-4.19/854-add-sdhci-reset-implementation.patch
+++ b/target/linux/ipq40xx/patches-4.19/854-add-sdhci-reset-implementation.patch
@@ -1,0 +1,57 @@
+From: Georgi Djakov <georgi.djakov@linaro.org>
+Date: Mon, 28 Nov 2016 19:39:20 +0200
+Subject: [PATCH v2] mmc: sdhci-msm: Add sdhci_reset() implementation
+
+Signed-off-by: Georgi Djakov <georgi.djakov@linaro.org>
+---
+
+drivers/mmc/host/sdhci-msm.c | 29 ++++++++++++++++++++++++++++-
+1 file changed, 28 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/host/sdhci-msm.c b/drivers/mmc/host/sdhci-msm.c
+index 32879b845b75..157ae07f9309 100644
+--- a/drivers/mmc/host/sdhci-msm.c
++++ b/drivers/mmc/host/sdhci-msm.c
+@@ -1117,6 +1117,33 @@ static void sdhci_msm_set_clock(struct sdhci_host *host, unsigned int clock)
+ 	__sdhci_msm_set_clock(host, clock);
+ }
+ 
++void sdhci_msm_reset(struct sdhci_host *host, u8 mask)
++{
++	unsigned long timeout = 100;
++
++	sdhci_writeb(host, mask, SDHCI_SOFTWARE_RESET);
++
++	if (mask & SDHCI_RESET_ALL) {
++		host->clock = 0;
++
++		/*
++		 * SDHCI_RESET_ALL triggers the PWR IRQ
++		 * and we need to handle it here.
++		 */
++		sdhci_msm_voltage_switch(host);
++	}
++
++	while (sdhci_readb(host, SDHCI_SOFTWARE_RESET) & mask) {
++		if (timeout == 0) {
++			pr_err("%s: Reset 0x%x never completed.\n",
++			       mmc_hostname(host->mmc), (int)mask);
++			return;
++		}
++		timeout--;
++		mdelay(1);
++	}
++}
++
+ static void sdhci_msm_write_w(struct sdhci_host *host, u16 val, int reg)
+ {
+	struct sdhci_pltfm_host *pltfm_host = sdhci_priv(host);
+@@ -1148,7 +1174,7 @@ static const struct of_device_id sdhci_msm_dt_match[] = {
+ MODULE_DEVICE_TABLE(of, sdhci_msm_dt_match);
+ 
+ static const struct sdhci_ops sdhci_msm_ops = {
+-	.reset = sdhci_reset,
++	.reset = sdhci_msm_reset,
+	.set_clock = sdhci_set_clock,
+	.get_min_clock = sdhci_msm_get_min_clock,
+	.get_max_clock = sdhci_msm_get_max_clock,


### PR DESCRIPTION
懒得重新发pr了，写点说明。
dts：删掉sd的gpio后，拔出sd卡后2.4G灯会恢复亮起。
4.19的漏了pcie0部分补上。
![0](https://user-images.githubusercontent.com/42570690/69944198-ae43bb80-1521-11ea-8d1f-79683a979853.PNG)
这个sd reset的系统日志很烦，没插上sd的话，有的人没有这些日志，有的人一直会有这个出现，我的机子是有时会有。
谷歌查了下引入一个patch：https://patchwork.kernel.org/patch/9449851
现在插上sd卡也不会有上图的日志了。