### PR TITLE
kernel: iio.mk: add missing kernel modules

### DIFF
--- a/package/kernel/linux/modules/iio.mk
+++ b/package/kernel/linux/modules/iio.mk
@@ -12,16 +12,9 @@ define KernelPackage/iio-core
   KCONFIG:= \
 	CONFIG_IIO \
 	CONFIG_IIO_BUFFER=y \
-	CONFIG_IIO_KFIFO_BUF \
-	CONFIG_IIO_TRIGGER=y \
-	CONFIG_IIO_TRIGGERED_BUFFER
-  FILES:= \
-	$(LINUX_DIR)/drivers/iio/industrialio.ko \
-	$(if $(CONFIG_IIO_TRIGGERED_BUFFER),$(LINUX_DIR)/drivers/iio/industrialio-triggered-buffer.ko@lt4.4) \
-	$(if $(CONFIG_IIO_TRIGGERED_BUFFER),$(LINUX_DIR)/drivers/iio/buffer/industrialio-triggered-buffer.ko@ge4.4) \
-	$(LINUX_DIR)/drivers/iio/kfifo_buf.ko@lt4.4 \
-	$(LINUX_DIR)/drivers/iio/buffer/kfifo_buf.ko@ge4.4
-  AUTOLOAD:=$(call AutoLoad,55,industrialio kfifo_buf industrialio-triggered-buffer)
+	CONFIG_IIO_TRIGGER=y
+  FILES:=$(LINUX_DIR)/drivers/iio/industrialio.ko
+  AUTOLOAD:=$(call AutoLoad,55,industrialio)
 endef
 
 define KernelPackage/iio-core/description
@@ -33,9 +26,42 @@ endef
 $(eval $(call KernelPackage,iio-core))
 
 
+define KernelPackage/iio-kfifo-buf
+  SUBMENU:=$(IIO_MENU)
+  TITLE:=Industrial I/O buffering based on kfifo
+  DEPENDS:=+kmod-iio-core
+  KCONFIG:=CONFIG_IIO_KFIFO_BUF
+  FILES:=$(LINUX_DIR)/drivers/iio/buffer/kfifo_buf.ko
+  AUTOLOAD:=$(call AutoLoad,55,kfifo_buf)
+endef
+
+define KernelPackage/iio-kfifo-buf/description
+ A simple fifo based on kfifo.  Note that this currently provides no buffer
+ events so it is up to userspace to work out how often to read from the buffer.
+endef
+
+$(eval $(call KernelPackage,iio-kfifo-buf))
+
+
+define KernelPackage/industrialio-triggered-buffer
+  SUBMENU:=$(IIO_MENU)
+  TITLE:=Provides helper functions for setting up triggered buffers.
+  DEPENDS:=+kmod-iio-core +kmod-iio-kfifo-buf
+  KCONFIG:=CONFIG_IIO_TRIGGERED_BUFFER
+  FILES:=$(LINUX_DIR)/drivers/iio/buffer/industrialio-triggered-buffer.ko
+  AUTOLOAD:=$(call AutoLoad,55,industrialio-triggered-buffer)
+endef
+
+define KernelPackage/industrialio-triggered-buffer/description
+ Provides helper functions for setting up triggered buffers.
+endef
+
+$(eval $(call KernelPackage,industrialio-triggered-buffer))
+
+
 define KernelPackage/iio-ad799x
   SUBMENU:=$(IIO_MENU)
-  DEPENDS:=+kmod-i2c-core +kmod-iio-core
+  DEPENDS:=+kmod-i2c-core +kmod-iio-core +kmod-industrialio-triggered-buffer
   TITLE:=Analog Devices AD799x ADC driver
   KCONFIG:= \
 	CONFIG_AD799X_RING_BUFFER=y \
@@ -54,7 +80,7 @@ $(eval $(call KernelPackage,iio-ad799x))
 
 define KernelPackage/iio-hmc5843
   SUBMENU:=$(IIO_MENU)
-  DEPENDS:=+kmod-i2c-core +kmod-iio-core +kmod-regmap-i2c
+  DEPENDS:=+kmod-i2c-core +kmod-iio-core +kmod-regmap-i2c +kmod-industrialio-triggered-buffer
   TITLE:=Honeywell HMC58x3 Magnetometer
   KCONFIG:= CONFIG_SENSORS_HMC5843_I2C
   FILES:= \
