### PR TITLE
ssr ping server: change from automatic to manual

### DIFF
--- a/package/lean/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/servers.lua
+++ b/package/lean/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/servers.lua
@@ -79,6 +79,10 @@ luci.http.redirect(luci.dispatcher.build_url("admin", "services", "shadowsocksr"
 return
 end
 
+o = s:option(Button,"ping",'')
+o.rawhtml  = true
+o.template = "shadowsocksr/ping_btn"
+
 -- [[ Servers Manage ]]--
 s = m:section(TypedSection, "servers")
 s.anonymous = true

--- a/package/lean/luci-app-ssr-plus/luasrc/view/shadowsocksr/ping_btn.htm
+++ b/package/lean/luci-app-ssr-plus/luasrc/view/shadowsocksr/ping_btn.htm
@@ -1,0 +1,3 @@
+<%+cbi/valueheader%>
+<input type="button" class="cbi-button cbi-input-apply" value="<%:Ping Latency%> " onclick="return ping()" />
+<%+cbi/valuefooter%>

--- a/package/lean/luci-app-ssr-plus/luasrc/view/shadowsocksr/server_list.htm
+++ b/package/lean/luci-app-ssr-plus/luasrc/view/shadowsocksr/server_list.htm
@@ -45,8 +45,11 @@ local dsp = require "luci.dispatcher"
 			xhr(task).then(thread);
 		}
 	}
-	for (let i = 0; i < 20; i++) {
-		thread()
+	function ping() {
+		task = -1;
+		for (let i = 0; i < 20; i++) {
+			thread()
+		}
 	}
 	
 	function cbi_row_drop(fromId, toId, store, isToBottom) {


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
  
服务器列表：当节点比较多时（100节点），页面打开即开始启动20 thread 测连通性，此时点击其他操作按钮，页面卡着没反应，等连通性测试结束后，页面跳到404界面（没记错的话）
考虑将自动改为手动