### PR TITLE
ppp: syncppp: further fix grep's regex match

### DIFF
--- a/package/network/services/ppp/files/ppp.sh
+++ b/package/network/services/ppp/files/ppp.sh
@@ -233,8 +233,8 @@ proto_pppoe_setup() {
 
 #By 蝈蝈：并发拨号同步的前期准备
 	syncppp_option=""
-	[ "$(uci get syncdial.config.enabled)" == "1" ] && {
-		ppp_if_cnt=$(cat /etc/config/network | grep -E -c "proto\s+?'pppoe'")
+	[ "$(uci get syncdial.config.enabled)" -eq "1" ] && {
+		ppp_if_cnt=$(uci show network | grep -c "\.proto=\'pppoe\'$")
 		syncppp_option="syncppp $ppp_if_cnt"
 		shellsync $ppp_if_cnt 10
 	}


### PR DESCRIPTION
/etc/config/network这个文件里的写法可以各种各样，pppoe外面可以有引号，也可以没引号。proto与pppoe之间可以有不同类型、不同数量的空格（或Tab）。用uci show，可以把输出格式统一掉，省得考虑配置文件不同写法的区别。

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
