### PR TITLE
luci-app-ssr-plus: add "same" mode for global socks5 server

### DIFF
--- a/package/lean/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
+++ b/package/lean/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
@@ -75,6 +75,7 @@ s.anonymous = true
 
 o = s:option(ListValue, "server", translate("Server"))
 o:value("nil", translate("Disable"))
+o:value("same", translate("Same as Global Server"))
 for _,key in pairs(key_table) do o:value(key,server_table[key]) end
 o.default = "nil"
 o.rmempty = false

--- a/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/package/lean/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -577,7 +577,8 @@ start_server() {
 
 start_local() {
 	local local_server=$(uci_get_by_type socks5_proxy server nil)
-	[ "$local_server" = "nil" ] && return 1
+	[ "$local_server" == "same" ] && local_server=$GLOBAL_SERVER
+	[ "$local_server" == "nil" ] && return 1
 	local local_type=$(uci_get_by_name $local_server type)
 	mkdir -p /var/run /var/etc
 


### PR DESCRIPTION
SOCKS5 代理服务端添加`与全局服务器相同`选项