### PR TITLE
fix autoreboot crontab not restart issue

### DIFF
--- a/package/lean/luci-app-autoreboot/root/etc/init.d/autoreboot
+++ b/package/lean/luci-app-autoreboot/root/etc/init.d/autoreboot
@@ -19,10 +19,12 @@ run_reboot()
         week="*"
 		fi
 		sed -i '/reboot/d' /etc/crontabs/root >/dev/null 2>&1
+		/etc/init.d/cron restart
 		echo "$minute $hour * * $week sleep 5 && touch /etc/banner && reboot" >> /etc/crontabs/root
 		echo "Auto REBOOT has started."
 	else
 		sed -i '/reboot/d' /etc/crontabs/root >/dev/null 2>&1
+		/etc/init.d/cron restart
 		echo "Auto REBOOT has started."
 	fi
 }


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [y] 我知道

你好，自动重启插件配置后没有立即生效，因为没有重启crontab服务导致