### PR TITLE
Rclone-OpenWRT: upgrade

### DIFF
--- a/package/lean/luci-app-rclone/Makefile
+++ b/package/lean/luci-app-rclone/Makefile
@@ -10,10 +10,10 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI support for Rclone
-LUCI_DEPENDS:=+rclone +rclone-webui-react +fuse-utils
+LUCI_DEPENDS:=+rclone +rclone-webui-react +fuse-utils +rclone-ng
 LUCI_PKGARCH:=all
 PKG_NAME:=luci-app-rclone
-PKG_VERSION:=1.3.21
+PKG_VERSION:=1.4.0
 PKG_RELEASE:=1
 PKG_LICENSE:=GPLv3.0+
 PKG_MAINTAINER:=ElonH <elonhhuang@gmail.com>

--- a/package/lean/luci-app-rclone/luasrc/model/cbi/rclone.lua
+++ b/package/lean/luci-app-rclone/luasrc/model/cbi/rclone.lua
@@ -38,10 +38,13 @@ m =
     translate('Rclone ("rsync for cloud storage") is a command line program to sync root/usr/bin and directories to and from different cloud storage providers.') ..
         ' <br/> <br/> ' .. translate('rclone state') .. ' : ' .. state_msg .. '<br/> <br/>'
         .. address_msg ..
-        translate('Installed Web Interface') ..
-        '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="button" class="cbi-button" style="margin: 0 5px;" value=" ' ..
-        translate('Webui React') ..
-        " \" onclick=\"window.open('http://'+window.location.hostname+'/rclone-webui-react')\"/> <br/><br/>"
+        translate('Installed Web Interface') ..                                                                                                                     
+        '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="button" class="cbi-button" style="margin: 0 5px;" value=" ' ..                                            
+        translate('Webui React') ..                                                                                                                                 
+        " \" onclick=\"window.open('http://'+window.location.hostname+'/rclone-webui-react')\"/>" ..                                                                
+        '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="button" class="cbi-button" style="margin: 0 5px;" value=" ' ..                                            
+        translate('RcloneNg') ..                                                                                                                                    
+        " \" onclick=\"window.open('http://'+window.location.hostname+'/RcloneNg')\"/> <br/><br/>"  
 )
 
 s = m:section(TypedSection, 'global', translate('global'))

--- a/package/lean/luci-app-rclone/po/templates/luci-app-rclone.pot
+++ b/package/lean/luci-app-rclone/po/templates/luci-app-rclone.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: luasrc/model/cbi/rclone.lua:118
+#: luasrc/model/cbi/rclone.lua:121
 msgid "FAQ"
 msgstr ""
 
@@ -23,11 +23,15 @@ msgid ""
 "usr/bin and directories to and from different cloud storage providers."
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:75
+#: luasrc/model/cbi/rclone.lua:46
+msgid "RcloneNg"
+msgstr ""
+
+#: luasrc/model/cbi/rclone.lua:78
 msgid "Recommand: run"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:127
+#: luasrc/model/cbi/rclone.lua:130
 msgid ""
 "The content of the variable is protocol://server:port. The protocol value is "
 "commonly either http or socks5."
@@ -37,63 +41,63 @@ msgstr ""
 msgid "Webui React"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:61
+#: luasrc/model/cbi/rclone.lua:64
 msgid "all address"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:54
+#: luasrc/model/cbi/rclone.lua:57
 msgid "configure"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:80
+#: luasrc/model/cbi/rclone.lua:83
 msgid "download"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:79
+#: luasrc/model/cbi/rclone.lua:82
 msgid "download configuration"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:120
+#: luasrc/model/cbi/rclone.lua:123
 msgid "enable proxy"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:47
+#: luasrc/model/cbi/rclone.lua:50
 msgid "global"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:58
+#: luasrc/model/cbi/rclone.lua:61
 msgid "listen address"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:65
+#: luasrc/model/cbi/rclone.lua:68
 msgid "listen port"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:60
