### PR TITLE
openssl: update to 1.1.1e

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,9 +9,9 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_BASE:=1.1.1
-PKG_BUGFIX:=d
+PKG_BUGFIX:=e
 PKG_VERSION:=$(PKG_BASE)$(PKG_BUGFIX)
-PKG_RELEASE:=3
+PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
 ENGINES_DIR=engines-1.1
 
@@ -19,12 +19,12 @@ PKG_BUILD_PARALLEL:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
+	http://www.openssl.org/source/ \
+	http://www.openssl.org/source/old/$(PKG_BASE)/ \
 	http://ftp.fi.muni.cz/pub/openssl/source/ \
 	http://ftp.linux.hr/pub/openssl/source/ \
-	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
-	http://www.openssl.org/source/ \
-	http://www.openssl.org/source/old/$(PKG_BASE)/
-PKG_HASH:=1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2
+	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/
+PKG_HASH:=694f61ac11cb51c9bf73f54e771ff6022b0327a43bbdfa1b2f19de1662a6dcbe
 
 PKG_LICENSE:=OpenSSL
 PKG_LICENSE_FILES:=LICENSE

--- a/package/libs/openssl/patches/150-openssl.cnf-add-engines-conf.patch
+++ b/package/libs/openssl/patches/150-openssl.cnf-add-engines-conf.patch
@@ -1,6 +1,6 @@
 --- a/apps/openssl.cnf
 +++ b/apps/openssl.cnf
-@@ -22,6 +22,53 @@ oid_section		= new_oids
+@@ -22,6 +22,82 @@ oid_section		= new_oids
  # (Alternatively, use a configuration file that has only
  # X.509v3 extensions in its main [= default] section.)
  
@@ -16,7 +16,36 @@
 +#padlock=padlock
 +
 +[afalg]
++# Leave this alone and configure algorithms with CIPERS/DIGESTS below
 +default_algorithms = ALL
++
++# The following commands are only available if using the alternative
++# (sync) AFALG engine
++# Configuration commands:
++# Run 'openssl engine -t -c -vv -pre DUMP_INFO devcrypto' to see a
++# list of supported algorithms, along with their driver, whether they
++# are hw accelerated or not, and the engine's configuration commands.
++
++# USE_SOFTDRIVERS: specifies whether to use software (not accelerated)
++# drivers (0=use only accelerated drivers, 1=allow all drivers, 2=use
++# if acceleration can't be determined) [default=2]
++#USE_SOFTDRIVERS = 2
++
++# CIPHERS: either ALL, NONE, NO_ECB (all except ECB-mode) or a
++# comma-separated list of ciphers to enable [default=NO_ECB]
++# Starting in 1.2.0, if you use a cipher list, each cipher may be
++# followed by a colon (:) and the minimum request length to use
++# AF_ALG drivers for that cipher; smaller requests are processed by
++# softare; a negative value will use the default for that cipher
++#CIPHERS=AES-128-CBC:1024, AES-256-CBC:768, DES-EDE3-CBC:0
++
++# DIGESTS: either ALL, NONE, or a comma-separated list of digests to
++# enable [default=NONE]
++# It is strongly recommended not to enable digests; their performance
++# is poor, and there are many cases in which they will not work,
++# especially when calling fork with open crypto contexts.  Openssh,
++# for example, does this, and you may not be able to login.
++#DIGESTS = NONE
 +
 +[devcrypto]
 +# Leave this alone and configure algorithms with CIPERS/DIGESTS below

--- a/package/libs/openssl/patches/430-e_devcrypto-make-the-dev-crypto-engine-dynamic.patch
+++ b/package/libs/openssl/patches/430-e_devcrypto-make-the-dev-crypto-engine-dynamic.patch
@@ -1,4 +1,4 @@
-From f3cef70b34afde3afd13ce3636232d41533b0162 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Eneas U de Queiroz <cote2004-github@yahoo.com>
 Date: Tue, 6 Nov 2018 10:57:03 -0200
 Subject: e_devcrypto: make the /dev/crypto engine dynamic
@@ -20,7 +20,7 @@ index e00802a3fd..47fe948966 100644
 -  SOURCE[../../libcrypto]=eng_devcrypto.c
 -ENDIF
 diff --git a/crypto/init.c b/crypto/init.c
