### PR TITLE
kernel: bump to 4.9.208, 4.14.162, 4.19.93

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -297,6 +297,7 @@ menu "Target Images"
 		int "Kernel partition size (in MB)"
 		depends on GRUB_IMAGES || EFI_IMAGES || USES_BOOT_PART
 		default 8 if TARGET_apm821xx_sata
+		default 64 if TARGET_brcm2708
 		default 16
 
 	config TARGET_ROOTFS_PARTSIZE

--- a/package/boot/kexec-tools/Makefile
+++ b/package/boot/kexec-tools/Makefile
@@ -44,7 +44,7 @@ define Package/kexec
   $(call Package/kexec-tools/Default)
   TITLE:=Kernel boots kernel
   DEPENDS:=\
-	@armeb||@arm||@i386||@x86_64||@powerpc64||@mipsel||@mips \
+	@(armeb||arm||i386||x86_64||powerpc64||mipsel||mips) \
 	+KEXEC_ZLIB:zlib +KEXEC_LZMA:liblzma @KERNEL_KEXEC
 endef
 
@@ -55,7 +55,7 @@ endef
 define Package/kdump
   $(call Package/kexec-tools/Default)
   TITLE:=Kernel crash analysis
-  DEPENDS:=+kexec @i386||@x86_64||@arm @KERNEL_CRASH_DUMP
+  DEPENDS:=+kexec @(i386||x86_64||arm) @KERNEL_CRASH_DUMP
 endef
 
 define Package/kdump/description

--- a/package/kernel/brcm2708-gpu-fw/Makefile
+++ b/package/kernel/brcm2708-gpu-fw/Makefile
@@ -9,8 +9,8 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=brcm2708-gpu-fw
-PKG_VERSION:=2019-07-09
-PKG_RELEASE:=025759b8634c2f8df35203be02c19a0633f1cec1
+PKG_VERSION:=2019-12-11
+PKG_RELEASE:=0c01dbefba45a08c47f8538d5a071a0fba6b7e83
 
 PKG_BUILD_DIR:=$(KERNEL_BUILD_DIR)/$(PKG_NAME)/rpi-firmware-$(PKG_RELEASE)
 
@@ -25,7 +25,7 @@ define Download/LICENCE_broadcom
   FILE:=$(RPI_FIRMWARE_FILE)-LICENCE.broadcom
   URL:=$(RPI_FIRMWARE_URL)
   URL_FILE:=LICENCE.broadcom
-  HASH:=ba76edfc10a248166d965b8eaf320771c44f4f432d4fce2fd31fd272e7038add
+  HASH:=c7283ff51f863d93a275c66e3b4cb08021a5dd4d8c1e7acc47d872fbe52d3d6b
 endef
 $(eval $(call Download,LICENCE_broadcom))
 
@@ -33,7 +33,7 @@ define Download/bootcode_bin
   FILE:=$(RPI_FIRMWARE_FILE)-bootcode.bin
   URL:=$(RPI_FIRMWARE_URL)
   URL_FILE:=bootcode.bin
-  HASH:=6948c07f60f93489bbbc78747a1dc09ff0b1de42035c915fbd6453cdbd0e6475
+  HASH:=6505bbc8798698bd8f1dff30789b22289ebb865ccba7833b87705264525cbe46
 endef
 $(eval $(call Download,bootcode_bin))
 
@@ -41,7 +41,7 @@ define Download/fixup_dat
   FILE:=$(RPI_FIRMWARE_FILE)-fixup.dat
   URL:=$(RPI_FIRMWARE_URL)
   URL_FILE:=fixup.dat
-  HASH:=d63bc6d3516dbb860091a34ec3ce584fafb4dc79740c11da9be87572849c2e02
+  HASH:=85a54bf460aa3ff0d04ee54bc606bf3af39a2c5194e519ab278cf74ecf75f7a8
 endef
 $(eval $(call Download,fixup_dat))
 
@@ -49,7 +49,7 @@ define Download/fixup_cd_dat
   FILE:=$(RPI_FIRMWARE_FILE)-fixup_cd.dat
   URL:=$(RPI_FIRMWARE_URL)
   URL_FILE:=fixup_cd.dat
-  HASH:=eba5b57f49d2e8c1b2261e59297256bdff4751aeb3c7a16e60044799bcfd6b68
+  HASH:=4d9ffff3719fff6b14f142cbb4b3f62df175e59be4ad382b0f39830dab18d760
 endef
 $(eval $(call Download,fixup_cd_dat))
 
