### PR TITLE
luci-app-baidupcs-web: refactoring

### DIFF
--- a/package/lean/baidupcs-web/Makefile
+++ b/package/lean/baidupcs-web/Makefile
@@ -1,13 +1,14 @@
 #
 # Copyright (C) 2019 OpenWrt.org
 #
+# KFERMercer <KFER.Mercer@gmail.com>
+#
 # This is free software, licensed under the GNU General Public License v3.
 #
-# By https://github.com/KFERMercer/openwrt-baidupcs-web
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=BaiduPCS-Web
+PKG_NAME:=baidupcs-web
 PKG_VERSION:=3.7.0
 PKG_RELEASE:=1
 
@@ -25,7 +26,12 @@ define Package/$(PKG_NAME)/description
 BaiduPCS-Web is a web controller for BaiduPCS-Go
 endef
 
+# 禁止OpenWrt对二进制文件进行strip
 STRIP:=true
+
+ifeq ($(ARCH),i386)
+	PKG_ARCH_BAIDUPCS-WEB:=86
+endif
 
 ifeq ($(ARCH),x86_64)
 	PKG_ARCH_BAIDUPCS-WEB:=amd64
@@ -35,8 +41,8 @@ ifeq ($(ARCH),mipsel)
 	PKG_ARCH_BAIDUPCS-WEB:=mipsle
 endif
 
-ifeq ($(ARCH),i386)
-	PKG_ARCH_BAIDUPCS-WEB:=86
+ifeq ($(ARCH),mips)
+	PKG_ARCH_BAIDUPCS-WEB:=mipsle
 endif
 
 ifeq ($(ARCH),arm)
@@ -47,15 +53,18 @@ ifeq ($(ARCH),aarch64)
 	PKG_ARCH_BAIDUPCS-WEB:=arm64
 endif
 
-BAIDUPCS-WEB_ZIP_NAME:=BaiduPCS-Go-$(PKG_VERSION)-linux-$(PKG_ARCH_BAIDUPCS-WEB)
-PKG_SOURCE:=$(BAIDUPCS-WEB_ZIP_NAME).zip
+
+PKG_SOURCE:=BaiduPCS-Go-$(PKG_VERSION)-linux-$(PKG_ARCH_BAIDUPCS-WEB).zip
+
 PKG_SOURCE_URL:=https://github.com/liuzhuoling2011/baidupcs-web/releases/download/$(PKG_VERSION)/
-UNZIP_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)-unzip/$(PKG_ARCH_BAIDUPCS-WEB)
+
+UNZIP_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/$(PKG_NAME)-unzip
+
 PKG_HASH:=skip
 
 define Build/Prepare
 	mkdir -vp $(UNZIP_DIR)
-	unzip -od $(UNZIP_DIR) $(DL_DIR)/$(BAIDUPCS-WEB_ZIP_NAME).zip
+	unzip -od $(UNZIP_DIR) $(DL_DIR)/$(PKG_SOURCE)
 endef
 
 define Build/Configure
@@ -66,7 +75,7 @@ endef
 
 define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(UNZIP_DIR)/$(BAIDUPCS-WEB_ZIP_NAME)/BaiduPCS-Go $(1)/usr/bin/$(PKG_NAME)