+#: luasrc/model/cbi/rclone.lua:63
 msgid "local network address"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:59
+#: luasrc/model/cbi/rclone.lua:62
 msgid "localhost address"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:129
+#: luasrc/model/cbi/rclone.lua:132
 msgid "log"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:108
+#: luasrc/model/cbi/rclone.lua:111
 msgid "password"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:133
+#: luasrc/model/cbi/rclone.lua:136
 msgid "path"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:114
+#: luasrc/model/cbi/rclone.lua:117
 msgid "proxy"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:123
+#: luasrc/model/cbi/rclone.lua:126
 msgid "proxy address"
 msgstr ""
 
@@ -101,7 +105,7 @@ msgstr ""
 msgid "rclone address"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:71
+#: luasrc/model/cbi/rclone.lua:74
 msgid "rclone configuration file path"
 msgstr ""
 
@@ -117,18 +121,18 @@ msgstr ""
 msgid "rclone state"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:51
+#: luasrc/model/cbi/rclone.lua:54
 msgid "run Rclone as daemon"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:77
+#: luasrc/model/cbi/rclone.lua:80
 msgid "than updaload configuration to here."
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:77
+#: luasrc/model/cbi/rclone.lua:80
 msgid "to setup configuration on pc,"
 msgstr ""
 
-#: luasrc/model/cbi/rclone.lua:103
+#: luasrc/model/cbi/rclone.lua:106
 msgid "username"
 msgstr ""

--- a/package/lean/luci-app-rclone/po/zh_Hans/luci-app-rclone.po
+++ b/package/lean/luci-app-rclone/po/zh_Hans/luci-app-rclone.po
@@ -11,7 +11,7 @@ msgstr ""
 "PO-Revision-Date: \n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: luasrc/model/cbi/rclone.lua:118
+#: luasrc/model/cbi/rclone.lua:121
 msgid "FAQ"
 msgstr "常见问题"
 
@@ -34,11 +34,15 @@ msgid ""
 msgstr ""
 "Rclone是一款的命令行工具，支持在不同对象存储、网盘间同步、上传、下载数据。"
 
-#: luasrc/model/cbi/rclone.lua:75
+#: luasrc/model/cbi/rclone.lua:46
+msgid "RcloneNg"
+msgstr "RcloneNg"
+
+#: luasrc/model/cbi/rclone.lua:78
 msgid "Recommand: run"
 msgstr "建议: 在 PC 上运行"
 
-#: luasrc/model/cbi/rclone.lua:127
+#: luasrc/model/cbi/rclone.lua:130
 msgid ""
 "The content of the variable is protocol://server:port. The protocol value is "
 "commonly either http or socks5."
@@ -50,63 +54,63 @@ msgstr ""
 msgid "Webui React"
 msgstr "Webui React"
 
-#: luasrc/model/cbi/rclone.lua:61
+#: luasrc/model/cbi/rclone.lua:64
 msgid "all address"
 msgstr "全部地址"
 
-#: luasrc/model/cbi/rclone.lua:54
+#: luasrc/model/cbi/rclone.lua:57
 msgid "configure"
 msgstr "配置"
 
-#: luasrc/model/cbi/rclone.lua:80
+#: luasrc/model/cbi/rclone.lua:83
 msgid "download"
 msgstr "下载"
 
-#: luasrc/model/cbi/rclone.lua:79
+#: luasrc/model/cbi/rclone.lua:82
 msgid "download configuration"
 msgstr "下载配置文件"
 
-#: luasrc/model/cbi/rclone.lua:120
+#: luasrc/model/cbi/rclone.lua:123
 msgid "enable proxy"
 msgstr "启用代理"
 
-#: luasrc/model/cbi/rclone.lua:47
+#: luasrc/model/cbi/rclone.lua:50
 msgid "global"
 msgstr "全局"
 
