### PR TITLE
ipq806x: add i2c chips support for m520

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -33,10 +33,6 @@ netgear,r7800)
 	ucidef_set_led_switch "wan" "WAN" "${boardname}:white:wan" "switch0" "0x20"
 	ucidef_set_led_ide "esata" "eSATA" "${boardname}:white:esata"
 	;;
-ruijie,rg-mtfi-m520)
-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "${boardname}:green:wlan2g" "phy1tpt"
-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "${boardname}:green:wlan5g" "phy0tpt"
-	;;
 tplink,c2600)
 	ucidef_set_led_usbport "usb1" "USB 1" "${boardname}:white:usb_2" "usb1-port1" "usb2-port1"
 	ucidef_set_led_usbport "usb2" "USB 2" "${boardname}:white:usb_4" "usb3-port1" "usb4-port1"

--- a/target/linux/ipq806x/base-files/lib/preinit/05_set_iface_mac_ipq806x.sh
+++ b/target/linux/ipq806x/base-files/lib/preinit/05_set_iface_mac_ipq806x.sh
@@ -5,10 +5,10 @@
 preinit_set_mac_address() {
 	case $(board_name) in
 	ruijie,rg-mtfi-m520)
-        base_mac=$(mtd_get_mac_ascii PRODUCTINFO ethaddr)
-        ip link set dev eth0 address $(macaddr_add "$base_mac" +1)
-        ip link set dev eth1 address $(macaddr_add "$base_mac" +2)
-        ;;
+		base_mac=$(mtd_get_mac_ascii PRODUCTINFO ethaddr)
+		ip link set dev eth0 address $(macaddr_add "$base_mac" +1)
+		ip link set dev eth1 address $(macaddr_add "$base_mac" +2)
+		;;
 	esac
 }
 

--- a/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-mtfi-m520.dts
+++ b/target/linux/ipq806x/files-4.14/arch/arm/boot/dts/qcom-ipq8064-mtfi-m520.dts
@@ -134,6 +134,27 @@
 			};
 		};
 
+		gsbi2: gsbi@12480000 {
+			qcom,mode = <GSBI_PROT_I2C_UART>;
+			status = "ok";
+
+			i2c@124a0000 {
+				status = "ok";
+
+				lm75@48 {
+					status = "okay";
+					compatible = "lm75";
+					reg = <0x48>;
+				};
+
+				pcf8563: rtc@51 {
+					status = "okay";
+					compatible = "nxp,pcf8563";
+					reg = <0x51>;
+				};
+			};
+		};
+
 		gsbi@16300000 {
 			qcom,mode = <GSBI_PROT_I2C_UART>;
 			status = "ok";
@@ -161,10 +182,10 @@
 				cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
 
 				flash: m25p80@0 {
-					compatible = "jedec,spi-nor";
+					compatible = "s25fl256s1";
 					#address-cells = <1>;
 					#size-cells = <1>;
-					spi-max-frequency = <51200000>;
+					spi-max-frequency = <50000000>;
 					reg = <0>;
 
 					SBL1@0 {
@@ -365,27 +386,6 @@
 			label = "reset";
 			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
-		pinctrl-names = "default";
-
-		usb_1 {
-			label = "m520:green:usb_1";
-			gpios = <&qcom_pinmux 7 GPIO_ACTIVE_HIGH>;
-		};
-
-		usb_3 {
-			label = "m520:green:usb_3";
-			gpios = <&qcom_pinmux 8 GPIO_ACTIVE_HIGH>;
-		};
-
-		status_green {
-			label = "m520:green:status";
-			gpios = <&qcom_pinmux 9 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-mtfi-m520.dts
+++ b/target/linux/ipq806x/files-4.19/arch/arm/boot/dts/qcom-ipq8064-mtfi-m520.dts
@@ -134,6 +134,27 @@
 			};
 		};
 
+		gsbi2: gsbi@12480000 {
+			qcom,mode = <GSBI_PROT_I2C_UART>;
+			status = "ok";
+
+			i2c@124a0000 {
+				status = "ok";
+
+				lm75@48 {
+					status = "okay";
+					compatible = "lm75";
+					reg = <0x48>;
+				};
+
+				pcf8563: rtc@51 {
+					status = "okay";
+					compatible = "nxp,pcf8563";
+					reg = <0x51>;
+				};
+			};
+		};
+
 		gsbi@16300000 {
 			qcom,mode = <GSBI_PROT_I2C_UART>;
 			status = "ok";
@@ -161,10 +182,10 @@
 				cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
 
 				flash: m25p80@0 {
-					compatible = "jedec,spi-nor";
+					compatible = "s25fl256s1";
 					#address-cells = <1>;
 					#size-cells = <1>;
-					spi-max-frequency = <51200000>;
+					spi-max-frequency = <50000000>;
 					reg = <0>;
 
 					SBL1@0 {
@@ -365,27 +386,6 @@
 			label = "reset";
 			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
-		pinctrl-names = "default";
-
-		usb_1 {
-			label = "m520:green:usb_1";
-			gpios = <&qcom_pinmux 7 GPIO_ACTIVE_HIGH>;
-		};
-
-		usb_3 {
-			label = "m520:green:usb_3";
-			gpios = <&qcom_pinmux 8 GPIO_ACTIVE_HIGH>;
-		};
-
-		status_green {
-			label = "m520:green:status";
-			gpios = <&qcom_pinmux 9 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -275,7 +275,8 @@ define Device/ruijie_rg-mtfi-m520
 	IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-to $$$${BLOCKSIZE} | sysupgrade-tar rootfs=$$$$@ | append-metadata
 	IMAGE/mmcblk0p2-kernel.bin := append-kernel | pad-to $$$${KERNEL_SIZE}
 	IMAGE/mmcblk0p3-rootfs.bin := append-rootfs | pad-rootfs
-	DEVICE_PACKAGES := ath10k-firmware-qca988x-ct blockd e2fsprogs f2fs-tools kmod-fs-ext4 kmod-fs-f2fs losetup
+	DEVICE_PACKAGES := ath10k-firmware-qca988x-ct e2fsprogs f2fs-tools \
+	kmod-hwmon-lm75 kmod-fs-ext4 kmod-fs-f2fs kmod-rtc-pcf8563 losetup
 endef
 TARGET_DEVICES += ruijie_rg-mtfi-m520
 


### PR DESCRIPTION
dmesg:
```
  [   15.868426] lm75 0-0048: hwmon0: sensor 'lm75'
  [   15.922580] Bluetooth: RFCOMM TTY layer initialized
  [   15.922610] Bluetooth: RFCOMM socket layer initialized
  [   15.926267] Bluetooth: RFCOMM ver 1.11
  [   15.939812] rtc-pcf8563 0-0051: rtc core: registered rtc-pcf8563 as rtc0
```