+	$(INSTALL_BIN) $(UNZIP_DIR)/*/BaiduPCS-Go $(1)/usr/bin/$(PKG_NAME)
 	chmod 755 $(1)/usr/bin/$(PKG_NAME)
 endef
 

--- a/package/lean/luci-app-baidupcs-web/Makefile
+++ b/package/lean/luci-app-baidupcs-web/Makefile
@@ -17,7 +17,6 @@ PKG_VERSION:=1.0
 PKG_RELEASE:=4
 PKG_MAINTAINER:=<https://github.com/KFERMercer/luci-app-baidupcs-web>
 
-
 include $(TOPDIR)/feeds/luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/package/lean/luci-app-baidupcs-web/Makefile
+++ b/package/lean/luci-app-baidupcs-web/Makefile
@@ -1,17 +1,23 @@
-# Copyright (C) 2016 Openwrt.org
 #
-# This is free software, licensed under the Apache License, Version 2.0 .
+# <https://github.com/KFERMercer/luci-app-baidupcs-web>
+# 
+# Copyright (C) 2020 KFERMercer <KFER.Mercer@gmail.com>
+# Copyright (C) 2020 [CTCGFW] Project OpenWRT
+# 
+# THIS IS FREE SOFTWARE, LICENSED UNDER GPLv3.
 #
 
 include $(TOPDIR)/rules.mk
 
-LUCI_TITLE:=LuCI Support for BaiduPCS-Web
-LUCI_DEPENDS:=+BaiduPCS-Web +wget +openssl-util
+PKG_NAME:=luci-app-baidupcs-web
+LUCI_TITLE:=LuCI support for BaiduPCS-Go
+LUCI_DEPENDS:=+baidupcs-web +wget +openssl-util
 LUCI_PKGARCH:=all
 PKG_VERSION:=1.0
-PKG_RELEASE:=1
+PKG_RELEASE:=4
+PKG_MAINTAINER:=<https://github.com/KFERMercer/luci-app-baidupcs-web>
+
 
 include $(TOPDIR)/feeds/luci/luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature
-

--- a/package/lean/luci-app-baidupcs-web/luasrc/controller/baidupcs-web.lua
+++ b/package/lean/luci-app-baidupcs-web/luasrc/controller/baidupcs-web.lua
@@ -4,7 +4,14 @@ function index()
 	if not nixio.fs.access("/etc/config/baidupcs-web") then
 		return
 	end
-	local page
-	page = entry({"admin", "nas", "baidupcs-web"}, cbi("baidupcs-web"), _("BaiduPCS Web"), 300)
-	page.dependent = true
+	entry({"admin", "nas", "baidupcs-web"}, cbi("baidupcs-web"), _("BaiduPCS Web"), 300).dependent = true
+	entry({"admin","nas","baidupcs-web","status"},call("act_status")).leaf=true
+end
+
+function act_status()
+	local e={}
+	e.running=luci.sys.call("pgrep baidupcs-web >/dev/null")==0
+	-- e.port=luci.sys.exec("uci get baidupcs-web.config.port")
+	luci.http.prepare_content("application/json")
+	luci.http.write_json(e)
 end

--- a/package/lean/luci-app-baidupcs-web/luasrc/model/cbi/baidupcs-web.lua
+++ b/package/lean/luci-app-baidupcs-web/luasrc/model/cbi/baidupcs-web.lua
@@ -1,46 +1,48 @@
-require("luci.sys")
-require("luci.util")
+--[[
 
-local fs  = require "nixio.fs"
+Copyright (C) 2020 KFERMercer <KFER.Mercer@gmail.com>
+Copyright (C) 2020 [CTCGFW] Project OpenWRT
 
-local uci = require "luci.model.uci".cursor()
+THIS IS FREE SOFTWARE, LICENSED UNDER GPLv3
 
-local m, s
+]]--
 
-local running=(luci.sys.call("pidof BaiduPCS-Web > /dev/null") == 0)
+m = Map("baidupcs-web")
+m.title	= translate("BaiduPCS-Web")
+m.description = translate("基于BaiduPCS-Go, 可以让你高效的使用百度云")
 
-local button = ""
-local state_msg = ""
-local trport = uci:get("baidupcs-web", "config", "port")
-if running  then
-	button = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type=\"button\" value=\" " .. translate("打开BaiduPCS-Web管理界面") .. " \" onclick=\"window.open('http://'+window.location.hostname+':" .. trport .. "')\"/>"
-end
+m:section(SimpleSection).template  = "baidupcs-web/baidupcs-web_status"
 
-if running then
-        state_msg = "<b><font color=\"green\">" .. translate("BaiduPCS-Web 运行中") .. "</font></b>"
-else
-        state_msg = "<b><font color=\"red\">" .. translate("BaiduPCS-Web 未运行") .. "</font></b>"
-end
-
-m = Map("baidupcs-web", translate("百度网盘管理"), translate("基于BaiduPCS-Web，让你高效的使用百度云。") .. button
-        .. "<br/><br/>" .. translate("BaiduPCS-Web运行状态").. " : "  .. state_msg .. "<br/>")
-
-s = m:section(TypedSection, "baidupcs-web", "")
+s = m:section(TypedSection, "baidupcs-web")
 s.addremove = false
 s.anonymous = true
 
 enable = s:option(Flag, "enabled", translate("启用"))
 enable.rmempty = false
 
-o = s:option(Value, "port", translate("监听端口"))
-o.placeholder = 5299
-o.default     = 5299
-o.datatype    = "port"
-o.rmempty     = false
+o = s:option(Value, "port", translate("网页端口"))
+o.datatype = "port"
+o.placeholder = "5299"
+o.default = "5299"
+o.rmempty = false
 
-o = s:option(Value, "dl_dir", translate("下载目录"))
+o = s:option(Value, "download_dir", translate("下载目录"))
 o.placeholder = "/opt/baidupcsweb-download"
-o.default     = "/opt/baidupcsweb-download"
-o.rmempty     = false
+o.default = "/opt/baidupcsweb-download"
+o.rmempty = false
+
+o = s:option(Value, "max_download_rate", translate("最大下载速度"))
+o.placeholder = "0"
+
+o = s:option(Value, "max_upload_rate", translate("最大上传速度"))
+o.placeholder = "0"
+o.description = translate("0代表不限制, 单位为每秒的传输速率, 后缀'/s' 可省略, 如 2MB/s, 2MB, 2m, 2mb 均为一个意思")
+
+o = s:option(Value, "max_download_load", translate("同时进行下载文件的最大数量"))
+o.placeholder = "1"
+o.description = translate("不要太贪心, 当心被封号")
+
+o = s:option(Value, "max_parallel", translate("最大并发连接数"))
+o.placeholder = "8"
 
 return m

--- a/package/lean/luci-app-baidupcs-web/luasrc/view/baidupcs-web/baidupcs-web_status.htm
+++ b/package/lean/luci-app-baidupcs-web/luasrc/view/baidupcs-web/baidupcs-web_status.htm
@@ -36,4 +36,3 @@ function openClient() {
 		<em><%:Collecting data...%></em>
 	</p>
 </fieldset>
-	

--- a/package/lean/luci-app-baidupcs-web/luasrc/view/baidupcs-web/baidupcs-web_status.htm
+++ b/package/lean/luci-app-baidupcs-web/luasrc/view/baidupcs-web/baidupcs-web_status.htm
@@ -1,0 +1,39 @@
+<!-- 
+	Copyright (C) 2020 KFERMercer <KFER.Mercer@gmail.com>
+	THIS IS FREE SOFTWARE, LICENSED UNDER GPLv3.
+ -->
+
+<script type="text/javascript">//<![CDATA[
+XHR.poll(3, '<%=url([[admin]], [[nas]], [[baidupcs-web]], [[status]])%>', null,
+	function(x, data) {
+		var tb = document.getElementById('baidupcs-web_status');
+
+		if (data && tb) {
+			if (data.running) {
+				var links = '<em><b><font color=green>BaiduPCS-Web <%:RUNNING%></font></b></em><input class="cbi-button mar-10" type="button" value="<%:打开管理页面%>" onclick="openClient();" />';
+				tb.innerHTML = links;
+			} else {
+				tb.innerHTML = '<em><b><font color=red>BaiduPCS-Web <%:NOT RUNNING%></font></b></em>';
+			}
+		}
+	}
+);
+
+function openClient() {
+	var curWwwPath = window.document.location.href;
+	var pathName = window.document.location.pathname;
+	var pos = curWwwPath.indexOf(pathName);
+	var localhostPath = curWwwPath.substring(0, pos);
+	var clientPort = window.document.querySelector("#cbid\\.baidupcs-web\\.config\\.port").value
+	var url = "http:" + localhostPath.substring(window.location.protocol.length) + ":" + clientPort;
+	window.open(url)
+};
+//]]>
+</script>
+<style>.mar-10 {margin-left: 50px; margin-right: 10px;}</style>
+<fieldset class="cbi-section">
+	<p id="baidupcs-web_status">
+		<em><%:Collecting data...%></em>
+	</p>
+</fieldset>
+	

--- a/package/lean/luci-app-baidupcs-web/root/etc/config/baidupcs-web
+++ b/package/lean/luci-app-baidupcs-web/root/etc/config/baidupcs-web
@@ -1,6 +1,1 @@
-
-config baidupcs-web 'config'
-	option enabled '0'
-	option port '5299'
-	option dl_dir '/opt/baidupcsweb-download'
-
+config baidupcs-web

--- a/package/lean/luci-app-baidupcs-web/root/etc/config/baidupcs-web
+++ b/package/lean/luci-app-baidupcs-web/root/etc/config/baidupcs-web
@@ -1,1 +1,2 @@
-config baidupcs-web
+
+config baidupcs-web 'config'

--- a/package/lean/luci-app-baidupcs-web/root/etc/config/baidupcs-web
+++ b/package/lean/luci-app-baidupcs-web/root/etc/config/baidupcs-web
@@ -1,6 +1,6 @@
 
 config baidupcs-web 'config'
-	option port '5299'
 	option enabled '0'
+	option port '5299'
 	option dl_dir '/opt/baidupcsweb-download'
 

--- a/package/lean/luci-app-baidupcs-web/root/etc/init.d/baidupcs-web
+++ b/package/lean/luci-app-baidupcs-web/root/etc/init.d/baidupcs-web
@@ -1,21 +1,32 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2019 By [CTCGFW] Project OpenWRT
 
 START=90
 STOP=10
 
 enabled="$(uci get baidupcs-web.config.enabled)"
 port="$(uci get baidupcs-web.config.port)"
-dl_dir="$(uci get baidupcs-web.config.dl_dir)"
+download_dir="$(uci get baidupcs-web.config.download_dir)"
+max_download_rate="$(uci get baidupcs-web.config.max_download_rate)"
+max_upload_rate="$(uci get baidupcs-web.config.max_upload_rate)"
+max_download_load="$(uci get baidupcs-web.config.max_download_load)"
+max_parallel="$(uci get baidupcs-web.config.max_parallel)"
 
 start() {
 	stop
 	[ "$enabled" == "1" ] || exit 0
-	mkdir -p "${dl_dir}"
-	BaiduPCS-Web config set -savedir="${dl_dir}" >/dev/null 2>&1
-	BaiduPCS-Web web --port "${port}" --access >/dev/null 2>&1 &
+	mkdir -p "${download_dir}"
+	baidupcs-web config set                         \
+	--savedir               "${download_dir}"       \
+	--max_download_rate     "${max_download_rate}"  \
+	--max_upload_rate       "${max_upload_rate}"    \
+	--max_download_load     "${max_download_load}"  \
+	--max_parallel          "${max_parallel}"       \
+	--max_upload_parallel   "${max_parallel}"       \
+	>/dev/null 2>&1
+
+	baidupcs-web web --port "${port}" --access >/dev/null 2>&1 &
 }
 
 stop() {
-	killall BaiduPCS-Web >/dev/null 2>&1
+	killall baidupcs-web >/dev/null 2>&1
 }


### PR DESCRIPTION
## 重构 luci-app-baidupcs-web:

之前的插件太简陋, 而且交互有问题.

- 加了些自定义功能.
- 实时刷新运行状态, 开启时显示web按钮.
- 把baidupcs-web包名改了, 大小写混杂有些不规范 (没在暗示UnblockNeteaseMusic).
- 测试过了, 各项功能正常.

效果图:

---
![enable](https://user-images.githubusercontent.com/37098748/71321933-f55b1600-24fb-11ea-9847-eba6bd59a0cd.png)
![disable](https://user-images.githubusercontent.com/37098748/71321935-f8560680-24fb-11ea-8a75-56c09ddaa6cd.png)