@@ -57,7 +57,7 @@ define Download/fixup_x_dat
   FILE:=$(RPI_FIRMWARE_FILE)-fixup_x.dat
   URL:=$(RPI_FIRMWARE_URL)
   URL_FILE:=fixup_x.dat
-  HASH:=74cc843d28f07940f7f9e618d2f5ff8c0ed245599bb45457bab1960e56cbf672
+  HASH:=81aae9581c120fbbf5020fa6b84b355ed342ead7185db0916cbce7a7849307eb
 endef
 $(eval $(call Download,fixup_x_dat))
 
@@ -65,7 +65,7 @@ define Download/fixup4_dat
   FILE:=$(RPI_FIRMWARE_FILE)-fixup4.dat
   URL:=$(RPI_FIRMWARE_URL)
   URL_FILE:=fixup4.dat
-  HASH:=d8b44fd10c87ae51d4cce14a692f7f322574d63f7255f9776a61005c37183c5a
+  HASH:=611ea1ec1384931c785687e78a50369aae3a0a29e37bed354862cf5fe6d23ade
 endef
 $(eval $(call Download,fixup4_dat))
 
@@ -73,7 +73,7 @@ define Download/fixup4cd_dat
   FILE:=$(RPI_FIRMWARE_FILE)-fixup4cd.dat
   URL:=$(RPI_FIRMWARE_URL)
   URL_FILE:=fixup4cd.dat
-  HASH:=efc3fa3cd5f94e08687824bf149ed8c9a11bbd3e8ebac034934246dbf502300c
+  HASH:=f82da018c2d9fe1ec54fcfe76514dbc3b9f27f53712bb5f5b90f0d38124370eb
 endef
 $(eval $(call Download,fixup4cd_dat))
 
@@ -81,7 +81,7 @@ define Download/fixup4x_dat
   FILE:=$(RPI_FIRMWARE_FILE)-fixup4x.dat
   URL:=$(RPI_FIRMWARE_URL)
   URL_FILE:=fixup4x.dat
-  HASH:=866c11f0770246fba0756ee671cf118313ee23be88decae09114b123db2f26bd
+  HASH:=36c1cdb7b5ff8c39c1c0cd962ea1095f79c5c290fc11813869cbb662240386d7
 endef
 $(eval $(call Download,fixup4x_dat))
 
@@ -89,7 +89,7 @@ define Download/start_elf
   FILE:=$(RPI_FIRMWARE_FILE)-start.elf
   URL:=$(RPI_FIRMWARE_URL)
   URL_FILE:=start.elf
-  HASH:=c9f831786f4c03d58110baddef4da32f56387d1af191866f839dffb9b0671aab
+  HASH:=442919907e4b7d8f007b79df1aa1e12f98e09ab393da65b48cd2b2af04301b7d
 endef
 $(eval $(call Download,start_elf))
 
@@ -97,7 +97,7 @@ define Download/start_cd_elf
   FILE:=$(RPI_FIRMWARE_FILE)-start_cd.elf
   URL:=$(RPI_FIRMWARE_URL)
   URL_FILE:=start_cd.elf
-  HASH:=c7ba345f71b1e5fed2cbc9d16dbb1b658546c1365e92302828f4f75ccb693df5
+  HASH:=0942b6ab8eec7e6116a3fc366cb0d4a94b5869c429292da600f92a37e361ec8d
 endef
 $(eval $(call Download,start_cd_elf))
 
@@ -105,7 +105,7 @@ define Download/start_x_elf
   FILE:=$(RPI_FIRMWARE_FILE)-start_x.elf
   URL:=$(RPI_FIRMWARE_URL)
   URL_FILE:=start_x.elf
-  HASH:=ab51744e7048a67758ac133ed20e3f482e40f81780915b88efb97647f838771e
+  HASH:=e83dc1fbb5a9cb29e1db5f9ca0f9bd847f5b57a1e421cc79e39640a865456fe6
 endef
 $(eval $(call Download,start_x_elf))
 
@@ -113,7 +113,7 @@ define Download/start4_elf
   FILE:=$(RPI_FIRMWARE_FILE)-start4.elf
   URL:=$(RPI_FIRMWARE_URL)
   URL_FILE:=start4.elf
-  HASH:=2691df2baa2d24dc08a7c7c99381555a819722a92c2b80731452724ddcd3e6d0
+  HASH:=550b55577075f4056a71b0faa2b1150290b2e8d61e5bc330a54452f28cc1b2d8
 endef
 $(eval $(call Download,start4_elf))
 
