### PR TITLE
npc: bump version to v0.26.3

### DIFF
--- a/package/lean/npc/Makefile
+++ b/package/lean/npc/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=npc
-PKG_VERSION:=0.26.2
+PKG_VERSION:=0.26.3
 PKG_RELEASE:=1
 
 ifeq ($(ARCH),mipsel)


### PR DESCRIPTION
fix:
mux 无锁队列同时进行pop可能导致死循环的问题
mux buffer pool 同一对象可能放入两次的问题
socks5 tcp连接未及时断开问题
udp 穿透逻辑不完善
change:
文件记录改为临时文件写入完毕后替换，避免文件被截断照成数据丢失 #412
service初始化失败后继续运行，但无法提供相关功能 #407