### PR TITLE
npc:bump to 0.26.6

### DIFF
--- a/package/lean/npc/Makefile
+++ b/package/lean/npc/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=npc
-PKG_VERSION:=0.26.5
+PKG_VERSION:=0.26.6
 PKG_RELEASE:=2
 
 ifeq ($(ARCH),mipsel)


### PR DESCRIPTION
fix:
web重新显示id #453 #461 #475
客户端首次添加时限速问题
mux计算长度重复赋值
服务端启动可能卡住的问题 #470
web中丢失的服务器ip项

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