@@ -121,7 +121,7 @@ define Download/start4cd_elf
   FILE:=$(RPI_FIRMWARE_FILE)-start4cd.elf
   URL:=$(RPI_FIRMWARE_URL)
   URL_FILE:=start4cd.elf
-  HASH:=5e0d5e20b212daab99c2dd57a363ccd64ed27c8bbd0205efee07a731e6ae1a4e
+  HASH:=1c8206a854fba486b7996aa3735aaca8aaeee7bf20fdbf190acdea4516794f1c
 endef
 $(eval $(call Download,start4cd_elf))
 
@@ -129,7 +129,7 @@ define Download/start4x_elf
   FILE:=$(RPI_FIRMWARE_FILE)-start4x.elf
   URL:=$(RPI_FIRMWARE_URL)
   URL_FILE:=start4x.elf
-  HASH:=67a748bb67267cfea45597681e8400a1794956dd9b7906032991cb6ce2d8742b
+  HASH:=3ca2e259861fd31b77a536ccb33637e5305ec44b9e0c62e898e7e1d97e776f22
 endef
 $(eval $(call Download,start4x_elf))
 

--- a/package/kernel/broadcom-wl/Makefile
+++ b/package/kernel/broadcom-wl/Makefile
@@ -32,15 +32,15 @@ include $(INCLUDE_DIR)/package.mk
 define Package/broadcom-wl/Default
   SECTION:=kernel
   CATEGORY:=Kernel modules
-  DEPENDS:=@PACKAGE_kmod-brcm-wl||PACKAGE_kmod-brcm-wl-mini
+  DEPENDS:=@(PACKAGE_kmod-brcm-wl||PACKAGE_kmod-brcm-wl-mini)
   SUBMENU:=Proprietary BCM43xx WiFi driver
-  SUBMENUDEP:=@TARGET_brcm47xx||TARGET_brcm63xx
+  SUBMENUDEP:=(TARGET_brcm47xx||TARGET_brcm63xx)
 endef
 
 define KernelPackage/brcm-wl/Default
   $(call Package/broadcom-wl/Default)
   SECTION:=kernel
-  DEPENDS:=@TARGET_brcm47xx||TARGET_brcm63xx +wireless-tools
+  DEPENDS:=@(TARGET_brcm47xx||TARGET_brcm63xx) +wireless-tools
   TITLE:=Kernel driver for BCM43xx chipsets
   FILES:=$(PKG_BUILD_DIR)/driver$(1)/wl.ko $(PKG_BUILD_DIR)/glue/wl_glue.ko
   AUTOLOAD:=$(call AutoProbe,wl)

--- a/package/system/procd/Makefile
+++ b/package/system/procd/Makefile
@@ -58,7 +58,7 @@ endef
 define Package/procd-seccomp
   SECTION:=base
   CATEGORY:=Base system
-  DEPENDS:=@arm||@armeb||@mips||@mipsel||@i386||@powerpc||@x86_64 @!TARGET_uml @KERNEL_SECCOMP +libubox +libblobmsg-json
+  DEPENDS:=@(arm||armeb||mips||mipsel||i386||powerpc||x86_64) @!TARGET_uml @KERNEL_SECCOMP +libubox +libblobmsg-json
   TITLE:=OpenWrt process seccomp helper + utrace
 endef
 

--- a/package/utils/mdadm/Makefile
+++ b/package/utils/mdadm/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mdadm
-PKG_VERSION:=4.0
-PKG_RELEASE:=5
+PKG_VERSION:=4.1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/raid/mdadm
-PKG_HASH:=1d6ae7f24ced3a0fa7b5613b32f4a589bb4881e3946a5a2c3724056254ada3a9
+PKG_HASH:=ab7688842908d3583a704d491956f31324c3a5fc9f6a04653cb75d19f1934f4a
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_CPE_ID:=cpe:/a:mdadm_project:mdadm

