### PR TITLE
verysync: update to 1.4.1

### DIFF
--- a/package/lean/verysync/Makefile
+++ b/package/lean/verysync/Makefile
@@ -19,21 +19,18 @@ ifeq ($(ARCH),i386)
 	PKG_ARCH_VERYSYNC:=386
 endif
 ifeq ($(ARCH),arm)
-	PKG_ARCH_VERYSYNC:=arm7
-endif
-ifeq ($(BOARD),bcm53xx)
-	PKG_ARCH_VERYSYNC:=arm6
-endif
-ifeq ($(BOARD),kirkwood)
 	PKG_ARCH_VERYSYNC:=arm
 endif
 ifeq ($(ARCH),aarch64)
 	PKG_ARCH_VERYSYNC:=arm64
 endif
+ifeq ($(ARCH),powerpc64)
+	PKG_ARCH_VERYSYNC:=ppc64
+endif
 
 PKG_NAME:=verysync
-PKG_VERSION:=v1.3.1
-PKG_RELEASE:=2
+PKG_VERSION:=v1.4.1
+PKG_RELEASE:=1
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-linux-$(PKG_ARCH_VERYSYNC)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://releases-cdn.verysync.com/releases/$(PKG_VERSION)/


### PR DESCRIPTION
verysync 官方日常删历史版本
