### PR TITLE
luci-app-ssr-plus: add stop mode for netflix service

### DIFF
--- a/package/lean/luci-app-ssr-plus/Makefile
+++ b/package/lean/luci-app-ssr-plus/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ssr-plus
 PKG_VERSION:=174
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/package/lean/luci-app-ssr-plus/Makefile
+++ b/package/lean/luci-app-ssr-plus/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ssr-plus
-PKG_VERSION:=173
-PKG_RELEASE:=7
+PKG_VERSION:=174
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/package/lean/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client.lua
+++ b/package/lean/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client.lua
@@ -44,10 +44,9 @@ o:value("same", translate("Same as Global Server"))
 for _,key in pairs(key_table) do o:value(key,server_table[key]) end
 
 o = s:option(ListValue, "netflix_server", translate("Netflix Node"))
+o:value("", translate("Disable"))
 o:value("same", translate("Same as Global Server"))
 for _,key in pairs(key_table) do o:value(key,server_table[key]) end
-o.default = "same"
-o.rmempty = false
 
 o = s:option(Flag, "netflix_proxy", translate("External Proxy Mode"))
 o.rmempty = false
@@ -104,3 +103,4 @@ o:depends("pdnsd_enable", "2")
 o.description = translate("Custom DNS Server format as IP:PORT (default: 8.8.4.4:53)")
 
 return m
+

--- a/package/lean/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client.lua
+++ b/package/lean/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client.lua
@@ -44,9 +44,11 @@ o:value("same", translate("Same as Global Server"))
 for _,key in pairs(key_table) do o:value(key,server_table[key]) end
 
 o = s:option(ListValue, "netflix_server", translate("Netflix Node"))
-o:value("", translate("Disable"))
+o:value("nil", translate("Disable"))
 o:value("same", translate("Same as Global Server"))
 for _,key in pairs(key_table) do o:value(key,server_table[key]) end
+o.default = "nil"
+o.rmempty = false
 
 o = s:option(Flag, "netflix_proxy", translate("External Proxy Mode"))
 o.rmempty = false
@@ -103,4 +105,5 @@ o:depends("pdnsd_enable", "2")
 o.description = translate("Custom DNS Server format as IP:PORT (default: 8.8.4.4:53)")
 
 return m
+
 

