### PR TITLE
luci-app-diskman: bump to 0.2.7

### DIFF
--- a/package/lean/luci-app-diskman/Makefile
+++ b/package/lean/luci-app-diskman/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-diskman
-PKG_VERSION:=v0.2.5
+PKG_VERSION:=v0.2.7
 PKG_RELEASE:=beta
 PKG_MAINTAINER:=lisaac <https://github.com/lisaac/luci-app-diskman>
 PKG_LICENSE:=AGPL-3.0


### PR DESCRIPTION
partition: automatic FIX GPT PARTITION TABLE while create partition
当硬盘分区表为GPT时，硬盘容量与GPT分区表不对应（使用DD刷入gpt镜像，或者调整RAID分区大小后），自动修复分区表，修复上述情况下无法创建新分区的BUG