### PR TITLE
ppp: syncppp: fix grep's regex match

### DIFF
--- a/package/network/services/ppp/files/ppp.sh
+++ b/package/network/services/ppp/files/ppp.sh
@@ -234,7 +234,7 @@ proto_pppoe_setup() {
 #By 蝈蝈：并发拨号同步的前期准备
 	syncppp_option=""
 	[ "$(uci get syncdial.config.enabled)" == "1" ] && {
-		ppp_if_cnt=$(cat /etc/config/network | grep -c "proto 'pppoe'")
+		ppp_if_cnt=$(cat /etc/config/network | grep -E -c "proto\s+?'pppoe'")
 		syncppp_option="syncppp $ppp_if_cnt"
 		shellsync $ppp_if_cnt 10
 	}


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

这边 interface 的数量获取可能出现问题。
`proto` 与 `'pppoe'` 之间有多个空格就没法匹配了，但是 uci config 语法可是允许的