### PR TITLE
luci-app-ssr-plus: support shadowsocks SIP003 plugin(Experimental)

### DIFF
--- a/package/lean/luci-app-ssr-plus/Makefile
+++ b/package/lean/luci-app-ssr-plus/Makefile
@@ -11,6 +11,14 @@ config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks
 	bool "Include Shadowsocks New Version"
 	default y if x86_64
 
+config PACKAGE_$(PKG_NAME)_INCLUDE_Simple_obfs
+        bool "Include Shadowsocks simple-obfs plugin"
+        default y if x86_64
+
+config PACKAGE_$(PKG_NAME)_INCLUDE_V2ray_plugin
+        bool "Include Shadowsocks v2ray plugin"
+        default y if x86_64
+
 config PACKAGE_$(PKG_NAME)_INCLUDE_V2ray
 	bool "Include V2ray"
 	default y if x86_64
@@ -40,6 +48,8 @@ define Package/luci-app-ssr-plus
 	PKGARCH:=all
 	DEPENDS:=+shadowsocksr-libev-alt +ipset +ip-full +iptables-mod-tproxy +dnsmasq-full +coreutils +coreutils-base64 +pdnsd-alt +wget +lua \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks:shadowsocks-libev-ss-redir \
+	+PACKAGE_$(PKG_NAME)_INCLUDE_Simple_obfs:simple-obfs \
+	+PACKAGE_$(PKG_NAME)_INCLUDE_V2ray_plugin:v2ray-plugin \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_V2ray:v2ray \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Trojan:trojan \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Trojan:ipt2socks \

--- a/package/lean/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/package/lean/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -164,6 +164,15 @@ for _, v in ipairs(encrypt_methods_ss) do o:value(v) end
 o.rmempty = true
 o:depends("type", "ss")
 
+-- Shadowsocks Plugin
+o = s:option(Value, "plugin", "Plugin")
+o.rmempty = true
+o:depends("type", "ss")
+
+o = s:option(Value, "plugin_opts", "Plugin Opts")
+o.rmempty = true
+o:depends("type", "ss")
+
 o = s:option(ListValue, "protocol", translate("Protocol"))
 for _, v in ipairs(protocol) do o:value(v) end
 o.rmempty = true

