### PR TITLE
npc:bump to 0.26.5

### DIFF
--- a/package/lean/npc/Makefile
+++ b/package/lean/npc/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=npc
-PKG_VERSION:=0.26.4
+PKG_VERSION:=0.26.5
 PKG_RELEASE:=2
 
 ifeq ($(ARCH),mipsel)


### PR DESCRIPTION
add:
web 新增和编辑tunnel时增加使用场景提示实现 #410 提到的在hostlist 列表中点击在线状态可以直接访问这个穿透地址。感谢@hzgjq
添加版本打印，现在客户端和服务端均可以用-version参数打印版本了
添加客户端linux sdk文件打包

