### PR TITLE
 default-settings: fix string replace

### DIFF
--- a/package/lean/default-settings/files/zzz-default-settings
+++ b/package/lean/default-settings/files/zzz-default-settings
@@ -30,7 +30,7 @@ sed -i 's/services/nas/g'  /usr/lib/lua/luci/view/minidlna_status.htm
 ln -sf /sbin/ip /usr/bin/ip
 
 sed -i 's/downloads.openwrt.org/openwrt.proxy.ustclug.org/g' /etc/opkg/distfeeds.conf
-sed -i 's/http/https/g' /etc/opkg/distfeeds.conf
+sed -i 's/http:/https:/g' /etc/opkg/distfeeds.conf
 sed -i 's/root::0:0:99999:7:::/root:$1$V4UetPzk$CYXluq4wUazHjmCDBCqXF.:0:0:99999:7:::/g' /etc/shadow
 
 sed -i "s/# //g" /etc/opkg/distfeeds.conf


### PR DESCRIPTION
修复一处 distfeeds.conf 中将源地址的 http 替换成 https 可能引发的问题
如果 distfeeds.conf 的默认源就是 https，那将会引发更严重的后果

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