--- a/package/lean/luci-app-ssr-plus/luasrc/view/shadowsocksr/ssrurl.htm
+++ b/package/lean/luci-app-ssr-plus/luasrc/view/shadowsocksr/ssrurl.htm
@@ -137,30 +137,73 @@
 			s.innerHTML = "<font color='green'>导入ShadowsocksR配置信息成功</font>";
 			return false;
 		} else if (ssu[0] == "ss") {
+
+			var url0, param = "";
+			var sipIndex = ssu[1].indexOf("@");
 			var ploc = ssu[1].indexOf("#");
 			if (ploc > 0) {
 				url0 = ssu[1].substr(0, ploc);
 				param = ssu[1].substr(ploc + 1);
 			} else {
-				url0 = ssu[1]
+				url0 = ssu[1];
 			}
-			var sstr = b64decsafe(url0);
-			document.getElementById('cbid.shadowsocksr.' + sid + '.type').value = "ss";
-			document.getElementById('cbid.shadowsocksr.' + sid + '.type').dispatchEvent(event);
-			var team = sstr.split('@');
-			console.log(param);
-			var part1 = team[0].split(':');
-			var part2 = team[1].split(':');
-			document.getElementById('cbid.shadowsocksr.' + sid + '.server').value = part2[0];
-			document.getElementById('cbid.shadowsocksr.' + sid + '.server_port').value = part2[1];
-			document.getElementById('cbid.shadowsocksr.' + sid + '.password').value = part1[1];
-			document.getElementById('cbid.shadowsocksr.' + sid + '.encrypt_method_ss').value = part1[0];
-			if (param != undefined) {
-				document.getElementById('cbid.shadowsocksr.' + sid + '.alias').value = decodeURI(param);
+
+			if (sipIndex != -1) {
+				// SIP002
+				var userInfo = b64decsafe(url0.substr(0, sipIndex));
+				var temp = url0.substr(sipIndex + 1).split("/?");
+				var serverInfo = temp[0].split(":");
+				var server = serverInfo[0];
+				var port = serverInfo[1];
+				var method, password, plugin, pluginOpts;
+				if (temp[1]) {
+					var pluginInfo = decodeURIComponent(temp[1]);
+					var pluginIndex = pluginInfo.indexOf(";");
+					var pluginNameInfo = pluginInfo.substr(0, pluginIndex);
+					plugin = pluginNameInfo.substr(pluginNameInfo.indexOf("=") + 1)
+					pluginOpts = pluginInfo.substr(pluginIndex + 1);
+				}
+
+				var userInfoSplitIndex = userInfo.indexOf(":");
+				if (userInfoSplitIndex != -1) {
+					method = userInfo.substr(0, userInfoSplitIndex);
+					password = userInfo.substr(userInfoSplitIndex + 1);
+				}
+				document.getElementById('cbid.shadowsocksr.' + sid + '.type').value = "ss";
+				document.getElementById('cbid.shadowsocksr.' + sid + '.type').dispatchEvent(event);
+				document.getElementById('cbid.shadowsocksr.' + sid + '.server').value = server;
+				document.getElementById('cbid.shadowsocksr.' + sid + '.server_port').value = port;
+				document.getElementById('cbid.shadowsocksr.' + sid + '.password').value = password || "";
+				document.getElementById('cbid.shadowsocksr.' + sid + '.encrypt_method_ss').value = method || "";
+				document.getElementById('cbid.shadowsocksr.' + sid + '.plugin').value = plugin || "";
+				document.getElementById('cbid.shadowsocksr.' + sid + '.plugin_opts').value = pluginOpts || "";
+
+				if (param != undefined) {
+					document.getElementById('cbid.shadowsocksr.' + sid + '.alias').value = decodeURI(param);
+				}
+				s.innerHTML = "<font color='green'>导入Shadowsocks配置信息成功</font>";
+			} else {
+				var sstr = b64decsafe(url0);
+				document.getElementById('cbid.shadowsocksr.' + sid + '.type').value = "ss";
+				document.getElementById('cbid.shadowsocksr.' + sid + '.type').dispatchEvent(event);
+				var team = sstr.split('@');
+				console.log(param);
+				var part1 = team[0].split(':');
+				var part2 = team[1].split(':');
+				document.getElementById('cbid.shadowsocksr.' + sid + '.server').value = part2[0];
+				document.getElementById('cbid.shadowsocksr.' + sid + '.server_port').value = part2[1];
+				document.getElementById('cbid.shadowsocksr.' + sid + '.password').value = part1[1];
+				document.getElementById('cbid.shadowsocksr.' + sid + '.encrypt_method_ss').value = part1[0];
+				document.getElementById('cbid.shadowsocksr.' + sid + '.plugin').value = "";
+				document.getElementById('cbid.shadowsocksr.' + sid + '.plugin_opts').value = "";
+				if (param != undefined) {
+					document.getElementById('cbid.shadowsocksr.' + sid + '.alias').value = decodeURI(param);
+				}
+				s.innerHTML = "<font color='green'>导入Shadowsocks配置信息成功</font>";
 			}
-			s.innerHTML = "<font color='green'>导入Shadowsocks配置信息成功</font>";
 			return false;
 		} else if (ssu[0] == "trojan") {
+			var url0, param = "";
 			var ploc = ssu[1].indexOf("#");
 			if (ploc > 0) {
 				url0 = ssu[1].substr(0, ploc);

--- a/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -102,6 +102,13 @@ if [ "$stype" == "ss" ] ;then
 "fast_open": $fastopen
 }
 EOF
+    local plugin=$(uci_get_by_name $1 plugin)
+    if [ -n $plugin ] &&  [ $plugin == "simple-obfs" ]; then
+        plugin="obfs-local"
+    fi
+    if [ -n "$plugin" -a -x "/usr/bin/$plugin" ]; then
+        sed -i "s@$hostip\",@$hostip\",\n\"plugin\": \"$plugin\",\n\"plugin_opts\": \"$(uci_get_by_name $1 plugin_opts)\",@" $config_file
+    fi
 elif [ "$stype" == "ssr" ] ;then
 cat <<-EOF >$config_file
 {

--- a/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
+++ b/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
@@ -210,6 +210,8 @@ local function processData(szType, content)
 		result.server_port = content.port
 		result.password = content.password
 		result.encrypt_method_ss = content.encryption
+		result.plugin = content.plugin
+		result.plugin_opts = content.plugin_options
 		result.alias = "[" .. content.airport .. "] " .. content.remarks
 	end
 	if not result.alias then

--- a/package/lean/simple-obfs/Makefile
+++ b/package/lean/simple-obfs/Makefile
@@ -1,0 +1,83 @@
+#
+# Copyright (C) 2017-2019 Jian Chang <aa65535@live.com>
+#
+# This is free software, licensed under the GNU General Public License v3.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=simple-obfs
+PKG_VERSION:=0.0.5
+PKG_RELEASE:=4
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/shadowsocks/simple-obfs.git
+PKG_SOURCE_VERSION:=df8089c159bc63d4a10328b371177a96cb8d9f0b
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
+
+PKG_LICENSE:=GPLv3
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=Jian Chang <aa65535@live.com>
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)/$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION)
+
+PKG_INSTALL:=1
+PKG_FIXUP:=autoreconf
+PKG_USE_MIPS16:=0
+PKG_BUILD_PARALLEL:=1
+PKG_BUILD_DEPENDS:=libev
+
+PKG_CONFIG_DEPENDS:= CONFIG_SIMPLE_OBFS_STATIC_LINK
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/simple-obfs
+	SECTION:=net
+	CATEGORY:=Network
+	TITLE:=Simple-obfs
+	URL:=https://github.com/shadowsocks/simple-obfs
+	DEPENDS:=+libpthread +!SIMPLE_OBFS_STATIC_LINK:libev
+endef
+
+Package/simple-obfs-server = $(Package/simple-obfs)
+
+define Package/simple-obfs-server/config
+menu "Simple-obfs Compile Configuration"
+	depends on PACKAGE_simple-obfs || PACKAGE_simple-obfs-server
+	config SIMPLE_OBFS_STATIC_LINK
+		bool "enable static link libraries."
+		default n
+endmenu
+endef
+
+define Package/simple-obfs/description
+Simple-obfs is a simple obfusacting tool, designed as plugin server of shadowsocks.
+endef
+
+Package/simple-obfs-server/description = $(Package/simple-obfs/description)
+
+CONFIGURE_ARGS += \
+	--disable-ssp \
+	--disable-documentation \
+	--disable-assert
+
+ifeq ($(CONFIG_SIMPLE_OBFS_STATIC_LINK),y)
+	CONFIGURE_ARGS += \
+		--with-ev="$(STAGING_DIR)/usr" \
+		LDFLAGS="-Wl,-static -static -static-libgcc"
+endif
+
+define Package/simple-obfs/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/obfs-local $(1)/usr/bin
+endef
+
+define Package/simple-obfs-server/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/obfs-server $(1)/usr/bin
+endef
+
+$(eval $(call BuildPackage,simple-obfs))
+$(eval $(call BuildPackage,simple-obfs-server))

--- a/package/lean/v2ray-plugin/Makefile
+++ b/package/lean/v2ray-plugin/Makefile
@@ -1,0 +1,74 @@
+#
+# Copyright (C) 2018-2020 chenhw2 <https://github.com/chenhw2>
+#
+# This is free software, licensed under the GNU General Public License v3.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=v2ray-plugin
+PKG_VERSION:=1.3.0
+PKG_RELEASE:=20200205
+PKG_MAINTAINER:=chenhw2 <https://github.com/chenhw2>
+
+# OpenWrt ARCH: arm, aarch64, i386, x86_64, mips, mipsel
+# Golang ARCH: arm[5-7], arm64, 386, amd64, mips, mipsle
+PKG_ARCH:=$(ARCH)
+BIN_ARCH:=$(ARCH)
+ifeq ($(ARCH),mips)
+    BIN_ARCH:=mips_sf
+endif
+ifeq ($(ARCH),mipsel)
+	PKG_ARCH:=mips
+	BIN_ARCH:=mipsle_sf
+endif
+ifeq ($(ARCH),i386)
+	PKG_ARCH:=386
+	BIN_ARCH:=386
+endif
+ifeq ($(ARCH),x86_64)
+	PKG_ARCH:=amd64
+	BIN_ARCH:=amd64
+endif
+ifeq ($(ARCH),arm)
+	BIN_ARCH:=arm7
+endif
+
+ifeq ($(ARCH),aarch64)
+	PKG_ARCH=arm64
+	BIN_ARCH=arm64
+endif
+
+PKG_SOURCE:=v2ray-plugin-linux-$(PKG_ARCH)-v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/shadowsocks/v2ray-plugin/releases/download/v$(PKG_VERSION)/
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_HASH:=skip
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/v2ray-plugin
+	SECTION:=net
+	CATEGORY:=Network
+	TITLE:=SIP003 plugin for shadowsocks, based on v2ray
+	URL:=https://github.com/shadowsocks/v2ray-plugin
+endef
+
+define Package/v2ray-plugin/description
+	Yet another SIP003 plugin for shadowsocks, based on v2ray
+endef
+
+define Build/Prepare
+	gzip -dc "$(DL_DIR)/$(PKG_SOURCE)" | tar -C $(PKG_BUILD_DIR)/ -xf -
+endef
+
+define Build/Compile
+	echo "$(PKG_NAME)Compile Skiped!"
+endef
+
+define Package/v2ray-plugin/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/v2ray-plugin_linux_$(BIN_ARCH) $(1)/usr/bin/v2ray-plugin
+endef
+
+$(eval $(call BuildPackage,v2ray-plugin))

--- a/package/lean/v2ray-plugin/Makefile
+++ b/package/lean/v2ray-plugin/Makefile
@@ -1,7 +1,7 @@
 #
-# Copyright (C) 2018-2020 chenhw2 <https://github.com/chenhw2>
+# Copyright (C) 2020 SharerMax
 #
-# This is free software, licensed under the GNU General Public License v3.
+# This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
 
@@ -9,49 +9,31 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v2ray-plugin
 PKG_VERSION:=1.3.0
-PKG_RELEASE:=20200205
-PKG_MAINTAINER:=chenhw2 <https://github.com/chenhw2>
+PKG_RELEASE:=1
+PKG_MAINTAINER:=ShareMax
+PKG_BUILD_DIR:=$(BUILD_DIR)/v2ray-plugin-$(PKG_VERSION)
 
-# OpenWrt ARCH: arm, aarch64, i386, x86_64, mips, mipsel
-# Golang ARCH: arm[5-7], arm64, 386, amd64, mips, mipsle
-PKG_ARCH:=$(ARCH)
-BIN_ARCH:=$(ARCH)
-ifeq ($(ARCH),mips)
-    BIN_ARCH:=mips_sf
-endif
-ifeq ($(ARCH),mipsel)
-	PKG_ARCH:=mips
-	BIN_ARCH:=mipsle_sf
-endif
-ifeq ($(ARCH),i386)
-	PKG_ARCH:=386
-	BIN_ARCH:=386
-endif
-ifeq ($(ARCH),x86_64)
-	PKG_ARCH:=amd64
-	BIN_ARCH:=amd64
-endif
-ifeq ($(ARCH),arm)
-	BIN_ARCH:=arm7
-endif
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/shadowsocks/v2ray-plugin/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=dfb86cd8d9be86e665c4b86b68cd7037e4310de001656eef01ec9aeea71edd10
 
-ifeq ($(ARCH),aarch64)
-	PKG_ARCH=arm64
-	BIN_ARCH=arm64
-endif
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=madeye <max.c.lv@gmail.com>
 
-PKG_SOURCE:=v2ray-plugin-linux-$(PKG_ARCH)-v$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/shadowsocks/v2ray-plugin/releases/download/v$(PKG_VERSION)/
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
-PKG_HASH:=skip
+GO_PKG:=github.com/shadowsocks/v2ray-plugin
+
 
 include $(INCLUDE_DIR)/package.mk
+include $(TOPDIR)/feeds/packages/lang/golang/golang-package.mk
+
 
 define Package/v2ray-plugin
 	SECTION:=net
 	CATEGORY:=Network
 	TITLE:=SIP003 plugin for shadowsocks, based on v2ray
 	URL:=https://github.com/shadowsocks/v2ray-plugin
+	DEPENDS:=$(GO_ARCH_DEPENDS) +ca-certificates
 endef
 
 define Package/v2ray-plugin/description
@@ -59,16 +41,16 @@ define Package/v2ray-plugin/description
 endef
 
 define Build/Prepare
-	gzip -dc "$(DL_DIR)/$(PKG_SOURCE)" | tar -C $(PKG_BUILD_DIR)/ -xf -
+	$(call Build/Prepare/Default)
 endef
 
 define Build/Compile
-	echo "$(PKG_NAME)Compile Skiped!"
+	$(call GoPackage/Build/Compile)
 endef
 
 define Package/v2ray-plugin/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/v2ray-plugin_linux_$(BIN_ARCH) $(1)/usr/bin/v2ray-plugin
+	$(INSTALL_BIN) $(GO_PKG_BUILD_BIN_DIR)/v2ray-plugin $(1)/usr/bin/v2ray-plugin
 endef
-
+$(eval $(call GoBinPackage,v2ray-plugin))
 $(eval $(call BuildPackage,v2ray-plugin))


### PR DESCRIPTION
1. add simple-obfs package (simple-obfs same as obfs-local)([openwrt-simple-obfs](https://github.com/aa65535/openwrt-simple-obfs))
2. add v2ray-plugin package 
3. support plugin option of SSD subscribe
4. support import SIP002(shadowsocks) URI

Test on Raspberry Pi 4B