-#: luasrc/model/cbi/rclone.lua:58
+#: luasrc/model/cbi/rclone.lua:61
 msgid "listen address"
 msgstr "监听地址"
 
-#: luasrc/model/cbi/rclone.lua:65
+#: luasrc/model/cbi/rclone.lua:68
 msgid "listen port"
 msgstr "监听端口"
 
-#: luasrc/model/cbi/rclone.lua:60
+#: luasrc/model/cbi/rclone.lua:63
 msgid "local network address"
 msgstr "局域网地址"
 
-#: luasrc/model/cbi/rclone.lua:59
+#: luasrc/model/cbi/rclone.lua:62
 msgid "localhost address"
 msgstr "本机地址"
 
-#: luasrc/model/cbi/rclone.lua:129
+#: luasrc/model/cbi/rclone.lua:132
 msgid "log"
 msgstr "日志"
 
-#: luasrc/model/cbi/rclone.lua:108
+#: luasrc/model/cbi/rclone.lua:111
 msgid "password"
 msgstr "密码"
 
-#: luasrc/model/cbi/rclone.lua:133
+#: luasrc/model/cbi/rclone.lua:136
 msgid "path"
 msgstr "路径"
 
-#: luasrc/model/cbi/rclone.lua:114
+#: luasrc/model/cbi/rclone.lua:117
 msgid "proxy"
 msgstr "代理"
 
-#: luasrc/model/cbi/rclone.lua:123
+#: luasrc/model/cbi/rclone.lua:126
 msgid "proxy address"
 msgstr "代理地址"
 
@@ -114,7 +118,7 @@ msgstr "代理地址"
 msgid "rclone address"
 msgstr "rclone 地址"
 
-#: luasrc/model/cbi/rclone.lua:71
+#: luasrc/model/cbi/rclone.lua:74
 msgid "rclone configuration file path"
 msgstr "rclone 配置文件地址"
 
@@ -130,19 +134,19 @@ msgstr "rclone 运行中"
 msgid "rclone state"
 msgstr "rclone 状态"
 
-#: luasrc/model/cbi/rclone.lua:51
+#: luasrc/model/cbi/rclone.lua:54
 msgid "run Rclone as daemon"
 msgstr "启动 rclone 后台服务"
 
-#: luasrc/model/cbi/rclone.lua:77
+#: luasrc/model/cbi/rclone.lua:80
 msgid "than updaload configuration to here."
 msgstr "然后上传配置文件到这里"
 
-#: luasrc/model/cbi/rclone.lua:77
+#: luasrc/model/cbi/rclone.lua:80
 msgid "to setup configuration on pc,"
 msgstr "命令设置 rclone 配置文件,"
 
-#: luasrc/model/cbi/rclone.lua:103
+#: luasrc/model/cbi/rclone.lua:106
 msgid "username"
 msgstr "用户名"
 

--- a/package/lean/luci-app-rclone/root/etc/init.d/rclone
+++ b/package/lean/luci-app-rclone/root/etc/init.d/rclone
@@ -1,4 +1,4 @@
-#!/bin/bash /etc/rc.common
+#!/bin/sh /etc/rc.common
 # Copyright (C) 2019 ElonH <elonhhuang@gmail.com>
 
 USE_PROCD=1
