### PR TITLE
luci-app-qbittorrent: switch WebUI use UPnP to false

### DIFF
--- a/package/lean/luci-app-qbittorrent/root/etc/init.d/qbittorrent
+++ b/package/lean/luci-app-qbittorrent/root/etc/init.d/qbittorrent
@@ -72,7 +72,7 @@ validate_QBT () {
 		'Password:string' \
 		'Port:port:8080' \
 		'Username:string' \
-		'UseUPnP:or("true","false"):true' \
+		'UseUPnP:or("true","false"):false' \
 		'AnonymousMode:or("true","false"):true' \
 		'AnnounceToAllTrackers:or("true","false")' \
 		'IgnoreLimitsLAN:or("true","false"):true' \


### PR DESCRIPTION
默认关闭qBittorrent-WebUI的UPnP转发