### PR TITLE
luci-app-nps: monitor uci configuration changes

### DIFF
--- a/package/lean/luci-app-nps/root/etc/init.d/nps
+++ b/package/lean/luci-app-nps/root/etc/init.d/nps
@@ -62,9 +62,7 @@ start_service() {
 	fi
 }
 
-reload_service()
-{
-        stop
-        start
+service_triggers() {
+        procd_add_reload_trigger "nps"
 }
 


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

when uci configuration about nps has been changed, 
service doesn't restart itself
