### PR TITLE
luci-app-ssr-plus: fix trojan url import

### DIFF
--- a/package/lean/luci-app-ssr-plus/luasrc/view/shadowsocksr/ssrurl.htm
+++ b/package/lean/luci-app-ssr-plus/luasrc/view/shadowsocksr/ssrurl.htm
@@ -211,16 +211,16 @@
 			} else {
 				url0 = ssu[1]
 			}
-			var sstr = b64decsafe(url0);
+			var sstr = url0;
 			document.getElementById('cbid.shadowsocksr.' + sid + '.type').value = "trojan";
 			document.getElementById('cbid.shadowsocksr.' + sid + '.type').dispatchEvent(event);
 			var team = sstr.split('@');
-			console.log(param);
-			var part1 = team[0].split(':');
-			var part2 = team[1].split(':');
-			document.getElementById('cbid.shadowsocksr.' + sid + '.server').value = part2[0];
-			document.getElementById('cbid.shadowsocksr.' + sid + '.server_port').value = part2[1];
-			document.getElementById('cbid.shadowsocksr.' + sid + '.password').value = part1[1];
+			var password = team[0]
+			var serverPart = team[1].split(':');
+			var port = serverPart[1].split('?')[0];
+			document.getElementById('cbid.shadowsocksr.' + sid + '.server').value = serverPart[0];
+			document.getElementById('cbid.shadowsocksr.' + sid + '.server_port').value = port;
+			document.getElementById('cbid.shadowsocksr.' + sid + '.password').value = password;
 			if (param != undefined) {
 				document.getElementById('cbid.shadowsocksr.' + sid + '.alias').value = decodeURI(param);
 			}


### PR DESCRIPTION
Ref :https://github.com/trojan-gfw/trojan-url
在其基础上增加别名的支持

>trojan://password@remote_host:remote_port#url-encode-tag

close #3175 