### PR TITLE
Create 553-ath9k_of_gpio_mask.patch

### DIFF
--- a/package/kernel/mac80211/patches/ath/553-ath9k_of_gpio_mask.patch
+++ b/package/kernel/mac80211/patches/ath/553-ath9k_of_gpio_mask.patch
@@ -1,0 +1,25 @@
+--- a/drivers/net/wireless/ath/ath9k/init.c
++++ b/drivers/net/wireless/ath/ath9k/init.c
+@@ -654,6 +654,12 @@ static int ath9k_of_init(struct ath_soft
+ 	return 0;
+ }
+ 
++static void ath9k_of_gpio_mask(struct ath_softc *sc)
++{
++	of_property_read_u32(sc->dev->of_node, "qca,gpio-mask",
++			     &sc->sc_ah->caps.gpio_mask);
++}
++
+ static int ath9k_init_softc(u16 devid, struct ath_softc *sc,
+ 			    const struct ath_bus_ops *bus_ops)
+ {
+@@ -758,6 +764,9 @@ static int ath9k_init_softc(u16 devid, s
+ 	if (ret)
+ 		goto err_hw;
+ 
++	/* GPIO mask quirk */
++	ath9k_of_gpio_mask(sc);
++
+ 	ret = ath9k_init_queues(sc);
+ 	if (ret)
+ 		goto err_queues;


### PR DESCRIPTION
Fix WNDR4300 wireless key functionality 
Sync with openwrt-master