### PR TITLE
ramips: sync source code

### DIFF
--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -324,7 +324,7 @@ define KernelPackage/pmbus-zl6100
   $(call AddDepends/hwmon, +kmod-pmbus-core)
 endef
 
-define KernelPackage/hwmon-sht21/description
+define KernelPackage/pmbus-zl6100/description
  Kernel module for Intersil / Zilker Labs ZL6100 and
 compatible digital DC-DC controllers
 endef

--- a/package/kernel/linux/modules/input.mk
+++ b/package/kernel/linux/modules/input.mk
@@ -119,7 +119,7 @@ define KernelPackage/input-gpio-encoder
   AUTOLOAD:=$(call AutoProbe,rotary_encoder)
 endef
 
-define KernelPackage/gpio-encoder/description
+define KernelPackage/input-gpio-encoder/description
  Kernel module to use rotary encoders connected to GPIO pins
 endef
 
@@ -166,7 +166,7 @@ define KernelPackage/input-matrixkmap
   AUTOLOAD:=$(call AutoProbe,matrix-keymap)
 endef
 
-define KernelPackage/input-matrix/description
+define KernelPackage/input-matrixkmap/description
  Kernel module support for input matrix devices
 endef
 

--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -279,7 +279,7 @@ define KernelPackage/switch-rtl8366-smi
   AUTOLOAD:=$(call AutoLoad,42,rtl8366_smi)
 endef
 
-define KernelPackage/switch-rtl8366_smi/description
+define KernelPackage/switch-rtl8366-smi/description
   Realtek RTL8366 series SMI switch interface support
 endef
 

--- a/package/kernel/linux/modules/sound.mk
+++ b/package/kernel/linux/modules/sound.mk
@@ -301,7 +301,7 @@ define KernelPackage/sound-dummy
   AUTOLOAD:=$(call AutoLoad,32,snd-dummy)
 endef
 
-define KernelPackage/sound_dummy/description
+define KernelPackage/sound-dummy/description
  Dummy sound device for Alsa when no hardware present
 endef
 

--- a/target/linux/ramips/base-files/lib/preinit/07_set_preinit_iface_ramips
+++ b/target/linux/ramips/base-files/lib/preinit/07_set_preinit_iface_ramips
@@ -3,27 +3,54 @@
 # Copyright (C) 2013 OpenWrt.org
 #
 
