### PR TITLE
Update translation in Luci settings

### DIFF
--- a/package/lean/default-settings/i18n/default.zh-cn.po
+++ b/package/lean/default-settings/i18n/default.zh-cn.po
@@ -53,12 +53,12 @@ msgid "Swap"
 msgstr "虚拟内存"
 
 msgid "Force 40MHz mode"
-msgstr "强制40MHz频宽"
+msgstr "强制硬件最大频宽"
 
 msgid ""
 "Always use 40MHz channels even if the secondary channel overlaps. Using this "
 "option does not comply with IEEE 802.11n-2009!"
-msgstr "强制启用40MHz频宽并忽略辅助信道重叠。此选项可能不兼容某些无线硬件导致无法启用!"
+msgstr "强制启用硬件最大频宽并忽略辅助信道重叠。此选项可能不兼容某些无线硬件导致无法启用!"
 
 msgid "Disassociate On Low Acknowledgement"
 msgstr "弱信号剔除"


### PR DESCRIPTION
Update translation in Luci settings.
大部分支持5.8G频段的现代路由已经支持超过40MHz频宽，但翻译并没有跟上，遂更新。
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
