### PR TITLE
npc: bump version to v0.26.4

### DIFF
--- a/package/lean/npc/Makefile
+++ b/package/lean/npc/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=npc
-PKG_VERSION:=0.26.3
+PKG_VERSION:=0.26.4
 PKG_RELEASE:=1
 
 ifeq ($(ARCH),mipsel)


### PR DESCRIPTION
fix:
busybox与sysV环境下(openwrt)service库失效问题 #419
客户端使用http代理连接服务端问题
