### PR TITLE
Solve a problem during compiling for mt76x8

### DIFF
--- a/target/linux/ramips/mt76x8/target.mk
+++ b/target/linux/ramips/mt76x8/target.mk
@@ -7,7 +7,7 @@ BOARDNAME:=MT76x8 based boards
 FEATURES+=usb ramdisk
 CPU_TYPE:=24kc
 
-DEFAULT_PACKAGES += kmod-mt7603 wpad-basic
+DEFAULT_PACKAGES += kmod-mt7603 wpad-openssl
 
 define Target/Description
 	Build firmware images for Ralink MT76x8 based boards.


### PR DESCRIPTION
change default package from wpad-basic to wpad-openssl for mt76x8 to solve some problems during compiling.