-ramips_set_preinit_iface() {
-	RT3X5X=$(grep -E "(RT3.5|RT5350|MT7628|MT7688|MT7620|MT7621)" /proc/cpuinfo)
+. /lib/functions.sh
 
-	if [ -n "${RT3X5X}" ]; then
-		# The ethernet switch driver enables VLAN by default, but
-		# failsafe uses eth0, making the device unreachable:
-		# https://dev.openwrt.org/ticket/18768
-		case "${RT3X5X}" in
-		*MT7620*)
-			ralink_switchdev=mt7620
-			;;
-		*MT7621*)
-			ralink_switchdev=mt7530
-			;;
-		*)
-			ralink_switchdev=rt305x
-			;;
-		esac
-		swconfig dev $ralink_switchdev set reset 1
-		swconfig dev $ralink_switchdev set enable_vlan 0
-		swconfig dev $ralink_switchdev set apply 1
+ramips_switchdev_from_soc() {
+	# The ethernet switch driver enables VLAN by default, but
+	# failsafe uses eth0, making the device unreachable:
+	# https://dev.openwrt.org/ticket/18768
+
+	local switchdev
+	local RT3X5X=$(grep -E "(RT3.5|RT5350|MT7628|MT7688|MT7620|MT7621)" /proc/cpuinfo)
+
+	[ -n "$RT3X5X" ] || return 1
+
+	case "$RT3X5X" in
+	*MT7620*)
+		switchdev=mt7620
+		;;
+	*MT7621*)
+		switchdev=mt7530
+		;;
+	*)
+		switchdev=rt305x
+		;;
+	esac
+
+	echo "$switchdev"
+}
+
+ramips_switchdev_from_board() {
+	# For these devices, external ethernet switch should be used
+	# instead of the SoC internal switch.
+
+	local switchdev
+	local board=$(board_name)
+
+	case "$board" in
+	esac
+
+	echo "$switchdev"
+}
+
+ramips_set_preinit_iface() {
+	local switchdev=$(ramips_switchdev_from_board)
+	[ -n "$switchdev" ] || switchdev=$(ramips_switchdev_from_soc)
+
+	if [ -n "$switchdev" ]; then
+		swconfig dev $switchdev set reset 1
+		swconfig dev $switchdev set enable_vlan 0
+		swconfig dev $switchdev set apply 1
 	fi
 
 	ifname=eth0

--- a/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr2.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr2.dts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621_iodata_wn-xx-xr.dtsi"
+
+/ {
+	compatible = "iodata,wn-ax1167gr2", "mediatek,mt7621-soc";
+	model = "I-O DATA WN-AX1167GR2";
+};
+
+&partitions {
+	partition@6b00000 {
+		label = "Backup";
+		reg = <0x6b00000 0x1480000>;
+		read-only;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_iodata_wn-dx1167r.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-dx1167r.dts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621_iodata_wn-xx-xr.dtsi"
+
+/ {
+	compatible = "iodata,wn-dx1167r", "mediatek,mt7621-soc";
+	model = "I-O DATA WN-DX1167R";
+};
+
+&partitions {
+	partition@6b00000 {
+		label = "idmkey";
+		reg = <0x6b00000 0x0100000>;
+		read-only;
+	};
+
+	partition@6c00000 {
+		label = "Backup";
+		reg = <0x6c00000 0x1380000>;
+		read-only;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_iodata_wn-xx-xr.dtsi
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-xx-xr.dtsi
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wps {
+			label = "iodata:green:wps";
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			label = "iodata:green:power";
+			gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		repeater {
+			label = "repeater";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions: partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x0100000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "u-boot-env";
+			reg = <0x0100000 0x0100000>;
+			read-only;
+		};
+
+		factory: partition@200000 {
+			label = "factory";
+			reg = <0x0200000 0x0100000>;
+		};
+
+		partition@300000 {
+			label = "SecondBoot";
+			reg = <0x0300000 0x0100000>;
+			read-only;
+		};
+
+		partition@400000 {
+			label = "kernel";
+			reg = <0x0400000 0x0400000>;
+		};
+
+		partition@800000 {
+			label = "ubi";
+			reg = <0x0800000 0x2e00000>;
+		};
+
+		partition@3600000 {
+			label = "Config";
+			reg = <0x3600000 0x0100000>;
+			read-only;
+		};
+
+		partition@3700000 {
+			label = "firmware_2";
+			reg = <0x3700000 0x3200000>;
+		};
+
+		partition@6900000 {
+			label = "Config_2";
+			reg = <0x6900000 0x0100000>;
+			read-only;
+		};
+
+		partition@6a00000 {
+			label = "persist";
+			reg = <0x6a00000 0x0100000>;
+		};
+	};
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&state_default {
+	gpio {
+		ralink,group = "uart2", "uart3", "wdt";
+		ralink,function = "gpio";
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5761a.dts
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5761a.dts
@@ -32,11 +32,22 @@
 			linux,default-trigger = "phy1tpt";
 		};
 	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		usb_power {
+			gpio-export,name = "usb_power";
+			gpio-export,output = <0>;
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		};
+	};
 };
 
 &state_default {
 	gpio {
-		ralink,group = "i2c", "refclk", "wdt", "p3led_an", "wled_an";
+		ralink,group = "i2c", "refclk", "wdt", "p2led_an", "p3led_an", "wled_an";
 		ralink,function = "gpio";
 	};
 };

--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7621.c
+++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7621.c
@@ -98,15 +98,9 @@ static void mt7621_hw_init(struct mt7620_gsw *gsw, struct device_node *np)
 	mt7530_mdio_w32(gsw, 0x7000, 0x3);
 	usleep_range(10, 20);
 
-	if ((rt_sysc_r32(SYSC_REG_CHIP_REV_ID) & 0xFFFF) == 0x0101) {
-		/* (GE1, Force 1000M/FD, FC ON, MAX_RX_LENGTH 1536) */
-		mtk_switch_w32(gsw, 0x2305e30b, GSW_REG_MAC_P0_MCR);
-		mt7530_mdio_w32(gsw, 0x3600, 0x5e30b);
-	} else {
-		/* (GE1, Force 1000M/FD, FC ON, MAX_RX_LENGTH 1536) */
-		mtk_switch_w32(gsw, 0x2305e33b, GSW_REG_MAC_P0_MCR);
-		mt7530_mdio_w32(gsw, 0x3600, 0x5e33b);
-	}
+	/* (GE1, Force 1000M/FD, FC OFF, MAX_RX_LENGTH 1536) */
+	mtk_switch_w32(gsw, 0x2305e30b, GSW_REG_MAC_P0_MCR);
+	mt7530_mdio_w32(gsw, 0x3600, 0x5e30b);
 
 	/* (GE2, Link down) */
 	mtk_switch_w32(gsw, 0x8000, GSW_REG_MAC_P1_MCR);

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -65,6 +65,28 @@ define Build/iodata-factory
 	fi
 endef
 
+define Build/iodata-mstc-header
+  ( \
+    data_size_crc="$$(dd if=$@ ibs=64 skip=1 2>/dev/null | \
+      gzip -c | tail -c 8 | od -An -tx8 --endian little | tr -d ' \n')"; \
+    echo -ne "$$(echo $$data_size_crc | sed 's/../\\x&/g')" | \
+      dd of=$@ bs=8 count=1 seek=7 conv=notrunc 2>/dev/null; \
+  )
+  dd if=/dev/zero of=$@ bs=4 count=1 seek=1 conv=notrunc 2>/dev/null
+  ( \
+    header_crc="$$(dd if=$@ bs=64 count=1 2>/dev/null | \
+      gzip -c | tail -c 8 | od -An -N4 -tx4 --endian little | tr -d ' \n')"; \
+    echo -ne "$$(echo $$header_crc | sed 's/../\\x&/g')" | \
+      dd of=$@ bs=4 count=1 seek=1 conv=notrunc 2>/dev/null; \
+  )
+endef
+
+define Build/netis-tail
+	echo -n $(1) >> $@
+	echo -n $(UIMAGE_NAME)-yun | $(STAGING_DIR_HOST)/bin/mkhash md5 | \
+		sed 's/../\\\\x&/g' | xargs echo -ne >> $@
+endef
+
 define Build/ubnt-erx-factory-image
 	if [ -e $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) -a "$$(stat -c%s $@)" -lt "$(KERNEL_SIZE)" ]; then \
 		echo '21001:6' > $(1).compat; \
@@ -336,6 +358,38 @@ define Device/iodata_wn-ax1167gr
 endef
 TARGET_DEVICES += iodata_wn-ax1167gr
 
+define Device/iodata_wn-ax1167gr2
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  UBINIZE_OPTS := -E 5
+  UIMAGE_MAGIC := 0x434f4d42
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 51200k
+  DEVICE_VENDOR := I-O DATA
+  DEVICE_MODEL := WN-AX1167GR2
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | custom-initramfs-uimage 3.10(XBC.1)b10 | \
+	iodata-mstc-header
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7615e wpad-openssl
+endef
+TARGET_DEVICES += iodata_wn-ax1167gr2
+
+define Device/iodata_wn-dx1167r
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  UBINIZE_OPTS := -E 5
+  UIMAGE_MAGIC := 0x434f4d43
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 51200k
+  DEVICE_VENDOR := I-O DATA
+  DEVICE_MODEL := WN-DX1167R
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | custom-initramfs-uimage 3.10(XIK.1)b10 | \
+	iodata-mstc-header
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7615e wpad-openssl
+endef
+TARGET_DEVICES += iodata_wn-dx1167r
+
 define Device/iodata_wn-gx300gr
   IMAGE_SIZE := 7616k
   DEVICE_VENDOR := I-O DATA
@@ -594,8 +648,9 @@ define Device/netis_wf2881
   FILESYSTEMS := squashfs
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 129280k
-  KERNEL := $(KERNEL_DTB) | pad-offset $$(BLOCKSIZE) 64 | uImage lzma
   UBINIZE_OPTS := -E 5
+  UIMAGE_NAME := WF2881_0.0.00
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | netis-tail WF2881 | uImage lzma
   IMAGES += factory.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | \
@@ -603,7 +658,6 @@ define Device/netis_wf2881
   DEVICE_VENDOR := NETIS
   DEVICE_MODEL := WF2881
   DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-openssl
-  SUPPORTED_DEVICES += wf-2881
 endef
 TARGET_DEVICES += netis_wf2881
 
@@ -611,8 +665,6 @@ define Device/phicomm_k2p
   IMAGE_SIZE := 15744k
   DEVICE_VENDOR := Phicomm
   DEVICE_MODEL := K2P
-  DEVICE_ALT0_VENDOR := Phicomm
-  DEVICE_ALT0_MODEL := KE 2P
   SUPPORTED_DEVICES += k2p
   DEVICE_PACKAGES := luci-app-mtwifi
 endef

--- a/target/linux/ramips/modules.mk
+++ b/target/linux/ramips/modules.mk
@@ -20,7 +20,7 @@ define KernelPackage/pwm-mediatek-ramips
   AUTOLOAD:=$(call AutoProbe,pwm-mediatek-ramips)
 endef
 
-define KernelPackage/pwm-mediatek/description
+define KernelPackage/pwm-mediatek-ramips/description
   Kernel modules for MediaTek Pulse Width Modulator
 endef
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -77,6 +77,8 @@ ramips_setup_interfaces()
 	elecom,wrc-1900gst|\
 	elecom,wrc-2533gst|\
 	iodata,wn-ax1167gr|\
+	iodata,wn-ax1167gr2|\
+	iodata,wn-dx1167r|\
 	iodata,wn-gx300gr|\
 	iodata,wnpr2600g|\
 	iptime,a8004t)
@@ -227,6 +229,12 @@ ramips_setup_macs()
 	xiaoyu,xy-c5)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1)
 		;;