--- a/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -223,10 +223,12 @@ start_rules() {
 	else
 		proxyport="-m multiport --dports 22,53,587,465,995,993,143,80,443"
 	fi
-	if [ -n "$NETFLIX_SERVER" ] && [ "$NETFLIX_SERVER" != "$GLOBAL_SERVER" ]; then
-		netflix="1"
-	elif [ "$NETFLIX_SERVER" == "$GLOBAL_SERVER" ]; then
-		netflix="2"
+	if [ "$NETFLIX_SERVER" != "nil" ]; then
+		if [ "$NETFLIX_SERVER" != "$GLOBAL_SERVER" ]; then
+			netflix="1"
+		else
+			netflix="2"
+		fi
 	else
 		netflix="0"
 	fi
@@ -403,7 +405,7 @@ start_redir() {
 		echo "$(date "+%Y-%m-%d %H:%M:%S") Network Tunnel REDIRECT $threads Threads Started!" >>/tmp/ssrplus.log
 	fi
 
-	if [ -n "$NETFLIX_SERVER" ] && [ "$NETFLIX_SERVER" != "$GLOBAL_SERVER" ]; then
+	if [ "$NETFLIX_SERVER" != "nil" ] && [ "$NETFLIX_SERVER" != "$GLOBAL_SERVER" ]; then
 		if [ "$ntype" == "ss" -o "$ntype" == "ssr" ]; then
 			gen_config_file $NETFLIX_SERVER 2 4321
 			gen_config_file $NETFLIX_SERVER 3 1088
@@ -621,7 +623,7 @@ start() {
 		switch_enable=1
 	fi
 	
-	NETFLIX_SERVER=$(uci_get_by_type global netflix_server)
+	NETFLIX_SERVER=$(uci_get_by_type global netflix_server nil)
 	if [ "$NETFLIX_SERVER" == "same" ]; then
 		NETFLIX_SERVER=$GLOBAL_SERVER
 	fi
@@ -643,7 +645,7 @@ start() {
 		fi
 		/usr/share/shadowsocksr/gfw2ipset.sh
 
-		if [ -n "$NETFLIX_SERVER" ]; then
+		if [ "$NETFLIX_SERVER" != "nil" ]; then
 			if [ "$NETFLIX_SERVER" != "$GLOBAL_SERVER" ]; then
 				cat /etc/config/netflix.list | while read line || [ -n "$line" ];
 				do
@@ -749,4 +751,5 @@ stop() {
 	fi
 	del_cron
 }
+
 

--- a/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -223,8 +223,10 @@ start_rules() {
 	else
 		proxyport="-m multiport --dports 22,53,587,465,995,993,143,80,443"
 	fi
-	if [ "$NETFLIX_SERVER" != "$GLOBAL_SERVER" ]; then
+	if [ -n "$NETFLIX_SERVER" ] && [ "$NETFLIX_SERVER" != "$GLOBAL_SERVER" ]; then
 		netflix="1"
+	elif [ "$NETFLIX_SERVER" == "$GLOBAL_SERVER" ]; then
+		netflix="2"
 	else
 		netflix="0"
 	fi
@@ -401,7 +403,7 @@ start_redir() {
 		echo "$(date "+%Y-%m-%d %H:%M:%S") Network Tunnel REDIRECT $threads Threads Started!" >>/tmp/ssrplus.log
 	fi
 
-	if [ "$NETFLIX_SERVER" != "$GLOBAL_SERVER" ]; then
+	if [ -n "$NETFLIX_SERVER" ] && [ "$NETFLIX_SERVER" != "$GLOBAL_SERVER" ]; then
 		if [ "$ntype" == "ss" -o "$ntype" == "ssr" ]; then
 			gen_config_file $NETFLIX_SERVER 2 4321
 			gen_config_file $NETFLIX_SERVER 3 1088
@@ -618,12 +620,12 @@ start() {
 		GLOBAL_SERVER=$switch_server
 		switch_enable=1
 	fi
-
-	NETFLIX_SERVER=$(uci_get_by_type global netflix_server same)
+	
+	NETFLIX_SERVER=$(uci_get_by_type global netflix_server)
 	if [ "$NETFLIX_SERVER" == "same" ]; then
 		NETFLIX_SERVER=$GLOBAL_SERVER
 	fi
-
+		
 	if rules; then
 		start_redir
 		mkdir -p /tmp/dnsmasq.d && cp -a /etc/dnsmasq.ssr /tmp/ && cp -a /etc/dnsmasq.oversea /tmp/
@@ -641,29 +643,37 @@ start() {
 		fi
 		/usr/share/shadowsocksr/gfw2ipset.sh
 
-		if [ "$NETFLIX_SERVER" != "$GLOBAL_SERVER" ]; then
-			cat /etc/config/netflix.list | while read line || [ -n "$line" ]; do
-				sed -i "/$line/d" /tmp/dnsmasq.ssr/gfw_list.conf
-			done
-			awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"netflix"'\n",$0)}' /etc/config/netflix.list >/tmp/dnsmasq.ssr/netflix_forward.conf
-			awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5555"'\n",$0)}' /etc/config/netflix.list >>/tmp/dnsmasq.ssr/netflix_forward.conf
+		if [ -n "$NETFLIX_SERVER" ]; then
+			if [ "$NETFLIX_SERVER" != "$GLOBAL_SERVER" ]; then
+				cat /etc/config/netflix.list | while read line || [ -n "$line" ];
+				do
+					sed -i "/$line/d" /tmp/dnsmasq.ssr/gfw_list.conf
+				done
+				awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"netflix"'\n",$0)}' /etc/config/netflix.list > /tmp/dnsmasq.ssr/netflix_forward.conf
+				awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5555"'\n",$0)}' /etc/config/netflix.list >> /tmp/dnsmasq.ssr/netflix_forward.conf
 
-			ipset -N netflix hash:net 2>/dev/null
-			cat /etc/config/netflixip.list | while read nip || [ -n "$nip" ]; do
-				ipset add netflix $nip 2>/dev/null
-			done
+				ipset -N netflix hash:net 2>/dev/null
+				cat /etc/config/netflixip.list | while read nip || [ -n "$nip" ];
+				do
+					ipset add netflix $nip 2>/dev/null
+				done
+			else
+				cat /etc/config/netflix.list | while read line || [ -n "$line" ];
+				do
+					sed -i "/$line/d" /tmp/dnsmasq.ssr/gfw_list.conf
+				done
+				awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"netflix"'\n",$0)}' /etc/config/netflix.list > /tmp/dnsmasq.ssr/netflix_forward.conf
+				awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/config/netflix.list >> /tmp/dnsmasq.ssr/netflix_forward.conf
+				ipset -N netflix hash:net 2>/dev/null
+				cat /etc/config/netflixip.list | while read nip || [ -n "$nip" ];
+				do
+					ipset add netflix $nip 2>/dev/null
+				done
+			fi
 		else
-			cat /etc/config/netflix.list | while read line || [ -n "$line" ]; do
-				sed -i "/$line/d" /tmp/dnsmasq.ssr/gfw_list.conf
-			done
-			awk '!/^$/&&!/^#/{printf("ipset=/.%s/'"netflix"'\n",$0)}' /etc/config/netflix.list >/tmp/dnsmasq.ssr/netflix_forward.conf
-			awk '!/^$/&&!/^#/{printf("server=/.%s/'"127.0.0.1#5335"'\n",$0)}' /etc/config/netflix.list >>/tmp/dnsmasq.ssr/netflix_forward.conf
-			ipset -N netflix hash:net 2>/dev/null
-			cat /etc/config/netflixip.list | while read nip || [ -n "$nip" ]; do
-				ipset add netflix $nip 2>/dev/null
-			done
+			rm -f /tmp/dnsmasq.ssr/netflix_forward.conf
 		fi
-
+		
 		/etc/init.d/dnsmasq restart >/dev/null 2>&1
 	fi
 	start_server
@@ -739,3 +749,4 @@ stop() {
 	fi
 	del_cron
 }
+

--- a/package/lean/luci-app-ssr-plus/root/usr/bin/ssr-rules
+++ b/package/lean/luci-app-ssr-plus/root/usr/bin/ssr-rules
@@ -119,16 +119,16 @@ ipset_r() {
 	$IPT -I SS_SPEC_WAN_AC -m set --match-set whitelist dst -j RETURN
 	for ip in $WAN_BP_IP; do ipset -! add whitelist $ip; done
 	for ip in $WAN_FW_IP; do ipset -! add blacklist $ip; done
-		
+
 	if [ "$NETFLIX" == "1" ]; then
-    $IPT -I SS_SPEC_WAN_AC -p tcp -m set --match-set netflix dst -j REDIRECT --to-ports 4321
-    if [ "$NETFLIX_PROXY" == "1" ]; then
-      $IPT -I SS_SPEC_WAN_AC -p tcp -d $NETFLIX_IP -j REDIRECT --to-ports $local_port
-    else
-      ipset -! add whitelist $NETFLIX_IP
-    fi
-  else
-    $IPT -I SS_SPEC_WAN_AC -p tcp -m set --match-set netflix dst -j REDIRECT --to-ports $local_port
+		$IPT -I SS_SPEC_WAN_AC -p tcp -m set --match-set netflix dst -j REDIRECT --to-ports 4321
+		if [ "$NETFLIX_PROXY" == "1" ]; then
+			$IPT -I SS_SPEC_WAN_AC -p tcp -d $NETFLIX_IP -j REDIRECT --to-ports $local_port
+		else
+			ipset -! add whitelist $NETFLIX_IP
+		fi
+	elif [ "$NETFLIX" == "2" ]; then
+		$IPT -I SS_SPEC_WAN_AC -p tcp -m set --match-set netflix dst -j REDIRECT --to-ports $local_port
 	fi
 
 	return $?
@@ -399,3 +399,4 @@ fi
 flush_r && fw_rule && ipset_r && ac_rule && tp_rule && gen_include
 [ "$?" == 0 ] || loger 3 "Start failed!"
 exit $?
+


### PR DESCRIPTION
为 netflix 分流服务增加停用模式
1. 不使用为 netflix 分流服务制定的相关规则
2. 不创建优先度很高的 nat 转发规则
3. 停用后与未增加 netflix 分流服务 时的状态保持一致

https://github.com/coolsnowwolf/lede/issues/3846#issuecomment-600980973