### PR TITLE
x86 EFI image: fix EFI image file size

### DIFF
--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -140,7 +140,7 @@ ifneq ($(CONFIG_GRUB_IMAGES)$(CONFIG_EFI_IMAGES),)
 		"$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img"
 
 	# Convert the MBR partition to GPT and set EFI ROOTFS signature
-	dd if=/dev/zero of="$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img" bs=512 count=33 conv=notrunc oflag=append
+	dd if=/dev/zero of="$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img" bs=512 count=34 conv=notrunc oflag=append
 	sgdisk -g "$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img"
 	sgdisk -t 2:EF00 "$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img"
 	sgdisk -t 3:EF02 "$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img"
@@ -276,13 +276,13 @@ endif
 ifneq ($(CONFIG_QCOW2_IMAGES),)
   define Image/Build/qcow2
 	rm $(BIN_DIR)/$(IMG_PREFIX)-combined-$(1).qcow2 || true
-	/usr/bin/qemu-img convert -O qcow2 \
+	/usr/bin/qemu-img convert -f raw -O qcow2 \
 		$(BIN_DIR)/$(IMG_PREFIX)-combined-$(1).img \
 		$(BIN_DIR)/$(IMG_PREFIX)-combined-$(1).qcow2
   endef
   define Image/Build/qcow2_efi
 	rm $(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).qcow2 || true
-	/usr/bin/qemu-img convert -O qcow2 \
+	/usr/bin/qemu-img convert -f raw -O qcow2 \
 		$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).img \
 		$(BIN_DIR)/$(IMG_PREFIX)-uefi-gpt-$(1).qcow2
   endef


### PR DESCRIPTION
生成的EFI镜像文件大小不是8k的倍数，在导入使用zfs文件系统的pve虚拟机中会出现问题，网上搜了一圈，需要重新pad镜像文件

    root@pve:~/openwrt/1# qm importdisk 103 openwrt-x86-64-uefi-gpt-squashfs.img local-zfs
    importing disk 'openwrt-x86-64-uefi-gpt-squashfs.img' to VM 103 ...
    zfs error: cannot create 'rpool/data/vm-103-disk-3': volume size must be a multiple of volume block size
    root@pve:~/openwrt/1# qm importdisk 103 openwrt-x86-64-uefi-gpt-squashfs.qcow2 local-zfs
    importing disk 'openwrt-x86-64-uefi-gpt-squashfs.qcow2' to VM 103 ...
    zfs error: cannot create 'rpool/data/vm-103-disk-3': volume size must be a multiple of volume block size