### PR TITLE
luci-app-ssr-plus: fix ssrp alwawys start two server

### DIFF
--- a/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -223,7 +223,7 @@ start_rules() {
 	else
 		proxyport="-m multiport --dports 22,53,587,465,995,993,143,80,443"
 	fi
-	if [ "$NETFLIX_SERVER" != "same" ]; then
+	if [ "$NETFLIX_SERVER" != "$GLOBAL_SERVER" ]; then
     netflix="1"
   else
     netflix="0"
@@ -398,7 +398,7 @@ start_redir() {
     echo "$(date "+%Y-%m-%d %H:%M:%S") Network Tunnel REDIRECT $threads Threads Started!" >>/tmp/ssrplus.log
 	fi
 	
-	if [ "$NETFLIX_SERVER" != "same" ]; then
+	if [ "$NETFLIX_SERVER" != "$GLOBAL_SERVER" ]; then
     if [ "$ntype" == "ss" -o "$ntype" == "ssr" ]; then
         gen_config_file $NETFLIX_SERVER 2 4321
         gen_config_file $NETFLIX_SERVER 3 1088
@@ -592,7 +592,7 @@ rules() {
 	[ "$GLOBAL_SERVER" == "nil" ] && return 1
 	mkdir -p /var/run /var/etc
 	UDP_RELAY_SERVER=$(uci_get_by_type global udp_relay_server)
-	[ "$UDP_RELAY_SERVER" == "same" ] && UDP_RELAY_SERVER=$GLOBAL_SERVER
+	[ "$UDP_RELAY_SERVER" == "$GLOBAL_SERVER" ] && UDP_RELAY_SERVER=$GLOBAL_SERVER
 	if start_rules; then
 		return 0
 	else
@@ -629,25 +629,27 @@ start() {
 			rm -f /tmp/dnsmasq.ssr/ad.conf
 		fi
 		/usr/share/shadowsocksr/gfw2ipset.sh
-		
-		if [ "$NETFLIX_SERVER" != "same" ]; then
-      cat /etc/config/netflix.list | while read line || [ -n "$line" ]; 
-      do
-        sed -i "/$line/d" /tmp/dnsmasq.ssr/gfw_list.conf
-      done
-      awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"netflix"'\n",$0)}' /etc/config/netflix.list > /tmp/dnsmasq.ssr/netflix_forward.conf
-      awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5555"'\n",$0)}' /etc/config/netflix.list >> /tmp/dnsmasq.ssr/netflix_forward.conf
-      
-      ipset -N netflix hash:net 2>/dev/null
-      cat /etc/config/netflixip.list | while read nip || [ -n "$nip" ]; 
-      do
-        ipset add netflix $nip 2>/dev/null
-      done
 
-      ipset add ss_spec_wan_ac $(check_host $(uci_get_by_name $NETFLIX_SERVER server)) 2>/dev/null
-    else
-      rm -f /tmp/dnsmasq.ssr/netflix_forward.conf
-    fi
+		if [ "$NETFLIX_SERVER" != "$GLOBAL_SERVER" ]; then
+			cat /etc/config/netflix.list | while read line || [ -n "$line" ];
+			do
+				sed -i "/$line/d" /tmp/dnsmasq.ssr/gfw_list.conf
+			done
+			awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"netflix"'\n",$0)}' /etc/config/netflix.list > /tmp/dnsmasq.ssr/netflix_forward.conf
+			awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5555"'\n",$0)}' /etc/config/netflix.list >> /tmp/dnsmasq.ssr/netflix_forward.conf
+
+			ipset add ss_spec_wan_ac $(check_host $(uci_get_by_name $NETFLIX_SERVER server)) 2>/dev/null
+		else
+			awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"netflix"'\n",$0)}' /etc/config/netflix.list > /tmp/dnsmasq.ssr/netflix_forward.conf
+			awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/config/netflix.list >> /tmp/dnsmasq.ssr/netflix_forward.conf
+
+		fi
+
+		ipset -N netflix hash:net 2>/dev/null
+		cat /etc/config/netflixip.list | while read nip || [ -n "$nip" ];
+		do
+			ipset add netflix $nip 2>/dev/null
+		done
 		
 		/etc/init.d/dnsmasq restart >/dev/null 2>&1
 	fi
@@ -723,3 +725,4 @@ stop() {
 	fi
 	del_cron
 }
+

--- a/package/lean/luci-app-ssr-plus/root/usr/bin/ssr-rules
+++ b/package/lean/luci-app-ssr-plus/root/usr/bin/ssr-rules
@@ -121,7 +121,9 @@ ipset_r() {
 	for ip in $WAN_FW_IP; do ipset -! add blacklist $ip; done
 	
 	if [ "$NETFLIX" == "1" ]; then
-    $IPT -I SS_SPEC_WAN_AC -p tcp -m set --match-set netflix dst -j REDIRECT --to-ports 4321
+	$IPT -I SS_SPEC_WAN_AC -p tcp -m set --match-set netflix dst -j REDIRECT --to-ports 4321
+	else
+	$IPT -I SS_SPEC_WAN_AC -p tcp -m set --match-set netflix dst -j REDIRECT --to-ports $local_port
 	fi
 	return $?
 }


### PR DESCRIPTION
1. 当 netflix 服务器与主服务器相同时，应该只启动一个服务
2. 当 netflix 服务器与主服务器相同时，应该是 Netflix 分流服务也继续起作用，所以netflix域名和ip也应该继续添加进对应当dnsmasq和ipset中，但是相应的 redir port 应该和主服务器保持一致
3. 当 netflix 服务器与主服务器相同时，主服务器的 dns 和 netflix 服务的 dns 保持一致
