### PR TITLE
npc: Improved compile duplicate download issues

### DIFF
--- a/package/lean/npc/Makefile
+++ b/package/lean/npc/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=npc
 PKG_VERSION:=0.26.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 ifeq ($(ARCH),mipsel)
 	NPC_ARCH:=mipsle
@@ -37,6 +37,8 @@ endif
 
 PKG_LICENSE:=Apache-2.0
 PKG_BUILD_DIR:=$(BUILD_DIR)/npc-$(PKG_VERSION)
+PKG_URL:=https://github.com/ehang-io/nps/releases/download/v$(PKG_VERSION)/linux_$(NPC_ARCH)_client.tar.gz
+PKG_FILE:=nps_linux_$(NPC_ARCH)_client-$(PKG_VERSION).tar.gz
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -45,18 +47,22 @@ define Package/$(PKG_NAME)
 	CATEGORY:=Network
 	TITLE:=NPC Client
 	DEPENDS:=
-	URL:=https://github.com/cnlh/nps/releases
+	URL:=https://github.com/ehang-io/nps/releases
 endef
-
-
 
 define Package/$(PKG_NAME)/description
 npc is a fast reverse proxy to help you expose a local server behind a NAT or firewall to the internet
 endef
 
+define Build/Download
+	if [ ! -f $(DL_DIR)/$(PKG_FILE) ] ; then \
+		wget -c -t 5 -O $(DL_DIR)/$(PKG_FILE) $(PKG_URL); \
+	fi
+endef
+
 define Build/Prepare
-	[ ! -f $(PKG_BUILD_DIR)/linux_$(NPC_ARCH)_client.tar.gz ] && wget https://github.com/cnlh/nps/releases/download/v$(PKG_VERSION)/linux_$(NPC_ARCH)_client.tar.gz -O $(PKG_BUILD_DIR)/linux_$(NPC_ARCH)_client.tar.gz
-	tar -zxvf $(PKG_BUILD_DIR)/linux_$(NPC_ARCH)_client.tar.gz -C $(PKG_BUILD_DIR)
+	$(Build/Download)
+	tar -zxvf $(DL_DIR)/$(PKG_FILE) -C $(PKG_BUILD_DIR)
 endef
 
 define Build/Configure


### PR DESCRIPTION
### NPC

* Improved compile duplicate download issues

* Change package download url

> NPC软件包下载在编译目录里，不在 dl 目录下，导致每次编译都重新下载，优化了文件命名和下载逻辑，有个问题要吐槽就是NPS发布的软件包文件名为啥不带版本号--O_O--