### PR TITLE
srelay: fix build on none linux os

### DIFF
--- a/package/lean/srelay/patches/001-compile.patch
+++ b/package/lean/srelay/patches/001-compile.patch
@@ -1,6 +1,15 @@
 --- a/configure
 +++ b/configure
-@@ -3999,11 +3999,11 @@
+@@ -2361,7 +2361,7 @@ test -n "$target_alias" &&
+     NONENONEs,x,x, &&
+   program_prefix=${target_alias}-
+ 
+-case "$build_os" in
++case "$host_os" in
+   freebsd*)
+ 	OS=FREEBSD
+ 	$as_echo "#define FREEBSD 1" >>confdefs.h
+@@ -3999,11 +3999,11 @@ $as_echo_n "checking whether enabling th
  	    LDFLAGS="$LDFLAGS -lpthread"
  	fi
  	if test "$cross_compiling" = yes; then :


### PR DESCRIPTION
Fix compile error on none linux os like macOS. 

```
In file included from init.c:36:0:
srelay.h:54:10: fatal error: sys/filio.h: No such file or directory
#include <sys/filio.h>
          ^~~~~~~~~~~~~
compilation terminated.
```

ref: https://www.right.com.cn/forum/thread-2764451-1-1.html