### PR TITLE
支持以空格分割的订阅节点和空订阅节点的处理

### DIFF
--- a/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
+++ b/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
@@ -232,7 +232,7 @@ local execute = function()
                     node = servers
                 else
                     -- ssd 外的格式
-                    node = split(base64Decode(raw, true), "\n")
+                    node = split(base64Decode(raw, true):gsub(" ", "\n"), "\n")
                 end
                 for _, v in ipairs(node) do
                     if v then

--- a/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
+++ b/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
@@ -112,6 +112,11 @@ local function processData(szType, content)
         hash = md5(luci.jsonc.stringify(content))
     end
     result.hashkey = hash
+    -- 如果节点内容为空，返回无效的节点信息
+    if content == '' then
+        result.server = ''
+        return result, hash
+    end
     if szType == 'ssr' then
         local dat = split(content, "/\\?")
         local hostInfo = split(dat[1], ':')


### PR DESCRIPTION
1. 新的订阅处理不能处理以空格分割节点的订阅内容，会触发以下错误
```
2020-01-13 16:20:29 发生错误, 正在恢复服务
	[C]: ?
	/usr/share/shadowsocksr/subscribe.lua:328: in main chunk
	[C]: in function 'xpcall'
	/usr/share/shadowsocksr/subscribe.lua:249: in function </usr/share/shadowsocksr/subscribe.lua:199>
	/usr/share/shadowsocksr/subscribe.lua:125: in function 'processData'
	/usr/share/shadowsocksr/subscribe.lua:29: in function 'split'
	/usr/share/shadowsocksr/subscribe.lua:330: in function </usr/share/shadowsocksr/subscribe.lua:328>
2020-01-13 16:20:29 stack traceback:
2020-01-13 16:20:29 /usr/share/shadowsocksr/subscribe.lua:29: attempt to index local 'full' (a nil value)
```
2. 增加当订阅节点为空字符串时的处理。
 未处理时导致的错误，[如图](https://user-images.githubusercontent.com/33367701/72317765-3eeee900-36d5-11ea-9c1b-86f48ebc855b.png)
 #2721 