-index 9fc0e8ef68..b387559920 100644
+index 1b0d523bea..ee3e2eb075 100644
 --- a/crypto/init.c
 +++ b/crypto/init.c
 @@ -329,18 +329,6 @@ DEFINE_RUN_ONCE_STATIC(ossl_init_engine_openssl)
@@ -116,7 +116,7 @@ diff --git a/crypto/engine/eng_devcrypto.c b/engines/e_devcrypto.c
 similarity index 95%
 rename from crypto/engine/eng_devcrypto.c
 rename to engines/e_devcrypto.c
-index 64dc6b891d..fb5c6e1636 100644
+index 0d420e50aa..3fcd81de7a 100644
 --- a/crypto/engine/eng_devcrypto.c
 +++ b/engines/e_devcrypto.c
 @@ -7,7 +7,7 @@
@@ -128,15 +128,7 @@ index 64dc6b891d..fb5c6e1636 100644
  #include <string.h>
  #include <sys/types.h>
  #include <sys/stat.h>
-@@ -23,26 +23,26 @@
- #include <openssl/objects.h>
- #include <crypto/cryptodev.h>
- 
--#include "internal/engine.h"
--
- /* #define ENGINE_DEVCRYPTO_DEBUG */
- 
- #if CRYPTO_ALGORITHM_MIN < CRYPTO_ALGORITHM_MAX
+@@ -31,18 +31,20 @@
  # define CHECK_BSD_STYLE_MACROS
  #endif
  
@@ -160,18 +152,7 @@ index 64dc6b891d..fb5c6e1636 100644
  
  /*
   * cipher/digest status & acceleration definitions
-@@ -66,6 +66,10 @@ struct driver_info_st {
-     char *driver_name;
- };
- 
-+#ifdef OPENSSL_NO_DYNAMIC_ENGINE
-+void engine_load_devcrypto_int(void);
-+#endif
-+
- static int clean_devcrypto_session(struct session_op *sess) {
-     if (ioctl(cfd, CIOCFSESSION, &sess->ses) < 0) {
-         SYSerr(SYS_F_IOCTL, errno);
-@@ -341,6 +345,7 @@ static int cipher_ctrl(EVP_CIPHER_CTX *ctx, int type, int p1, void* p2)
+@@ -341,6 +343,7 @@ static int cipher_ctrl(EVP_CIPHER_CTX *ctx, int type, int p1, void* p2)
      struct cipher_ctx *to_cipher_ctx;
  
      switch (type) {
@@ -179,7 +160,7 @@ index 64dc6b891d..fb5c6e1636 100644
      case EVP_CTRL_COPY:
          if (cipher_ctx == NULL)
              return 1;
-@@ -702,7 +707,6 @@ static int digest_init(EVP_MD_CTX *ctx)
+@@ -702,7 +705,6 @@ static int digest_init(EVP_MD_CTX *ctx)
          SYSerr(SYS_F_IOCTL, errno);
          return 0;
      }
@@ -187,7 +168,7 @@ index 64dc6b891d..fb5c6e1636 100644
      return 1;
  }
  
-@@ -1058,7 +1062,7 @@ static const ENGINE_CMD_DEFN devcrypto_cmds[] = {
+@@ -1058,7 +1060,7 @@ static const ENGINE_CMD_DEFN devcrypto_cmds[] = {
          OPENSSL_MSTR(DEVCRYPTO_USE_SOFTWARE) "=allow all drivers, "
          OPENSSL_MSTR(DEVCRYPTO_REJECT_SOFTWARE)
          "=use if acceleration can't be determined) [default="
@@ -196,7 +177,7 @@ index 64dc6b891d..fb5c6e1636 100644
      ENGINE_CMD_FLAG_NUMERIC},
  #endif
  
-@@ -1166,55 +1170,70 @@ static int devcrypto_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
+@@ -1166,55 +1168,70 @@ static int devcrypto_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
   *
   *****/
  
@@ -284,12 +265,12 @@ index 64dc6b891d..fb5c6e1636 100644
 -        || !ENGINE_set_ctrl_function(e, devcrypto_ctrl)
 +        || !ENGINE_set_ctrl_function(e, devcrypto_ctrl))
 +        return 0;
-+
+ 
 +    prepare_cipher_methods();
 +#ifdef IMPLEMENT_DIGEST
 +    prepare_digest_methods();
 +#endif
