### PR TITLE
dockerman: fix luci entry display

### DIFF
--- a/package/lean/luci-app-dockerman/Makefile
+++ b/package/lean/luci-app-dockerman/Makefile
@@ -3,55 +3,16 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=luci-app-dockerman
 PKG_VERSION:=v0.3.0
 PKG_RELEASE:=beta
+PKG_TITLE:=Docker Manager interface for LuCI
+PKG_DEPENDS:=+luci-lib-docker +docker-ce +e2fsprogs +fdisk
 PKG_MAINTAINER:=lisaac <https://github.com/lisaac/luci-app-dockerman>
 PKG_LICENSE:=AGPL-3.0
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/lisaac/luci-app-dockerman.git
-PKG_SOURCE_VERSION:=$(PKG_VERSION)
-
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)
-PKG_SOURCE:=$(PKG_SOURCE_SUBDIR)-$(PKG_VERSION).tar.gz
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_SUBDIR)
-
-include $(INCLUDE_DIR)/package.mk
-
-define Package/$(PKG_NAME)
-	SECTION:=luci
-	CATEGORY:=LuCI
-	SUBMENU:=3. Applications
-	TITLE:=Docker Manager interface for LuCI
-	PKGARCH:=all
-	DEPENDS:=+luci-lib-docker +docker-ce +e2fsprogs +fdisk
-endef
-
-define Package/$(PKG_NAME)/description
-	Docker Manager interface for LuCI
-endef
-
-define Build/Prepare
-	tar -xzvf $(DL_DIR)/$(PKG_SOURCE) -C $(BUILD_DIR)
-endef
-
-define Build/Compile
-endef
+include $(TOPDIR)/feeds/luci/luci.mk
 
 define Package/$(PKG_NAME)/postinst
 #!/bin/sh
-rm -fr /tmp/luci-indexcache /tmp/luci-modulecache
+rm -rf /tmp/luci-indexcache /tmp/luci-modulecache
 endef
 
-define Package/$(PKG_NAME)/install
-	$(INSTALL_DIR) $(1)/
-	cp -pR $(PKG_BUILD_DIR)/root/* $(1)/
-	# $(INSTALL_DIR) $(1)/www
-	# cp -pR $(PKG_BUILD_DIR)/htdoc/* $(1)/www
-	$(INSTALL_DIR) $(1)/usr/lib/lua/luci
-	cp -pR $(PKG_BUILD_DIR)/luasrc/* $(1)/usr/lib/lua/luci/
-	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/i18n
-	$(foreach po, $(shell find $(PKG_BUILD_DIR)/po/*/*.po),\
-		po2lmo $(po) $(1)/usr/lib/lua/luci/i18n/dockerman.$(shell echo $(po) | awk -F'/' '{print $$(NF-1)}').lmo;)
-	#po2lmo $(PKG_BUILD_DIR)/po/zh-cn/dockerman.po $(1)/usr/lib/lua/luci/i18n/dockerman.zh-cn.lmo
-endef
-
-$(eval $(call BuildPackage,$(PKG_NAME)))
+# call BuildPackage - OpenWrt buildroot signature

--- a/package/lean/luci-app-dockerman/luasrc/controller/dockerman.lua
+++ b/package/lean/luci-app-dockerman/luasrc/controller/dockerman.lua
@@ -10,7 +10,7 @@ module("luci.controller.dockerman",package.seeall)
 
 function index()
 
-  entry({"admin", "services","docker"}, firstchild(), "Docker", 40).dependent = false
+  entry({"admin", "services","docker"},cbi("dockerman/overview"),_("Docker"), 40).dependent = true
   entry({"admin","services","docker","overview"},cbi("dockerman/overview"),_("Overview"),0).leaf=true
 
   local socket = luci.model.uci.cursor():get("dockerman", "local", "socket_path")

--- a/package/lean/luci-app-dockerman/luasrc/controller/dockerman.lua
+++ b/package/lean/luci-app-dockerman/luasrc/controller/dockerman.lua
@@ -10,7 +10,7 @@ module("luci.controller.dockerman",package.seeall)
 
 function index()
 
-  entry({"admin", "services","docker"},cbi("dockerman/overview"),_("Docker"), 40).dependent = true
+  entry({"admin", "services","docker"}, firstchild(), "Docker", 40).dependent = false
   entry({"admin","services","docker","overview"},cbi("dockerman/overview"),_("Overview"),0).leaf=true
 
   local socket = luci.model.uci.cursor():get("dockerman", "local", "socket_path")


### PR DESCRIPTION
抱歉, 上次在操作合并时直接打了 patch , 没仔细看原作者的具体代码更改, 导致 dockerman 页面错误出现在了 luci 的一级菜单里, 这可能会导致部分功能异常.

原作者这几次提交代码量巨大, 走马观花紧急抢救了一下, 现在应该正常了, 但是还没有经过测试, 请暂缓拉取.