@@ -84,7 +110,7 @@ $(eval $(call KernelPackage,iio-bh1750))
 
 define KernelPackage/iio-am2315
   SUBMENU:=$(IIO_MENU)
-  DEPENDS:=+kmod-i2c-core +kmod-iio-core
+  DEPENDS:=+kmod-i2c-core +kmod-iio-core +kmod-industrialio-triggered-buffer
   TITLE:=Asong AM2315 humidity/temperature sensor
   KCONFIG:= CONFIG_AM2315
   FILES:=$(LINUX_DIR)/drivers/iio/humidity/am2315.ko
@@ -97,7 +123,7 @@ $(eval $(call KernelPackage,iio-am2315))
 
 define KernelPackage/iio-mxs-lradc
   SUBMENU:=$(IIO_MENU)
-  DEPENDS:=@TARGET_mxs +kmod-iio-core
+  DEPENDS:=@TARGET_mxs +kmod-iio-core +kmod-industrialio-triggered-buffer
   TITLE:=Freescale i.MX23/i.MX28 LRADC ADC driver
   KCONFIG:= \
 	CONFIG_MXS_LRADC_ADC
@@ -133,7 +159,7 @@ $(eval $(call KernelPackage,iio-dht11))
 define KernelPackage/iio-bme680
   SUBMENU:=$(IIO_MENU)
   TITLE:=BME680 gas/humidity/pressure/temperature sensor
-  DEPENDS:=@LINUX_4_19 +kmod-iio-core +kmod-regmap-core
+  DEPENDS:=@!LINUX_4_14 +kmod-iio-core +kmod-regmap-core
   KCONFIG:=CONFIG_BME680
   FILES:=$(LINUX_DIR)/drivers/iio/chemical/bme680_core.ko
 endef
@@ -247,7 +273,7 @@ $(eval $(call KernelPackage,iio-htu21))
 
 define KernelPackage/iio-ccs811
   SUBMENU:=$(IIO_MENU)
-  DEPENDS:=+kmod-i2c-core +kmod-iio-core
+  DEPENDS:=+kmod-i2c-core +kmod-iio-core +kmod-industrialio-triggered-buffer
   TITLE:=AMS CCS811 VOC sensor
   KCONFIG:= \
 	CONFIG_CCS811
@@ -280,6 +306,76 @@ endef
 $(eval $(call KernelPackage,iio-si7020))
 
 
+define KernelPackage/iio-st_accel
+  SUBMENU:=$(IIO_MENU)
+  TITLE:=STMicroelectronics accelerometer 3-Axis Driver
+  DEPENDS:=+kmod-iio-core +kmod-regmap-core +kmod-industrialio-triggered-buffer
+  KCONFIG:= \
+	CONFIG_IIO_ST_ACCEL_3AXIS \
+	CONFIG_IIO_ST_SENSORS_CORE
+  FILES:= \
+	$(LINUX_DIR)/drivers/iio/accel/st_accel.ko \
+	$(LINUX_DIR)/drivers/iio/common/st_sensors/st_sensors.ko
+endef
+
+define KernelPackage/iio-st_accel/description
+ This package adds support for STMicroelectronics accelerometers:
+  LSM303DLH, LSM303DLHC, LIS3DH, LSM330D, LSM330DL, LSM330DLC,
+  LIS331DLH, LSM303DL, LSM303DLM, LSM330, LIS2DH12, H3LIS331DL,
+  LNG2DM, LIS3DE, LIS2DE12
+endef
+
+$(eval $(call KernelPackage,iio-st_accel))
+
+
+define KernelPackage/iio-st_sensors-i2c
+  SUBMENU:=$(IIO_MENU)
+  TITLE:=STMicroelectronics accelerometer 3-Axis Driver (I2C)
+  DEPENDS:=+kmod-iio-st_accel +kmod-i2c-core +kmod-regmap-i2c
+  KCONFIG:= CONFIG_IIO_ST_ACCEL_I2C_3AXIS
+  FILES:=$(LINUX_DIR)/drivers/iio/common/st_sensors/st_sensors_i2c.ko
+  AUTOLOAD:=$(call AutoLoad,56,st_sensors_i2c)
+endef
+
+define KernelPackage/iio-st_sensors-i2c/description
+ This package adds support for STMicroelectronics I2C based accelerometers
+endef
+
+$(eval $(call KernelPackage,iio-st_sensors-i2c))
+
+
+define KernelPackage/iio-sps30
+  SUBMENU:=$(IIO_MENU)
+  DEPENDS:=@!LINUX_4_14 +kmod-i2c-core +kmod-iio-core +kmod-industrialio-triggered-buffer +kmod-lib-crc8
+  TITLE:=Sensirion SPS30 particulate matter sensor
+  KCONFIG:=CONFIG_SPS30
+  FILES:=$(LINUX_DIR)/drivers/iio/chemical/sps30.ko
+  AUTOLOAD:=$(call AutoProbe,sps30)
+endef
+
+define KernelPackage/iio-sps30/description
+ Support for the Sensirion SPS30 particulate matter sensor.
+endef
+
+$(eval $(call KernelPackage,iio-sps30))
+
+
+define KernelPackage/iio-st_sensors-spi
+  SUBMENU:=$(IIO_MENU)
+  TITLE:=STMicroelectronics accelerometer 3-Axis Driver (SPI)
+  DEPENDS:=+kmod-iio-st_accel +kmod-regmap-spi
+  KCONFIG:= CONFIG_IIO_ST_ACCEL_SPI_3AXIS
+  FILES:=$(LINUX_DIR)/drivers/iio/common/st_sensors/st_sensors_spi.ko
+  AUTOLOAD:=$(call AutoLoad,56,st_sensors_spi)
+endef
+
+define KernelPackage/iio-st_sensors-spi/description
+ This package adds support for STMicroelectronics SPI based accelerometers
+endef
+
+$(eval $(call KernelPackage,iio-st_sensors-spi))
+
+
 define KernelPackage/iio-tsl4531
   SUBMENU:=$(IIO_MENU)
   DEPENDS:=+kmod-i2c-core +kmod-iio-core
