### PR TITLE
npc:bump to v0.26.2

### DIFF
--- a/package/lean/npc/Makefile
+++ b/package/lean/npc/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=npc
-PKG_VERSION:=0.26.1
+PKG_VERSION:=0.26.2
 PKG_RELEASE:=1
 
 ifeq ($(ARCH),mipsel)


### PR DESCRIPTION
add: pprof 调试端口可在配置中设置 #382