### PR TITLE
luci-app-ssr-plus: fix dns2socks unavailable in gfw mode

### DIFF
--- a/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -451,7 +451,7 @@ start_redir() {
 	local dnsstr="$(uci_get_by_type global tunnel_forward 8.8.4.4:53)"
 	local dnsserver=$(echo "$dnsstr" | awk -F ':' '{print $1}')
 	local dnsport=$(echo "$dnsstr" | awk -F ':' '{print $2}')
-	if [ "$ssr_dns" == "1" ]; then
+	if [ "$ssr_dns" != "0" ]; then # not use custom dns service
 		if [ "$run_mode" == "gfw" ]; then
 			ipset add gfwlist $dnsserver 2>/dev/null
 		elif [ "$run_mode" == "oversea" ]; then
@@ -459,12 +459,14 @@ start_redir() {
 		else
 			ipset add ss_spec_wan_ac $dnsserver nomatch 2>/dev/null
 		fi
+	fi
+	if [ "$ssr_dns" == "1" ]; then
 		start_pdnsd $dnsserver $dnsport
 		pdnsd_enable_flag=1
 	elif [ "$ssr_dns" == "2" ]; then
-    microsocks -i 127.0.0.1 -p 10802 ssr-dns >/dev/null 2>&1 &
-    dns2socks 127.0.0.1:10802 $dnsserver:$dnsport 127.0.0.1:5335 -q >/dev/null 2>&1 &
-    pdnsd_enable_flag=2
+		microsocks -i 127.0.0.1 -p 10802 ssr-dns >/dev/null 2>&1 &
+		dns2socks 127.0.0.1:10802 $dnsserver:$dnsport 127.0.0.1:5335 -q >/dev/null 2>&1 &
+		pdnsd_enable_flag=2
 	fi
 	if [ "$(uci_get_by_type global enable_switch)" == "1" ]; then
 		if [ "$(uci_get_by_name $GLOBAL_SERVER switch_enable 1)" == "1" ]; then
@@ -696,3 +698,4 @@ stop() {
 	fi
 	del_cron
 }
+


### PR DESCRIPTION
当使用dns2socks时，选择的dns ip未添加到gfwlist 中，导致 dns 的 TCP 请求未通过代理转发