@@ -296,3 +392,53 @@ define KernelPackage/iio-tsl4531/description
 endef
 
 $(eval $(call KernelPackage,iio-tsl4531))
+
+
+define KernelPackage/iio-fxos8700
+  SUBMENU:=$(IIO_MENU)
+  TITLE:=Freescale FXOS8700 3-axis accelerometer driver
+  DEPENDS:=+kmod-iio-core +kmod-regmap-core
+  KCONFIG:= CONFIG_FXOS8700
+  FILES:=$(LINUX_DIR)/drivers/iio/imu/fxos8700_core.ko
+  AUTOLOAD:=$(call AutoLoad,56,fxos8700)
+endef
+
+define KernelPackage/iio-fxos8700/description
+ Support for Freescale FXOS8700 3-axis accelerometer.
+endef
+
+$(eval $(call KernelPackage,iio-fxos8700))
+
+
+define KernelPackage/iio-fxos8700-i2c
+  SUBMENU:=$(IIO_MENU)
+  TITLE:=Freescale FXOS8700 3-axis acceleromter driver (I2C)
+  DEPENDS:=+kmod-iio-fxos8700 +kmod-i2c-core +kmod-regmap-i2c
+  KCONFIG:= CONFIG_FXOS8700_I2C
+  FILES:=$(LINUX_DIR)/drivers/iio/imu/fxos8700_i2c.ko
+  AUTOLOAD:=$(call AutoLoad,56,fxos8700_i2c)
+endef
+
+define KernelPackage/iio-fxos8700-i2c/description
+ Support for Freescale FXOS8700 3-axis accelerometer
+ connected via I2C.
+endef
+
+
+$(eval $(call KernelPackage,iio-fxos8700-i2c))
+
+define KernelPackage/iio-fxos8700-spi
+  SUBMENU:=$(IIO_MENU)
+  DEPENDS:=+kmod-iio-fxos8700 +kmod-regmap-spi
+  TITLE:=Freescale FXOS8700 3-axis accelerometer driver (SPI)
+  KCONFIG:= CONFIG_FXOS8700_SPI
+  FILES:=$(LINUX_DIR)/drivers/iio/imu/fxos8700_spi.ko
+  AUTOLOAD:=$(call AutoLoad,56,fxos8700_spi)
+endef
+
+define KernelPackage/iio-fxos8700-spi/description
+ Support for Freescale FXOS8700 3-axis accelerometer
+ connected via SPI.
+endef
+
+$(eval $(call KernelPackage,iio-fxos8700-spi))


### PR DESCRIPTION
This commit fix:
  SPS30 particulate matter sensor (SPS30) [N/m/y/?] (NEW)
![make](https://user-images.githubusercontent.com/42570690/77495881-a919cc00-6e84-11ea-90b9-81754f2dcf3b.png)
Run-tested-on: sunxi