### PR TITLE
luci-app-v2ray-server: add http proxy support and fix bug

### DIFF
--- a/package/lean/luci-app-v2ray-server/luasrc/model/cbi/v2ray_server/api/genv2rayconfig.lua
+++ b/package/lean/luci-app-v2ray-server/luasrc/model/cbi/v2ray_server/api/genv2rayconfig.lua
@@ -15,13 +15,23 @@ if server.protocol == "vmess" then
 				}
 			}
 		}
+elseif server.protocol == "http" then
+	proset = {
+			allowTransparent = false,
+			accounts = {
+				{
+					user = (server.Http_user == nil) and "lean" or server.Http_user,
+					pass = (server.Http_pass == nil) and "password" or server.Http_pass
+				}
+			}
+		}
 else
     proset = {
 			auth = "password",
 			accounts = {
 				{
-					user = server.Socks_user,
-					pass = server.Socks_pass
+					user = (server.Socks_user == nil) and "lean" or server.Socks_user,
+					pass = (server.Socks_pass == nil) and "password" or server.Socks_pass
 				}
 			}
 		}
@@ -33,12 +43,12 @@ local v2ray = {
 		--error = "/var/log/v2ray.log",
 		loglevel = "warning"
 	},
-	-- 传入连接
+	-- 浼犲叆杩炴帴
 	inbound = {
 		port = tonumber(server.port),
 		protocol = server.protocol,
 		settings = proset,
-		-- 底层传输配置
+		-- 搴曞眰浼犺緭閰嶇疆
 		streamSettings = {
 			network = server.transport,
 			security = (server.tls == '1') and "tls" or "none",
@@ -67,11 +77,11 @@ local v2ray = {
 			} or nil
 		}
 	},
-	-- 传出连接
+	-- 浼犲嚭杩炴帴
 	outbound = {
 		protocol = "freedom"
 	},
-	-- 额外传出连接
+	-- 棰濆浼犲嚭杩炴帴
 	outboundDetour = {
 		{
 			protocol = "blackhole",

--- a/package/lean/luci-app-v2ray-server/luasrc/model/cbi/v2ray_server/config.lua
+++ b/package/lean/luci-app-v2ray-server/luasrc/model/cbi/v2ray_server/config.lua
@@ -32,6 +32,7 @@ e.default=10086
 e=t:option(ListValue,"protocol",translate("Protocol"))
 e:value("vmess",translate("Vmess"))
 e:value("socks",translate("Socks"))
+e:value("http",translate("Http"))
 
 e=t:option(Value,"VMess_id",translate("ID"))
 e.default=luci.sys.exec("cat /proc/sys/kernel/random/uuid")
@@ -53,6 +54,17 @@ e.default="password"
 e.rmempty=true
 e.password=true
 e:depends("protocol","socks")
+
+e=t:option(Value,"Http_user",translate("User name"))
+e.default="lean"
+e.rmempty=true
+e:depends("protocol","http")
+
+e=t:option(Value,"Http_pass",translate("Password"))
+e.default="password"
+e.rmempty=true
+e.password=true
+e:depends("protocol","http")
 
 e=t:option(Value,"VMess_level",translate("User Level"))
 e.default=1

--- a/package/lean/luci-app-v2ray-server/po/zh-cn/v2ray_server.po
+++ b/package/lean/luci-app-v2ray-server/po/zh-cn/v2ray_server.po
@@ -16,6 +16,9 @@ msgstr "备注"
 msgid "Port"
 msgstr "端口"
 
+msgid "User name"
+msgstr "用户名"
+
 msgid "Password"
 msgstr "密码"
 


### PR DESCRIPTION
V2ray服务端：
1.增加http代理支持
2.修复保存socks设置时用户名或密码为空，服务无法启动问题
3.增加缺失的翻译文字