### PR TITLE
Update v2ray-core to 4.23.4

### DIFF
--- a/package/lean/v2ray/Makefile
+++ b/package/lean/v2ray/Makefile
@@ -9,13 +9,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=v2ray
-PKG_VERSION:=4.23.3
+PKG_VERSION:=4.23.4
 PKG_RELEASE:=1
 PKG_BUILD_DIR:=$(BUILD_DIR)/v2ray-core-$(PKG_VERSION)
 
 PKG_SOURCE:=v2ray-core-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/v2ray/v2ray-core/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=39558c5a9300158a4adf76d099b210790f7ef9705ce2909c6bdc2fccc70d5c69
+PKG_SOURCE_URL:=https://codeload.github.com/v2fly/v2ray-core/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=726dd98d674bd73150158b1d4c8bc0d59dbb672ba10096ac61548d6278213c78
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x ] 我知道

Please refer to https://github.com/v2fly/v2ray-core/releases for further updates instead of the V2Ray release page. Currently, update in V2Fly will be mirrored to the V2Ray release page but this will NOT continue indefinitely.