### PR TITLE
修改迅雷快鸟的注销问题

### DIFF
--- a/package/lean/luci-app-xlnetacc/root/etc/init.d/xlnetacc
+++ b/package/lean/luci-app-xlnetacc/root/etc/init.d/xlnetacc
@@ -32,10 +32,10 @@ stop() {
 	local pid spid
 	for pid in $(ps | grep xlnetacc.sh | grep -v 'grep' | awk '{print $1}'); do
 		echo "Stop XLNetAcc process PID: $pid"
-		kill -9 $pid >/dev/null 2>&1
+		kill $pid >/dev/null 2>&1
 		for spid in $(pgrep -P $pid "sleep"); do
 			echo "Stop XLNetAcc process SPID: $spid"
-			kill -9 $spid >/dev/null 2>&1
+			kill $spid >/dev/null 2>&1
 		done
 	done
 	logger -p "daemon.notice" -t "$NAME" "XLNetAcc has stoped."


### PR DESCRIPTION
迅雷快鸟openwrt的原作者项目：https://github.com/sensec/luci-app-xlnetacc/blob/master/files/root/etc/init.d/xlnetacc
原项目并没有采用kill -9的强杀方式
lean项目中迁移后的版本使用kill -9会导致不能正确注销，从而产生如下问题。
1、luci 快鸟web界面中切换从“启用”切换为“不启用”后，短期内无法停止提速效果（因为只是强杀xlnetacc.sh）
2、强杀将导致未注销就丢失了最近一次的sessionid（该变量为xlnetacc.sh的临时变量，强杀后就丢失了）。根据迅雷快鸟的官方规则，在前一次未注销的情况下，假如ip变化，那么新ip在24小时内将无法再次加速。
所以导致了在
a.重启路由
b.重启光猫
c.重新插拔光猫网线
d.web界面中手工停用快鸟后又进行了重新拨号

这些操作都将导致24小时内无法再次提速

原始项目中采用不加-9的kill能够安全发送信号导致注销操作

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
