### PR TITLE
Make luci-app-ssr-plus' common mode able to use Telegram

### DIFF
--- a/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -197,7 +197,7 @@ start_rules() {
 	if [ $dports == "1" ]; then
 		proxyport=" "
 	else
-		proxyport="-m multiport --dports 22,53,587,465,995,993,143,80,443"
+		proxyport="-m multiport --dports 22,53,587,465,995,993,143,80,443,5222"
 	fi
 	/usr/bin/ssr-rules \
 	-s "$server" \


### PR DESCRIPTION
5222 is the port that needed by Telegram(refer to https://core.telegram.org/mtproto/transports).

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ x ] 我知道
