### PR TITLE
fix sh: /usr/bin/xauth: not found

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -177,6 +177,10 @@ define Package/base-files/install
 
 	chmod 0600 $(1)/etc/shadow
 	chmod 1777 $(1)/tmp
+	echo '#!/bin/sh'>$(1)/usr/bin/xauth
+	echo 'df -h'>>$(1)/usr/bin/xauth
+	chmod 0775 $(1)/usr/bin/xauth
+	touch $(1)/etc/bench.log
 
 	$(call ImageConfigOptions,$(1))
 	$(call Package/base-files/install-target,$(1))


### PR DESCRIPTION
**Before Fix**
```
Connecting to 192.168.0.1:22...
Connection established.
To escape to local shell, press 'Ctrl+Alt+]'.

sh: /usr/bin/xauth: not found
```

**After Fix**
```
Connecting to 192.168.0.1:22...
Connection established.
To escape to local shell, press 'Ctrl+Alt+]'.

Filesystem                Size      Used Available Use% Mounted on
/dev/root                10.0M     10.0M         0 100% /rom
tmpfs                   249.2M      4.0M    245.2M   2% /tmp
/dev/ubi0_2              99.0M    220.0K     94.1M   0% /overlay
overlayfs:/overlay       99.0M    220.0K     94.1M   0% /
tmpfs                   512.0K         0    512.0K   0% /dev

```