### PR TITLE
treewide: adjust sysupgrade script

### DIFF
--- a/target/linux/apm821xx/base-files/lib/upgrade/wdbook.sh
+++ b/target/linux/apm821xx/base-files/lib/upgrade/wdbook.sh
@@ -7,7 +7,7 @@ mbl_do_platform_check() {
 
 	[ "$#" -gt 1 ] && return 1
 
-	export_bootdevice && export_partdevice diskdev 0 || {
+	export_bootdevice && export_partdevice diskdev -2 || {
 		echo "Unable to determine upgrade device"
 		return 1
 	}
@@ -36,7 +36,7 @@ mbl_do_platform_check() {
 mbl_do_upgrade() {
 	local diskdev partdev diff
 
-	export_bootdevice && export_partdevice diskdev 0 || {
+	export_bootdevice && export_partdevice diskdev -2 || {
 		echo "Unable to determine upgrade device"
 		return 1
 	}
@@ -70,6 +70,10 @@ mbl_do_upgrade() {
 
 	#iterate over each partition from the image and write it to the boot disk
 	while read part start size; do
+		# root is /dev/sd[a|b]2 and not /dev/sd[a|b] this causes some problem
+		# one of which is this offset, I'm not sure what's the best fix, so
+		# here's a WA.
+		let part=$((part - 2))
 		if export_partdevice partdev $part; then
 			echo "Writing image to /dev/$partdev..."
 			get_image "$@" | dd of="/dev/$partdev" ibs="512" obs=1M skip="$start" count="$size" conv=fsync
@@ -86,7 +90,8 @@ mbl_do_upgrade() {
 mbl_copy_config() {
 	local partdev
 
-	if export_partdevice partdev 1; then
+	# Same as above /dev/sd[a|b]2 is root, so /boot is -1
+	if export_partdevice partdev -1; then
 		mount -t ext4 -o rw,noatime "/dev/$partdev" /mnt
 		cp -af "$CONF_TAR" /mnt/
 		umount /mnt

--- a/target/linux/bcm27xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/bcm27xx/base-files/lib/upgrade/platform.sh
@@ -9,7 +9,7 @@ platform_check_image() {
 
 	[ "$#" -gt 1 ] && return 1
 
-	export_bootdevice && export_partdevice diskdev 0 || {
+	export_bootdevice && export_partdevice diskdev -2 || {
 		echo "Unable to determine upgrade device"
 		return 1
 	}
@@ -38,7 +38,7 @@ platform_check_image() {
 platform_do_upgrade() {
 	local diskdev partdev diff
 
-	export_bootdevice && export_partdevice diskdev 0 || {
+	export_bootdevice && export_partdevice diskdev -2 || {
 		echo "Unable to determine upgrade device"
 		return 1
 	}
@@ -72,6 +72,10 @@ platform_do_upgrade() {
 
 	#iterate over each partition from the image and write it to the boot disk
 	while read part start size; do
+		# root is /dev/sd[a|b]2 and not /dev/sd[a|b] this causes some problem
+		# one of which is this offset, I'm not sure what's the best fix, so
+		# here's a WA.
+		let part=$((part - 2))
 		if export_partdevice partdev $part; then
 			echo "Writing image to /dev/$partdev..."
 			get_image "$@" | dd of="/dev/$partdev" ibs="512" obs=1M skip="$start" count="$size" conv=fsync
@@ -88,7 +92,8 @@ platform_do_upgrade() {
 platform_copy_config() {
 	local partdev
 
-	if export_partdevice partdev 1; then
+	# Same as above /dev/sd[a|b]2 is root, so /boot is -1
+	if export_partdevice partdev -1; then
 		mkdir -p /boot
 		[ -f /boot/kernel.img ] || mount -t vfat -o rw,noatime "/dev/$partdev" /boot
 		cp -af "$CONF_TAR" /boot/


### PR DESCRIPTION
This commit fix sysupgrade failed for bcm27xx, fix #4072, fix #4108 

Run-tested-by: @1715173329 Dalao on Raspberry Pi 3B
Run-tested-by: @EnnawYang Dalao on Raspberry Pi 4B