@@ -31,6 +31,9 @@ init_config() {
 	[ -d "$config_dir" ] || mkdir -p "$config_dir" 2>/dev/null
 
 	[ -f "$config_path" ] || touch "$config_path"
+
+	[ -d "/lib/upgrade/keep.d" ] || mkdir -p /lib/upgrade/keep.d/luci-app-rclone 2>/dev/null
+	echo "$config_path" > /lib/upgrade/keep.d/luci-app-rclone
 
 	log_dir=${log_path%/*}
 	[ -d "$log_dir" ] || mkdir -p "$log_dir" 2>/dev/null && echo /dev/null > "$log_path"
@@ -81,8 +84,8 @@ start_service() {
 	procd_append_param command "--rc-allow-origin=*"
 	procd_append_param command "--log-file=${log_path}"
 	if [[ "${proxy_enable}" == "1" ]]; then
-		procd_set_param env all_proxy="$proxy_addr" https_proxy="$proxy_addr" http_proxy="$proxy_addr"
-		procd_set_param env ALL_PROXY="$proxy_addr" HTTPS_PROXY="$proxy_addr" HTTP_PROXY="$proxy_addr"
+		procd_set_param    env all_proxy="$proxy_addr" https_proxy="$proxy_addr" http_proxy="$proxy_addr"
+		procd_append_param env ALL_PROXY="$proxy_addr" HTTPS_PROXY="$proxy_addr" HTTP_PROXY="$proxy_addr"
 	fi
 	procd_set_param stdout 1
 	procd_set_param stderr 1

--- a/package/lean/rclone-ng/Makefile
+++ b/package/lean/rclone-ng/Makefile
@@ -1,0 +1,58 @@
+####
+ #  File: /rclone-ng/Makefile
+ #  Project: Rclone-OpenWrt
+ #  File Created: Friday, 5th June 2020 12:37:26 am
+ #  Author: ElonH[EH](elonhhuang@gmail.com)
+ #  License: GNU General Public License v3.0 or later(http://www.gnu.org/licenses/gpl-3.0-standalone.html)
+ #  Copyright (C) 2020 [ElonH]
+####
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=rclone-ng
+PKG_VERSION:=0.2.4
+PKG_RELEASE:=1
+
+
+PKG_LICENSE:=GPLv3
+PKG_MAINTAINER:=ElonH <elonhhuang@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+PKG_SOURCE:=RcloneNg-v$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/ElonH/RcloneNg/releases/download/v$(PKG_VERSION)/
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_HASH:=3090a713253b17bfbb4d6a69b4b55b81d69e1768cf56d3abca8631e4a35f270b
+
+define Package/$(PKG_NAME)
+	SECTION:=net
+	CATEGORY:=Network
+	SUBMENU:=File Transfer
+	SUBMENU:=Cloud Manager
+	TITLE:=An angular web application for rclone
+	URL:=https://github.com/ElonH/RcloneNg
+	PKGARCH:=all
+endef
+
+define Package/$(PKG_NAME)/description
+	An angular web application for rclone
+endef
+
+define Build/Prepare
+	mkdir -vp $(PKG_BUILD_DIR)
+	tar -xzf $(DL_DIR)/$(PKG_SOURCE) -C $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+	echo "$(PKG_NAME) Compile Skiped!"
+endef
+
+define Package/$(PKG_NAME)/install
+	$(INSTALL_DIR) $(1)/www
+	$(CP) $(PKG_BUILD_DIR)/RcloneNg $(1)/www
+endef
+
+$(eval $(call BuildPackage,$(PKG_NAME)))

--- a/package/lean/rclone/patches/010-change-default-config-path.patch
+++ b/package/lean/rclone/patches/010-change-default-config-path.patch
@@ -1,0 +1,45 @@
+##
+#   File: /patches/010-change-default-config-path.patch
+#   Project: rclone
+#   File Created: Friday, 1st May 2020 10:54:31 pm
+#   Author: ElonH[EH](elonhhuang@gmail.com)
+#   License: GNU General Public License v3.0 or later(http://www.gnu.org/licenses/gpl-3.0-standalone.html)
+#   Copyright (C) 2020 [ElonH]
+##
+# set /etc/rclone/rclone.conf as default configuration path
+diff --git a/fs/config/config.go b/fs/config/config.go
+index 53d67ef03..cc5d6436b 100644
+--- a/fs/config/config.go
++++ b/fs/config/config.go
+@@ -25,7 +25,6 @@ import (
+ 	"unicode/utf8"
+ 
+ 	"github.com/Unknwon/goconfig"
+-	homedir "github.com/mitchellh/go-homedir"
+ 	"github.com/pkg/errors"
+ 	"github.com/rclone/rclone/fs"
+ 	"github.com/rclone/rclone/fs/accounting"
+@@ -133,21 +132,10 @@ func makeConfigPath() string {
+ 	}
+ 
+ 	// Find user's home directory
+-	homeDir, err := homedir.Dir()
++	homeDir := "/etc"
+ 
+-	// Find user's configuration directory.
+-	// Prefer XDG config path, with fallback to $HOME/.config.
+-	// See XDG Base Directory specification
+-	// https://specifications.freedesktop.org/basedir-spec/latest/),
+-	xdgdir := os.Getenv("XDG_CONFIG_HOME")
+ 	var cfgdir string
+-	if xdgdir != "" {
+-		// User's configuration directory for rclone is $XDG_CONFIG_HOME/rclone
+-		cfgdir = filepath.Join(xdgdir, "rclone")
+-	} else if homeDir != "" {
+-		// User's configuration directory for rclone is $HOME/.config/rclone
+-		cfgdir = filepath.Join(homeDir, ".config", "rclone")
+-	}
++	cfgdir = filepath.Join(homeDir, "rclone")
+ 
+ 	// Use rclone.conf from user's configuration directory if already existing
+ 	var cfgpath string

--- a/package/lean/rclone/patches/020-Notice-Access-Control-Allow-Origin-only-once.patch
+++ b/package/lean/rclone/patches/020-Notice-Access-Control-Allow-Origin-only-once.patch
@@ -1,0 +1,44 @@
+##
+#   File: /patches/020-Notice-Access-Control-Allow-Origin-only-once.patch
+#   Project: rclone
+#   File Created: Sunday, 3rd May 2020 1:44:22 pm
+#   Author: ElonH[EH](elonhhuang@gmail.com)
+#   License: GNU General Public License v3.0 or later(http://www.gnu.org/licenses/gpl-3.0-standalone.html)
+#   Copyright (C) 2020 [ElonH]
+##
+diff --git a/fs/rc/rcserver/rcserver.go b/fs/rc/rcserver/rcserver.go
+index 4a2b5c71e..f00994e93 100644
+--- a/fs/rc/rcserver/rcserver.go
++++ b/fs/rc/rcserver/rcserver.go
+@@ -14,6 +14,7 @@ import (
+ 	"regexp"
+ 	"sort"
+ 	"strings"
++	"sync"
+ 
+ 	"github.com/pkg/errors"
+ 	"github.com/rclone/rclone/cmd/serve/httplib"
+@@ -29,6 +30,8 @@ import (
+ 	"github.com/skratchdot/open-golang/open"
+ )
+ 
++var onlyOnce sync.Once
++
+ // Start the remote control server if configured
+ //
+ // If the server wasn't configured the *Server returned may be nil
+@@ -172,9 +175,11 @@ func (s *Server) handler(w http.ResponseWriter, r *http.Request) {
+ 
+ 	allowOrigin := rcflags.Opt.AccessControlAllowOrigin
+ 	if allowOrigin != "" {
+-		if allowOrigin == "*" {
+-			fs.Logf(nil, "Warning: Allow origin set to *. This can cause serious security problems.")
+-		}
++		onlyOnce.Do(func() {
++			if allowOrigin == "*" {
++				fs.Logf(nil, "Warning: Allow origin set to *. This can cause serious security problems.")
++			}
++		})
+ 		w.Header().Add("Access-Control-Allow-Origin", allowOrigin)
+ 	} else {
+ 		w.Header().Add("Access-Control-Allow-Origin", s.URL())


### PR DESCRIPTION
* feat(rcloneng): an angular web application for rclone
* feat(backup): backup rclone configuration files during system upgrade
* :bug: luci-app-rclone: rclone service without bash
* :mute: filter out duplicate log
* :bug: luci-app-rclone: proxy work around
* :page_facing_up: add license header
* rclone: set /etc/rclone/rclone.conf as default config path

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
