### PR TITLE
dockerman: fix path issue

### DIFF
--- a/package/lean/luci-app-dockerman/luasrc/view/dockerman/cbi/xsimpleform.htm
+++ b/package/lean/luci-app-dockerman/luasrc/view/dockerman/cbi/xsimpleform.htm
@@ -8,7 +8,7 @@
 				},
 				path = {
 					resource = resource,
-					browser  = url("admin/services/filebrowser")
+					browser  = url("admin/filebrowser")
 				}
 			}))
 		%>>


### PR DESCRIPTION
合并上游提交时使用的批量替换脚本出现的小问题.

会导致镜像/容器的路径读取出现错误, 但应该不影响使用.

总之先放在这里