### PR TITLE
Revert "kernel: update 4.19 patch"

### DIFF
--- a/target/linux/generic/config-4.19
+++ b/target/linux/generic/config-4.19
@@ -3191,6 +3191,7 @@ CONFIG_NETWORK_FILESYSTEMS=y
 # CONFIG_NET_9P is not set
 # CONFIG_NET_ACT_BPF is not set
 # CONFIG_NET_ACT_CSUM is not set
+# CONFIG_NET_ACT_CTINFO is not set
 # CONFIG_NET_ACT_GACT is not set
 # CONFIG_NET_ACT_IFE is not set
 # CONFIG_NET_ACT_IPT is not set

--- a/target/linux/generic/hack-4.19/835-misc-owl_loader.patch
+++ b/target/linux/generic/hack-4.19/835-misc-owl_loader.patch
@@ -1,0 +1,52 @@
+From dd36f935973d91644449bd9749f6062a2bed821b Mon Sep 17 00:00:00 2001
+From: Christian Lamparter <chunkeey@googlemail.com>
+Date: Fri, 7 Jul 2017 17:26:46 +0200
+Subject: misc: owl-loader for delayed Atheros ath9k fixup
+
+Some devices (like the Cisco Meraki Z1 Cloud Managed Teleworker Gateway)
+need to be able to initialize the PCIe wifi device. Normally, this is done
+during the early stages of booting linux, because the necessary init code
+is read from the memory mapped SPI and passed to pci_enable_ath9k_fixup.
+However,this isn't possible for devices which have the init code for the
+Atheros chip stored on NAND in an UBI volume. Hence, this module can be
+used to initialze the chip when the user-space is ready to extract the
+init code.
+
+Signed-off-by: Martin Blumenstingl <martin.blumenstingl@googlemail.com>
+Signed-off-by: Christian Lamparter <chunkeey@googlemail.com>
+---
+ drivers/misc/Kconfig  | 12 ++++++++++++
+ drivers/misc/Makefile |  1 +
+ 2 files changed, 13 insertions(+)
+
+--- a/drivers/misc/Kconfig
++++ b/drivers/misc/Kconfig
+@@ -164,6 +164,18 @@ config SGI_IOC4
+ 	  If you have an SGI Altix with an IOC4-based card say Y.
+ 	  Otherwise say N.
+ 
++config OWL_LOADER
++	tristate "Owl loader for initializing Atheros PCI(e) Wifi chips"
++	depends on PCI
++	---help---
++	This kernel module helps to initialize certain Qualcomm
++	Atheros' PCI(e) Wifi chips, which have the init data
++	(which contains the PCI device ID for example) stored
++	together with the calibration data in the file system.
++
++	This is necessary for devices like the Cisco Meraki Z1, say M.
++	Otherwise say N.
++
+ config TIFM_CORE
+ 	tristate "TI Flash Media interface support"
+ 	depends on PCI
+--- a/drivers/misc/Makefile
++++ b/drivers/misc/Makefile
+@@ -14,6 +14,7 @@ obj-$(CONFIG_ATMEL_TCLIB)	+= atmel_tclib
+ obj-$(CONFIG_DUMMY_IRQ)		+= dummy-irq.o
+ obj-$(CONFIG_ICS932S401)	+= ics932s401.o
+ obj-$(CONFIG_LKDTM)		+= lkdtm/
++obj-$(CONFIG_OWL_LOADER)	+= owl-loader.o
+ obj-$(CONFIG_TIFM_CORE)       	+= tifm_core.o
+ obj-$(CONFIG_TIFM_7XX1)       	+= tifm_7xx1.o
+ obj-$(CONFIG_PHANTOM)		+= phantom.o