- 
++
 +    return (ENGINE_set_ciphers(e, devcrypto_ciphers)
 +#ifdef IMPLEMENT_DIGEST
 +        && ENGINE_set_digests(e, devcrypto_digests)
@@ -297,7 +278,7 @@ index 64dc6b891d..fb5c6e1636 100644
  /*
   * Asymmetric ciphers aren't well supported with /dev/crypto.  Among the BSD
   * implementations, it seems to only exist in FreeBSD, and regarding the
-@@ -1237,23 +1256,36 @@ void engine_load_devcrypto_int()
+@@ -1237,23 +1254,36 @@ void engine_load_devcrypto_int()
   */
  #if 0
  # ifndef OPENSSL_NO_RSA
@@ -343,7 +324,7 @@ index 64dc6b891d..fb5c6e1636 100644
          ENGINE_free(e);
          return;
      }
-@@ -1262,3 +1294,22 @@ void engine_load_devcrypto_int()
+@@ -1262,3 +1292,22 @@ void engine_load_devcrypto_int()
      ENGINE_free(e);          /* Loose our local reference */
      ERR_clear_error();
  }

--- a/package/libs/openssl/patches/500-e_devcrypto-default-to-not-use-digests-in-engine.patch
+++ b/package/libs/openssl/patches/500-e_devcrypto-default-to-not-use-digests-in-engine.patch
@@ -1,4 +1,4 @@
-From 52ddedc09ee81fe05ea2fa384fce89afe92d6d72 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Eneas U de Queiroz <cote2004-github@yahoo.com>
 Date: Mon, 11 Mar 2019 09:29:13 -0300
 Subject: e_devcrypto: default to not use digests in engine
@@ -20,10 +20,10 @@ turn them on if it is safe and fast enough.
 Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
 diff --git a/engines/e_devcrypto.c b/engines/e_devcrypto.c
-index fb5c6e1636..7741138b82 100644
+index 3fcd81de7a..d25230d366 100644
 --- a/engines/e_devcrypto.c
 +++ b/engines/e_devcrypto.c
-@@ -854,7 +854,7 @@ static void prepare_digest_methods(void)
+@@ -852,7 +852,7 @@ static void prepare_digest_methods(void)
      for (i = 0, known_digest_nids_amount = 0; i < OSSL_NELEM(digest_data);
           i++) {
  
@@ -32,7 +32,7 @@ index fb5c6e1636..7741138b82 100644
  
          /*
           * Check that the digest is usable
-@@ -1074,7 +1074,7 @@ static const ENGINE_CMD_DEFN devcrypto_cmds[] = {
+@@ -1072,7 +1072,7 @@ static const ENGINE_CMD_DEFN devcrypto_cmds[] = {
  #ifdef IMPLEMENT_DIGEST
     {DEVCRYPTO_CMD_DIGESTS,
      "DIGESTS",

--- a/package/libs/openssl/patches/510-e_devcrypto-ignore-error-when-closing-session.patch
+++ b/package/libs/openssl/patches/510-e_devcrypto-ignore-error-when-closing-session.patch
@@ -1,4 +1,4 @@
-From b6b2744f06f64922b449b3cb4bf0ad3df3efba71 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Eneas U de Queiroz <cote2004-github@yahoo.com>
 Date: Mon, 11 Mar 2019 10:15:14 -0300
 Subject: e_devcrypto: ignore error when closing session
@@ -9,10 +9,10 @@ session.  It may have been closed by another process after a fork.
 Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
 diff --git a/engines/e_devcrypto.c b/engines/e_devcrypto.c
-index 7741138b82..2480bdbd57 100644
+index d25230d366..f4570f1666 100644
 --- a/engines/e_devcrypto.c
 +++ b/engines/e_devcrypto.c
-@@ -197,9 +197,8 @@ static int cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
+@@ -195,9 +195,8 @@ static int cipher_init(EVP_CIPHER_CTX *ctx, const unsigned char *key,
          get_cipher_data(EVP_CIPHER_CTX_nid(ctx));
  
      /* cleanup a previous session */


### PR DESCRIPTION
This version includes bug and security fixes, including medium-severity
CVE-2019-1551, affecting RSA1024, RSA1536, DSA1024 & DH512 on x86_64.

Ref: openwrt/openwrt@dcef8d6