+	iodata,wn-ax1167gr2|\
+	iodata,wn-dx1167r|\
+	xiaomi,mir3g-v2)
+		wan_mac=$(mtd_get_mac_binary factory 0xe006)
+		label_mac=$wan_mac
+		;;
 	iodata,wnpr2600g)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		label_mac=$wan_mac
@@ -271,10 +279,6 @@ ramips_setup_macs()
 	xiaomi,mir3p)
 		lan_mac=$(mtd_get_mac_binary factory 0xe006)
 		label_mac=$lan_mac
-		;;
-	xiaomi,mir3g-v2)
-		wan_mac=$(mtd_get_mac_binary factory 0xe006)
-		label_mac=$wan_mac
 		;;
 	zbtlink,zbt-we1326)
 		wan_mac=$(mtd_get_mac_binary factory 0xe006)

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/iodata.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/iodata.sh
@@ -1,0 +1,55 @@
+#
+# Copyright (C) 2019 OpenWrt.org
+#
+
+. /lib/functions.sh
+
+iodata_mstc_prepare_fail() {
+	echo "failed to check and prepare the environment, rebooting..."
+	umount -a
+	reboot -f
+}
+
+# I-O DATA devices manufactured by MSTC (MitraStar Technology Corp.)
+# have two important flags:
+# - bootnum: switch between two os images
+#     use 1st image in OpenWrt
+# - debugflag: enable/disable debug
+#     users can interrupt Z-Loader for recovering the device if enabled
+iodata_mstc_upgrade_prepare() {
+	local persist_mtd="$(find_mtd_part persist)"
+	local factory_mtd="$(find_mtd_part factory)"
+
+	if [ -z "$persist_mtd" -o -z "$factory_mtd" ]; then
+		echo 'cannot find mtd partition(s), "factory" or "persist"'
+		iodata_mstc_prepare_fail
+	fi
+
+	local bootnum=$(hexdump -s 4 -n 1 -e '"%x"' ${persist_mtd})
+	local debugflag=$(hexdump -s 65141 -n 1 -e '"%x"' ${factory_mtd})
+
+	if [ "$bootnum" != "1" -a "$bootnum" != "2" ]; then
+		echo "failed to get bootnum, please check the value at 0x4 in ${persist_mtd}"
+		iodata_mstc_prepare_fail
+	fi
+	if [ "$debugflag" != "0" -a "$debugflag" != "1" ]; then
+		echo "failed to get debugflag, please check the value at 0xFE75 in ${factory_mtd}"
+		iodata_mstc_prepare_fail
+	fi
+	echo "current: bootnum => ${bootnum}, debugflag => ${debugflag}"
+
+	if [ "$bootnum" = "2" ]; then
+		if ! (echo -ne "\x01" | dd bs=1 count=1 seek=4 conv=notrunc of=${persist_mtd} 2>/dev/null); then
+			echo "failed to set bootnum"
+			iodata_mstc_prepare_fail
+		fi
+		echo "### switch to 1st os-image on next boot ###"
+	fi
+	if [ "$debugflag" = "0" ]; then
+		if ! (echo -ne "\x01" | dd bs=1 count=1 seek=65141 conv=notrunc of=${factory_mtd} 2>/dev/null); then
+			echo "failed to set debugflag"
+			iodata_mstc_prepare_fail
+		fi
+		echo "### enable debug ###"
+	fi
+}

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -55,6 +55,11 @@ platform_do_upgrade() {
 	xiaomi,mir3p)
 		nand_do_upgrade "$1"
 		;;