--- a/package/utils/mdadm/patches/100-cross_compile.patch
+++ b/package/utils/mdadm/patches/100-cross_compile.patch
@@ -1,11 +1,11 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -86,7 +86,7 @@ DLM:=$(shell [ -f /usr/include/libdlm.h
+@@ -97,7 +97,7 @@ DLM:=$(shell [ -f /usr/include/libdlm.h
  DIRFLAGS = -DMAP_DIR=\"$(MAP_DIR)\" -DMAP_FILE=\"$(MAP_FILE)\"
  DIRFLAGS += -DMDMON_DIR=\"$(MDMON_DIR)\"
  DIRFLAGS += -DFAILED_SLOTS_DIR=\"$(FAILED_SLOTS_DIR)\"
 -CFLAGS = $(CWFLAGS) $(CXFLAGS) -DSendmail=\""$(MAILCMD)"\" $(CONFFILEFLAGS) $(DIRFLAGS) $(COROSYNC) $(DLM)
-+# CFLAGS = $(CWFLAGS) $(CXFLAGS) -DSendmail=\""$(MAILCMD)"\" $(CONFFILEFLAGS) $(DIRFLAGS) $(COROSYNC) $(DLM)
++#CFLAGS = $(CWFLAGS) $(CXFLAGS) -DSendmail=\""$(MAILCMD)"\" $(CONFFILEFLAGS) $(DIRFLAGS) $(COROSYNC) $(DLM)
  
  VERSION = $(shell [ -d .git ] && git describe HEAD | sed 's/mdadm-//')
- VERS_DATE = $(shell [ -d .git ] && date --date="`git log -n1 --format=format:%cd --date=short`" '+%0dth %B %Y' | sed -e 's/1th/1st/' -e 's/2th/2nd/' -e 's/11st/11th/' -e 's/12nd/12th/')
+ VERS_DATE = $(shell [ -d .git ] && date --iso-8601 --date="`git log -n1 --format=format:%cd --date=iso --date=short`")

--- a/package/utils/mdadm/patches/101-mdadm.h-Undefine-dprintf-before-redefining.patch
+++ b/package/utils/mdadm/patches/101-mdadm.h-Undefine-dprintf-before-redefining.patch
@@ -22,7 +22,7 @@ Upstream-Status: Pending
 
 --- a/mdadm.h
 +++ b/mdadm.h
-@@ -1595,11 +1595,13 @@ static inline char *to_subarray(struct m
+@@ -1649,11 +1649,13 @@ static inline char *to_subarray(struct m
  }
  
  #ifdef DEBUG

--- a/package/utils/mdadm/patches/102-Add-missing-include-file-sys-sysmacros.h.patch
+++ b/package/utils/mdadm/patches/102-Add-missing-include-file-sys-sysmacros.h.patch
@@ -1,0 +1,29 @@
+From 452dc4d13a012cdcb05088c0dbc699959c4d6c73 Mon Sep 17 00:00:00 2001
+From: Baruch Siach <baruch@tkos.co.il>
+Date: Tue, 6 Aug 2019 16:05:23 +0300
+Subject: mdadm.h: include sysmacros.h unconditionally
+
+musl libc now also requires sys/sysmacros.h for the major/minor macros.
+All supported libc implementations carry sys/sysmacros.h, including
+diet-libc, klibc, and uclibc-ng.
+
+Cc: Hauke Mehrtens <hauke@hauke-m.de>
+Signed-off-by: Baruch Siach <baruch@tkos.co.il>
+Signed-off-by: Jes Sorensen <jsorensen@fb.com>
+---
+ mdadm.h | 2 --
+ 1 file changed, 2 deletions(-)
+
+--- a/mdadm.h
++++ b/mdadm.h
+@@ -45,10 +45,8 @@ extern __off64_t lseek64 __P ((int __fd,
+ #include	<errno.h>
+ #include	<string.h>
+ #include	<syslog.h>
+-#ifdef __GLIBC__
+ /* Newer glibc requires sys/sysmacros.h directly for makedev() */
+ #include	<sys/sysmacros.h>
+-#endif
+ #ifdef __dietlibc__
+ #include	<strings.h>
+ /* dietlibc has deprecated random and srandom!! */

--- a/package/utils/mdadm/patches/200-reduce_size.patch
+++ b/package/utils/mdadm/patches/200-reduce_size.patch
@@ -1,6 +1,6 @@
 --- a/Incremental.c
 +++ b/Incremental.c
-@@ -1642,6 +1642,10 @@ static int Incremental_container(struct
+@@ -1619,6 +1619,10 @@ static int Incremental_container(struct
  	if (ra_all == ra_blocked)
  		return 0;
  
@@ -13,7 +13,7 @@
  	memcpy(suuid, uuid_zero, sizeof(int[4]));
 --- a/util.c
 +++ b/util.c
-@@ -1151,7 +1151,9 @@ void wait_for(char *dev, int fd)
+@@ -1220,7 +1220,9 @@ void wait_for(char *dev, int fd)
  struct superswitch *superlist[] =
  {
  	&super0, &super1,
@@ -21,5 +21,5 @@
  	&super_ddf, &super_imsm,
 +#endif
  	&mbr, &gpt,
- 	NULL };
- 
+ 	NULL
+ };

--- a/package/utils/nvram/Makefile
+++ b/package/utils/nvram/Makefile
@@ -21,7 +21,7 @@ define Package/nvram
   CATEGORY:=Base system
   TITLE:=Userspace port of the Broadcom NVRAM manipulation tool
   MAINTAINER:=Jo-Philipp Wich <xm@subsignal.org>
-  DEPENDS:=@TARGET_brcm47xx||@TARGET_bcm53xx||@TARGET_ar71xx||@TARGET_ath79
+  DEPENDS:=@(TARGET_brcm47xx||TARGET_bcm53xx||TARGET_ar71xx||TARGET_ath79)
 endef
 
 define Package/nvram/description

--- a/package/utils/otrx/Makefile
+++ b/package/utils/otrx/Makefile
@@ -19,7 +19,7 @@ define Package/otrx
   CATEGORY:=Base system
   TITLE:=Utility for opening (analyzing) TRX firmware images
   MAINTAINER:=Rafał Miłecki <zajec5@gmail.com>
-  DEPENDS:=@TARGET_brcm47xx||@TARGET_bcm53xx
+  DEPENDS:=@(TARGET_brcm47xx||TARGET_bcm53xx)
 endef
 
 define Package/otrx/description

--- a/target/linux/generic/pending-4.14/681-NET-add-of_get_mac_address_mtd.patch
+++ b/target/linux/generic/pending-4.14/681-NET-add-of_get_mac_address_mtd.patch
@@ -32,62 +32,17 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  {
  	struct property *pp = of_find_property(np, name, NULL);
  
-@@ -47,6 +48,133 @@ static const void *of_get_mac_addr(struc
+@@ -47,6 +48,79 @@ static const void *of_get_mac_addr(struc
  	return NULL;
  }
  
-+typedef int(*mtd_mac_address_read)(struct mtd_info *mtd, loff_t from, u_char *buf);
-+
-+static int read_mtd_mac_address(struct mtd_info *mtd, loff_t from, u_char *mac)
-+{
-+	int retlen;
-+
-+	return mtd_read(mtd, from, 6, &retlen, mac);
-+}
-+
-+static int read_mtd_mac_address_ascii(struct mtd_info *mtd, loff_t from, u_char *mac)
-+{
-+	int retlen;
-+	char buf[17];
-+
-+	if (mtd_read(mtd, from, 12, &retlen, buf)) {
-+		return -1;
-+	}
-+	if (sscanf(buf, "%2hhx%2hhx%2hhx%2hhx%2hhx%2hhx",
-+			&mac[0], &mac[1], &mac[2], &mac[3],
-+			&mac[4], &mac[5]) == 6) {
-+		return 0;
-+	}
-+	if (mtd_read(mtd, from+12, 5, &retlen, buf+12)) {
-+		return -1;
-+	}
-+	if (sscanf(buf, "%2hhx:%2hhx:%2hhx:%2hhx:%2hhx:%2hhx",
-+			&mac[0], &mac[1], &mac[2], &mac[3],
-+			&mac[4], &mac[5]) == 6) {
-+		return 0;
-+	}
-+	return -1;
-+}
-+
-+static struct mtd_mac_address_property {
-+	char *name;
-+	mtd_mac_address_read read;
-+} mtd_mac_address_properties[] = {
-+	{
-+		.name = "mtd-mac-address",
-+		.read = read_mtd_mac_address,
-+	}, {
-+		.name = "mtd-mac-address-ascii",
-+		.read = read_mtd_mac_address_ascii,
-+	},
-+};
-+
 +static const void *of_get_mac_address_mtd(struct device_node *np)
 +{
 +#ifdef CONFIG_MTD
 +	struct device_node *mtd_np = NULL;
 +	struct property *prop;
-+	int size, ret = -1;
++	size_t retlen;
++	int size, ret;
 +	struct mtd_info *mtd;
 +	const char *part;
 +	const __be32 *list;
@@ -96,37 +51,28 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	u8 mac[ETH_ALEN];
 +	void *addr;
 +	u32 inc_idx;
-+	int i;
 +
-+	for (i = 0; i < ARRAY_SIZE(mtd_mac_address_properties); i++) {
-+		list = of_get_property(np, mtd_mac_address_properties[i].name, &size);
-+		if (!list || (size != (2 * sizeof(*list))))
-+			continue;
-+
-+		phandle = be32_to_cpup(list++);
-+		if (phandle)
-+			mtd_np = of_find_node_by_phandle(phandle);
-+
-+		if (!mtd_np)
-+			continue;
-+
-+		part = of_get_property(mtd_np, "label", NULL);
-+		if (!part)
-+			part = mtd_np->name;
-+
-+		mtd = get_mtd_device_nm(part);
-+		if (IS_ERR(mtd))
-+			continue;
-+
-+		ret = mtd_mac_address_properties[i].read(mtd, be32_to_cpup(list), mac);
-+		put_mtd_device(mtd);
-+		if (!ret) {
-+			break;
-+		}
-+	}
-+	if (ret) {
++	list = of_get_property(np, "mtd-mac-address", &size);
++	if (!list || (size != (2 * sizeof(*list))))
 +		return NULL;
-+	}
++
++	phandle = be32_to_cpup(list++);
++	if (phandle)
++		mtd_np = of_find_node_by_phandle(phandle);
++
++	if (!mtd_np)
++		return NULL;
++
++	part = of_get_property(mtd_np, "label", NULL);
++	if (!part)
++		part = mtd_np->name;
++
++	mtd = get_mtd_device_nm(part);
++	if (IS_ERR(mtd))
++		return NULL;
++
++	ret = mtd_read(mtd, be32_to_cpup(list), 6, &retlen, mac);
++	put_mtd_device(mtd);
 +
 +	if (of_property_read_u32(np, "mtd-mac-address-increment-byte", &inc_idx))
 +		inc_idx = 5;
@@ -166,7 +112,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  /**
   * Search the device tree for the best MAC address to use.  'mac-address' is
   * checked first, because that is supposed to contain to "most recent" MAC
-@@ -64,11 +192,18 @@ static const void *of_get_mac_addr(struc
+@@ -64,11 +138,18 @@ static const void *of_get_mac_addr(struc
   * addresses.  Some older U-Boots only initialized 'local-mac-address'.  In
   * this case, the real MAC is in 'local-mac-address', and 'mac-address' exists
   * but is all zeros.

--- a/target/linux/generic/pending-4.19/681-NET-add-of_get_mac_address_mtd.patch
+++ b/target/linux/generic/pending-4.19/681-NET-add-of_get_mac_address_mtd.patch
@@ -32,62 +32,17 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  {
  	struct property *pp = of_find_property(np, name, NULL);
  
-@@ -48,6 +49,133 @@ static const void *of_get_mac_addr(struc
+@@ -48,6 +49,79 @@ static const void *of_get_mac_addr(struc
  	return NULL;
  }
  
-+typedef int(*mtd_mac_address_read)(struct mtd_info *mtd, loff_t from, u_char *buf);
-+
-+static int read_mtd_mac_address(struct mtd_info *mtd, loff_t from, u_char *mac)
-+{
-+	int retlen;
-+
-+	return mtd_read(mtd, from, 6, &retlen, mac);
-+}
-+
-+static int read_mtd_mac_address_ascii(struct mtd_info *mtd, loff_t from, u_char *mac)
-+{
-+	int retlen;
-+	char buf[17];
-+
-+	if (mtd_read(mtd, from, 12, &retlen, buf)) {
-+		return -1;
-+	}
-+	if (sscanf(buf, "%2hhx%2hhx%2hhx%2hhx%2hhx%2hhx",
-+			&mac[0], &mac[1], &mac[2], &mac[3],
-+			&mac[4], &mac[5]) == 6) {
-+		return 0;
-+	}
-+	if (mtd_read(mtd, from+12, 5, &retlen, buf+12)) {
-+		return -1;
-+	}
-+	if (sscanf(buf, "%2hhx:%2hhx:%2hhx:%2hhx:%2hhx:%2hhx",
-+			&mac[0], &mac[1], &mac[2], &mac[3],
-+			&mac[4], &mac[5]) == 6) {
-+		return 0;
-+	}
-+	return -1;
-+}
-+
-+static struct mtd_mac_address_property {
-+	char *name;
-+	mtd_mac_address_read read;
-+} mtd_mac_address_properties[] = {
-+	{
-+		.name = "mtd-mac-address",
-+		.read = read_mtd_mac_address,
-+	}, {
-+		.name = "mtd-mac-address-ascii",
-+		.read = read_mtd_mac_address_ascii,
-+	},
-+};
-+
 +static const void *of_get_mac_address_mtd(struct device_node *np)
 +{
 +#ifdef CONFIG_MTD
 +	struct device_node *mtd_np = NULL;
 +	struct property *prop;
-+	int size, ret = -1;
++	size_t retlen;
++	int size, ret;
 +	struct mtd_info *mtd;
 +	const char *part;
 +	const __be32 *list;
@@ -96,37 +51,28 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	u8 mac[ETH_ALEN];
 +	void *addr;
 +	u32 inc_idx;
-+	int i;
 +
-+	for (i = 0; i < ARRAY_SIZE(mtd_mac_address_properties); i++) {
-+		list = of_get_property(np, mtd_mac_address_properties[i].name, &size);
-+		if (!list || (size != (2 * sizeof(*list))))
-+			continue;
-+
-+		phandle = be32_to_cpup(list++);
-+		if (phandle)
-+			mtd_np = of_find_node_by_phandle(phandle);
-+
-+		if (!mtd_np)
-+			continue;
-+
-+		part = of_get_property(mtd_np, "label", NULL);
-+		if (!part)
-+			part = mtd_np->name;
-+
-+		mtd = get_mtd_device_nm(part);
-+		if (IS_ERR(mtd))
-+			continue;
-+
-+		ret = mtd_mac_address_properties[i].read(mtd, be32_to_cpup(list), mac);
-+		put_mtd_device(mtd);
-+		if (!ret) {
-+			break;
-+		}
-+	}
-+	if (ret) {
++	list = of_get_property(np, "mtd-mac-address", &size);
++	if (!list || (size != (2 * sizeof(*list))))
 +		return NULL;
-+	}
++
++	phandle = be32_to_cpup(list++);
++	if (phandle)
++		mtd_np = of_find_node_by_phandle(phandle);
++
++	if (!mtd_np)
++		return NULL;
++
++	part = of_get_property(mtd_np, "label", NULL);
++	if (!part)
++		part = mtd_np->name;
++
++	mtd = get_mtd_device_nm(part);
++	if (IS_ERR(mtd))
++		return NULL;
++
++	ret = mtd_read(mtd, be32_to_cpup(list), 6, &retlen, mac);
++	put_mtd_device(mtd);
 +
 +	if (of_property_read_u32(np, "mtd-mac-address-increment-byte", &inc_idx))
 +		inc_idx = 5;
@@ -166,7 +112,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  /**
   * Search the device tree for the best MAC address to use.  'mac-address' is
   * checked first, because that is supposed to contain to "most recent" MAC
-@@ -65,11 +193,18 @@ static const void *of_get_mac_addr(struc
+@@ -65,11 +139,18 @@ static const void *of_get_mac_addr(struc
   * addresses.  Some older U-Boots only initialized 'local-mac-address'.  In
   * this case, the real MAC is in 'local-mac-address', and 'mac-address' exists
   * but is all zeros.

--- a/target/linux/generic/pending-4.9/681-NET-add-of_get_mac_address_mtd.patch
+++ b/target/linux/generic/pending-4.9/681-NET-add-of_get_mac_address_mtd.patch
@@ -32,62 +32,17 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  {
  	struct property *pp = of_find_property(np, name, NULL);
  
-@@ -47,6 +48,133 @@ static const void *of_get_mac_addr(struc
+@@ -47,6 +48,73 @@ static const void *of_get_mac_addr(struc
  	return NULL;
  }
  
-+typedef int(*mtd_mac_address_read)(struct mtd_info *mtd, loff_t from, u_char *buf);
-+
-+static int read_mtd_mac_address(struct mtd_info *mtd, loff_t from, u_char *mac)
-+{
-+	int retlen;
-+
-+	return mtd_read(mtd, from, 6, &retlen, mac);
-+}
-+
-+static int read_mtd_mac_address_ascii(struct mtd_info *mtd, loff_t from, u_char *mac)
-+{
-+	int retlen;
-+	char buf[17];
-+
-+	if (mtd_read(mtd, from, 12, &retlen, buf)) {
-+		return -1;
-+	}
-+	if (sscanf(buf, "%2hhx%2hhx%2hhx%2hhx%2hhx%2hhx",
-+			&mac[0], &mac[1], &mac[2], &mac[3],
-+			&mac[4], &mac[5]) == 6) {
-+		return 0;
-+	}
-+	if (mtd_read(mtd, from+12, 5, &retlen, buf+12)) {
-+		return -1;
-+	}
-+	if (sscanf(buf, "%2hhx:%2hhx:%2hhx:%2hhx:%2hhx:%2hhx",
-+			&mac[0], &mac[1], &mac[2], &mac[3],
-+			&mac[4], &mac[5]) == 6) {
-+		return 0;
-+	}
-+	return -1;
-+}
-+
-+static struct mtd_mac_address_property {
-+	char *name;
-+	mtd_mac_address_read read;
-+} mtd_mac_address_properties[] = {
-+	{
-+		.name = "mtd-mac-address",
-+		.read = read_mtd_mac_address,
-+	}, {
-+		.name = "mtd-mac-address-ascii",
-+		.read = read_mtd_mac_address_ascii,
-+	},
-+};
-+
 +static const void *of_get_mac_address_mtd(struct device_node *np)
 +{
 +#ifdef CONFIG_MTD
 +	struct device_node *mtd_np = NULL;
 +	struct property *prop;
-+	int size, ret = -1;
++	size_t retlen;
++	int size, ret;
 +	struct mtd_info *mtd;
 +	const char *part;
 +	const __be32 *list;
@@ -95,46 +50,31 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	u32 mac_inc = 0;
 +	u8 mac[ETH_ALEN];
 +	void *addr;
-+	u32 inc_idx;
-+	int i;
 +
-+	for (i = 0; i < ARRAY_SIZE(mtd_mac_address_properties); i++) {
-+		list = of_get_property(np, mtd_mac_address_properties[i].name, &size);
-+		if (!list || (size != (2 * sizeof(*list))))
-+			continue;
-+
-+		phandle = be32_to_cpup(list++);
-+		if (phandle)
-+			mtd_np = of_find_node_by_phandle(phandle);
-+
-+		if (!mtd_np)
-+			continue;
-+
-+		part = of_get_property(mtd_np, "label", NULL);
-+		if (!part)
-+			part = mtd_np->name;
-+
-+		mtd = get_mtd_device_nm(part);
-+		if (IS_ERR(mtd))
-+			continue;
-+
-+		ret = mtd_mac_address_properties[i].read(mtd, be32_to_cpup(list), mac);
-+		put_mtd_device(mtd);
-+		if (!ret) {
-+			break;
-+		}
-+	}
-+	if (ret) {
++	list = of_get_property(np, "mtd-mac-address", &size);
++	if (!list || (size != (2 * sizeof(*list))))
 +		return NULL;
-+	}
 +
-+	if (of_property_read_u32(np, "mtd-mac-address-increment-byte", &inc_idx))
-+		inc_idx = 5;
-+	if (inc_idx > 5)
++	phandle = be32_to_cpup(list++);
++	if (phandle)
++		mtd_np = of_find_node_by_phandle(phandle);
++
++	if (!mtd_np)
 +		return NULL;
++
++	part = of_get_property(mtd_np, "label", NULL);
++	if (!part)
++		part = mtd_np->name;
++
++	mtd = get_mtd_device_nm(part);
++	if (IS_ERR(mtd))
++		return NULL;
++
++	ret = mtd_read(mtd, be32_to_cpup(list), 6, &retlen, mac);
++	put_mtd_device(mtd);
 +
 +	if (!of_property_read_u32(np, "mtd-mac-address-increment", &mac_inc))
-+		mac[inc_idx] += mac_inc;
++		mac[5] += mac_inc;
 +
 +	if (!is_valid_ether_addr(mac))
 +		return NULL;
@@ -166,7 +106,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  /**
   * Search the device tree for the best MAC address to use.  'mac-address' is
   * checked first, because that is supposed to contain to "most recent" MAC
-@@ -64,11 +192,18 @@ static const void *of_get_mac_addr(struc
+@@ -64,11 +132,18 @@ static const void *of_get_mac_addr(struc
   * addresses.  Some older U-Boots only initialized 'local-mac-address'.  In
   * this case, the real MAC is in 'local-mac-address', and 'mac-address' exists
   * but is all zeros.


### PR DESCRIPTION
1. update mdadm to latest version, fix issue #2751
2. fix syntax errors exposed after kconfig update
3. revert add support for mtd-mac-address-ascii in device-tree, this change have problems in some platforms.