### PR TITLE
luci-app-openvpn-server: avoid repeated forwarding rules

### DIFF
--- a/package/lean/luci-app-openvpn-server/root/etc/uci-defaults/openvpn
+++ b/package/lean/luci-app-openvpn-server/root/etc/uci-defaults/openvpn
@@ -1,41 +1,49 @@
 #!/bin/sh
 
 uci -q batch <<-EOF >/dev/null
-	set network.vpn0="interface"
-	set network.vpn0.ifname="tun0"
-	set network.vpn0.proto="none"
-	commit network
+	delete network.vpn0
+	set network.vpn0=interface
+	set network.vpn0.ifname='tun0'
+	set network.vpn0.proto='none'
 	
-	delete firewall.vpn
-	delete firewall.vpnwan
-	delete firewall.vpnlan
+	commit network
+
 	delete firewall.openvpn
-	add firewall rule 
-	rename firewall.@rule[-1]="openvpn"
-	set firewall.@rule[-1].name="openvpn"
-	set firewall.@rule[-1].target="ACCEPT"
-	set firewall.@rule[-1].src="wan"
-	set firewall.@rule[-1].proto="tcp udp"
-	set firewall.@rule[-1].dest_port="1194"
-	add firewall zone
-	rename firewall.@zone[-1]="vpn"
-	set firewall.@zone[-1].name="vpn"
-	set firewall.@zone[-1].input="ACCEPT"
-	set firewall.@zone[-1].forward="ACCEPT"
-	set firewall.@zone[-1].output="ACCEPT"
-	set firewall.@zone[-1].masq="1"
-	set firewall.@zone[-1].network="vpn0"
-	add firewall forwarding
-	set firewall.@forwarding[-1].src="vpn"
-	set firewall.@forwarding[-1].dest="wan"
-	add firewall forwarding
-	set firewall.@forwarding[-1].src="vpn"
-	set firewall.@forwarding[-1].dest="lan"
-	add firewall forwarding
-	set firewall.@forwarding[-1].dest='vpn'
-	set firewall.@forwarding[-1].src='lan'
+	set firewall.openvpn=rule
+	set firewall.openvpn.name='openvpn'
+	set firewall.openvpn.target='ACCEPT'
+	set firewall.openvpn.src='wan'
+	set firewall.openvpn.proto='tcp udp'
+	set firewall.openvpn.dest_port='1194'
+
+	delete firewall.vpn
+	set firewall.vpn=zone
+	set firewall.vpn.name='vpn'
+	set firewall.vpn.input='ACCEPT'
+	set firewall.vpn.forward='ACCEPT'
+	set firewall.vpn.output='ACCEPT'
+	set firewall.vpn.masq='1'
+	set firewall.vpn.network='vpn0'
+
+	delete firewall.vpntowan
+	set firewall.vpntowan=forwarding
+	set firewall.vpntowan.src='vpn'
+	set firewall.vpntowan.dest='wan'
+
+	delete firewall.vpntolan
+	set firewall.vpntolan=forwarding
+	set firewall.vpntolan.src='vpn'
+	set firewall.vpntolan.dest='lan'
+
+	delete firewall.lantovpn
+	set firewall.lantovpn=forwarding
+	set firewall.lantovpn.src='lan'
+	set firewall.lantovpn.dest='vpn'
+
 	commit firewall
 EOF
+
+chmod 0777 /etc/openvpn/server/checkpsw.sh
 
 rm -f /tmp/luci-indexcache
 exit 0


### PR DESCRIPTION
Fix the bug that flashing firmware multiple times will cause repeated forwarding rules in firewall.

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
