### PR TITLE
update README with recommandation for space reserved.

### DIFF
--- a/README
+++ b/README
@@ -9,7 +9,7 @@
 
 编译命令如下:
 
-1. 首先装好 Ubuntu 64bit，推荐  Ubuntu  14 LTS x64
+1. 首先装好 Ubuntu 64bit，推荐  Ubuntu  14 LTS x64. 磁盘预留最少30G的空间，如果需要编译多个固件，请预留至少50G的空间。
 
 2. 命令行输入 sudo apt-get update ，然后输入
 sudo apt-get -y install build-essential asciidoc binutils bzip2 gawk gettext git libncurses5-dev libz-dev patch python3.5 unzip zlib1g-dev lib32gcc1 libc6-dev-i386 subversion flex uglifyjs git-core gcc-multilib p7zip p7zip-full msmtp libssl-dev texinfo libglib2.0-dev xmlto qemu-utils upx libelf-dev autoconf automake libtool autopoint device-tree-compiler g++-multilib linux-libc-dev:i386


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

tl;dr

根据实操体会，提出建议预留至少30G的虚拟机磁盘空间。

longer version:

在第一次实操过程中，我只创建了一个10G空间的磁盘，用于安装虚拟机。
在编译的过程中，出现了报错。还以为是lede有问题，后来阴差阳错发现是磁盘空间不足了。
于是重新花时间安装了虚拟机，这次给了30G的空间。成功的编译了小米路由器Pro的固件（未测试固件是否OK，只是说固件编译过程没有明显的报错）。
在编译软路由的固件的时候，发现空间不足了，所以建议至少准备50G的磁盘空间。避免不必要的麻烦。