--- a/target/linux/generic/pending-4.19/681-NET-add-of_get_mac_address_mtd.patch
+++ b/target/linux/generic/pending-4.19/681-NET-add-of_get_mac_address_mtd.patch
@@ -32,17 +32,67 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  {
  	struct property *pp = of_find_property(np, name, NULL);
  
-@@ -48,6 +49,79 @@ static const void *of_get_mac_addr(struc
+@@ -48,6 +49,138 @@ static const void *of_get_mac_addr(struc
  	return NULL;
  }
  
++typedef int(*mtd_mac_address_read)(struct mtd_info *mtd, loff_t from, u_char *buf);
++
++static int read_mtd_mac_address(struct mtd_info *mtd, loff_t from, u_char *mac)
++{
++	size_t retlen;
++
++	return mtd_read(mtd, from, 6, &retlen, mac);
++}
++
++static int read_mtd_mac_address_ascii(struct mtd_info *mtd, loff_t from, u_char *mac)
++{
++	size_t retlen;
++	char buf[17];
++
++	if (mtd_read(mtd, from, 12, &retlen, buf)) {
++		return -1;
++	}
++	if (sscanf(buf, "%2hhx%2hhx%2hhx%2hhx%2hhx%2hhx",
++			&mac[0], &mac[1], &mac[2], &mac[3],
++			&mac[4], &mac[5]) == 6) {
++		if (mac[0] == '\0' && mac[1] == '\0') { /* First 2 bytes are zero, probably a bug. Trying to re-read */
++			buf[4] = '\0'; /* Make it null-terminated */
++			if (sscanf(buf, "%4hx", mac) == 1)
++				*(uint16_t*)mac = htons(*(uint16_t*)mac);
++		}
++		return 0;
++	}
++	if (mtd_read(mtd, from+12, 5, &retlen, buf+12)) {
++		return -1;
++	}
++	if (sscanf(buf, "%2hhx:%2hhx:%2hhx:%2hhx:%2hhx:%2hhx",
++			&mac[0], &mac[1], &mac[2], &mac[3],
++			&mac[4], &mac[5]) == 6) {
++		return 0;
++	}
++	return -1;
++}
++
++static struct mtd_mac_address_property {
++	char *name;
++	mtd_mac_address_read read;
++} mtd_mac_address_properties[] = {
++	{
++		.name = "mtd-mac-address",
++		.read = read_mtd_mac_address,
++	}, {
++		.name = "mtd-mac-address-ascii",
++		.read = read_mtd_mac_address_ascii,
++	},
++};
++
 +static const void *of_get_mac_address_mtd(struct device_node *np)
 +{
 +#ifdef CONFIG_MTD
 +	struct device_node *mtd_np = NULL;
 +	struct property *prop;
-+	size_t retlen;
-+	int size, ret;
++	int size, ret = -1;
 +	struct mtd_info *mtd;
 +	const char *part;
 +	const __be32 *list;
@@ -51,28 +101,37 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	u8 mac[ETH_ALEN];
 +	void *addr;
 +	u32 inc_idx;
++	int i;
 +
-+	list = of_get_property(np, "mtd-mac-address", &size);
-+	if (!list || (size != (2 * sizeof(*list))))
++	for (i = 0; i < ARRAY_SIZE(mtd_mac_address_properties); i++) {
++		list = of_get_property(np, mtd_mac_address_properties[i].name, &size);
++		if (!list || (size != (2 * sizeof(*list))))
++			continue;
++
++		phandle = be32_to_cpup(list++);
++		if (phandle)
++			mtd_np = of_find_node_by_phandle(phandle);
++
++		if (!mtd_np)
++			continue;
++
++		part = of_get_property(mtd_np, "label", NULL);
++		if (!part)
++			part = mtd_np->name;
++
++		mtd = get_mtd_device_nm(part);
++		if (IS_ERR(mtd))
++			continue;
++
++		ret = mtd_mac_address_properties[i].read(mtd, be32_to_cpup(list), mac);
++		put_mtd_device(mtd);
++		if (!ret) {
++			break;
++		}
++	}
++	if (ret) {
 +		return NULL;
-+
-+	phandle = be32_to_cpup(list++);
-+	if (phandle)
-+		mtd_np = of_find_node_by_phandle(phandle);
-+
-+	if (!mtd_np)
-+		return NULL;
-+
-+	part = of_get_property(mtd_np, "label", NULL);
-+	if (!part)
-+		part = mtd_np->name;
-+
-+	mtd = get_mtd_device_nm(part);
-+	if (IS_ERR(mtd))
-+		return NULL;
-+
-+	ret = mtd_read(mtd, be32_to_cpup(list), 6, &retlen, mac);
-+	put_mtd_device(mtd);
++	}
 +
 +	if (of_property_read_u32(np, "mtd-mac-address-increment-byte", &inc_idx))
 +		inc_idx = 5;
@@ -112,7 +171,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  /**
   * Search the device tree for the best MAC address to use.  'mac-address' is
   * checked first, because that is supposed to contain to "most recent" MAC
-@@ -65,11 +139,18 @@ static const void *of_get_mac_addr(struc
+@@ -65,11 +193,18 @@ static const void *of_get_mac_addr(struc
   * addresses.  Some older U-Boots only initialized 'local-mac-address'.  In
   * this case, the real MAC is in 'local-mac-address', and 'mac-address' exists
   * but is all zeros.


### PR DESCRIPTION
1. misc-owl_loader是mac80211 v5.4的更改，故revert
2. 681-NET-add-of_get_mac_address_mtd.patch这个改动是支持`mtd-mac-ascii`的