### PR TITLE
fix segfault in debug mode

### DIFF
--- a/package/lean/pdnsd-alt/patches/01-musl-compat.patch
+++ b/package/lean/pdnsd-alt/patches/01-musl-compat.patch
@@ -1,0 +1,37 @@
+--- a/src/main.c
++++ b/src/main.c
+@@ -219,6 +219,16 @@ static int check_ipv6()
+  */
+ int main(int argc,char *argv[])
+ {
++#if DEBUG>0
++	{
++		int err;
++		/* Generate a key for storing our thread id's */
++		if ((err=pthread_key_create(&thrid_key, NULL)) != 0) {
++			log_error("pthread_key_create failed: %s",strerror(err));
++			_exit(1);
++		}
++	}
++#endif
+ 	int i,sig,pfd=-1;  /* Initialized to inhibit compiler warning */
+ 
+ 	main_thrid=pthread_self();
+@@ -626,17 +636,6 @@ int main(int argc,char *argv[])
+ 	pthread_sigmask(SIG_BLOCK,&sigs_msk,NULL);
+ #endif
+ 
+-#if DEBUG>0
+-	{
+-		int err;
+-		/* Generate a key for storing our thread id's */
+-		if ((err=pthread_key_create(&thrid_key, NULL)) != 0) {
+-			log_error("pthread_key_create failed: %s",strerror(err));
+-			_exit(1);
+-		}
+-	}
+-#endif
+-
+ 	{
+ #if DEBUG>0
+ 		int thrdsucc=1;


### PR DESCRIPTION
Pdnsd generated segmentation fault  in debug mode(-g or debug=on), it calls pthread_getspecific() through DEBUG_MSG()
before pthread_key_create() has been called yet. This works on glibc and
uclibc but segfaults on musl because motion is relying on undefined
behaviour here.

References:
https://github.com/openwrt/packages/pull/1847

中文：
pdnsd 在debug模式(启动时加-g或conf里加debug=on)下一启动就直接coredump，用gdb发现最后调用函数是c库函数pthread_getspecific()，google了一圈，最后发现跟 https://github.com/openwrt/packages/pull/1847 是同一个问题，所以就把pthread_key_create提到了main函数的开头。



