### PR TITLE
HAproxy has supported both domain and ip now

### DIFF
--- a/package/lean/luci-app-haproxy-tcp/luasrc/model/cbi/haproxy.lua
+++ b/package/lean/luci-app-haproxy-tcp/luasrc/model/cbi/haproxy.lua
@@ -41,7 +41,7 @@ s=m:section(TypedSection,"main_server","<b>" .. translate("Main Server List") ..
 	o=s:option(Flag,"validate",translate("validate"))
 
 	o=s:option(Value,"server_ip",translate("Proxy Server IP"))
-	o.datatype="ip4addr"
+	
 	o=s:option(Value,"server_port",translate("Proxy Server Port"))
 	o.datatype="uinteger"
 	o=s:option(Value,"server_weight",translate("Weight"))
@@ -56,7 +56,7 @@ s=m:section(TypedSection,"backup_server","<b>" .. translate("Backup Server List"
 	o=s:option(Flag,"validate",translate("validate"))
 
 	o=s:option(Value,"server_ip",translate("Proxy Server IP"))
-	o.datatype="ip4addr"
+	
 	o=s:option(Value,"server_port",translate("Proxy Server Port"))
 	o.datatype="uinteger"
 -- ---------------------------------------------------

--- a/package/lean/luci-app-haproxy-tcp/po/zh-cn/haproxy-tcp.po
+++ b/package/lean/luci-app-haproxy-tcp/po/zh-cn/haproxy-tcp.po
@@ -14,7 +14,7 @@ msgid "Only English Characters,No spaces"
 msgstr "仅限英文字母,不要有空格"
 
 msgid "Proxy Server IP"
-msgstr "代理服务器IP"
+msgstr "代理服务器IP或域名"
 
 msgid "Proxy Server Port"
 msgstr "代理服务器端口"

--- a/package/lean/luci-app-haproxy-tcp/root/etc/haproxy_init.sh
+++ b/package/lean/luci-app-haproxy-tcp/root/etc/haproxy_init.sh
@@ -50,6 +50,10 @@ listen admin_stats
   stats realm Haproxy             #统计页面密码框上提示文本
   stats auth admin:root           #设置监控页面的用户和密码:admin,可以设置多个用户名
   stats  admin if TRUE            #设置手工启动/禁用，后端服务器(haproxy-1.4.9以后版本)
+resolvers mydns
+  nameserver dns1 114.114.114.114:53
+  nameserver dns2 223.5.5.5:53
+
 frontend ss-in
 	bind 127.0.0.1:2222
 	default_backend ss-out
@@ -77,7 +81,7 @@ EOF
 		fi
 		echo the main server $COUNTER $server_ip $server_name $server_port $server_weight
 		[ "$validate" = 1 ] && {
-			echo server $server_name $server_ip:$server_port weight $server_weight maxconn 1024 check inter 1500 rise 3 fall 3 >> $CFG_FILE
+			echo server $server_name $server_ip:$server_port weight $server_weight maxconn 1024 check resolvers mydns inter 1500 rise 3 fall 3 >> $CFG_FILE
 		}
 		iptables -t nat -A HAPROXY -p tcp -d $server_ip -j ACCEPT
 		COUNTER=$(($COUNTER+1))
@@ -96,7 +100,7 @@ EOF
 		fi
 		echo the backup server $COUNTER $server_ip $server_name $server_port
 		[ "$validate" = 1 ] && {
-			echo server $server_name $server_ip:$server_port weight 10 check backup inter 1500 rise 3 fall 3 >> $CFG_FILE
+			echo server $server_name $server_ip:$server_port weight 10 check resolvers mydns backup inter 1500 rise 3 fall 3 >> $CFG_FILE
 		}
 		iptables -t nat -A HAPROXY -p tcp -d $server_ip -j ACCEPT
 		COUNTER=$(($COUNTER+1))


### PR DESCRIPTION
感谢老大鼓励,发个pr
修改了haproxy的配置,让"HAProxy- LuCI"可以配置后端时可以直接写域名,毕竟1.8版本的HAproxy原生支持直接在配置文件中写域名了.