+	iodata,wn-ax1167gr2|\
+	iodata,wn-dx1167r)
+		iodata_mstc_upgrade_prepare
+		nand_do_upgrade "$1"
+		;;
 	ubiquiti,edgerouterx|\
 	ubiquiti,edgerouterx-sfp)
 		platform_upgrade_ubnt_erx "$1"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -60,7 +60,6 @@ ramips_setup_interfaces()
 			"1:lan" "2:lan" "3:lan" "4:lan" "0:wan" "6@eth0"
 		;;
 	hiwifi,hc5661a|\
-	hiwifi,hc5761a|\
 	mediatek,mt7628an-eval-board|\
 	mercury,mac1200r-v2|\
 	totolink,lr1200|\
@@ -68,6 +67,10 @@ ramips_setup_interfaces()
 	wavlink,wl-wn575a3)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
+		;;
+	hiwifi,hc5761a)
+		ucidef_add_switch "switch0" \
+			"0:lan" "1:lan" "4:wan" "6@eth0"
 		;;
 	iptime,a3)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
From issue #3242 

This commit sync ramips source code from openwrt master.
1. ramips: gsw_mt7621: disable PORT 5 MAC RX/TX flow control by default
2. ramips: allow to set switchdev by board in ramips_set_preinit_iface
3. kernel: fix typos in KernelPackage description