### PR TITLE
r8168: Cancel default selection

### DIFF
--- a/package/lean/r8168/Makefile
+++ b/package/lean/r8168/Makefile
@@ -24,7 +24,6 @@ define KernelPackage/r8168
   VERSION:=$(LINUX_VERSION)+$(PKG_VERSION)-$(BOARD)-$(PKG_RELEASE)
   FILES:= $(PKG_BUILD_DIR)/r8168.ko
   AUTOLOAD:=$(call AutoProbe,r8168)
-  DEFAULT:=y
 endef
 
 define Package/r8168/description

--- a/target/linux/x86/Makefile
+++ b/target/linux/x86/Makefile
@@ -25,7 +25,7 @@ htop lm-sensors autocore automount autosamba luci-app-ipsec-vpnd luci-proto-bond
 luci-app-airplay2 luci-app-music-remote-center luci-app-qbittorrent luci-app-amule luci-app-openvpn-server \
 ath10k-firmware-qca988x ath10k-firmware-qca9888 ath10k-firmware-qca9984 brcmfmac-firmware-43602a1-pcie \
 kmod-sound-hda-core kmod-sound-hda-codec-realtek kmod-sound-hda-codec-via kmod-sound-via82xx kmod-sound-hda-intel kmod-sound-hda-codec-hdmi kmod-sound-i8x0 kmod-usb-audio \
-kmod-usb-net kmod-usb-net-asix kmod-usb-net-asix-ax88179 kmod-usb-net-rtl8150 kmod-usb-net-rtl8152
+kmod-usb-net kmod-usb-net-asix kmod-usb-net-asix-ax88179 kmod-usb-net-rtl8150 kmod-usb-net-rtl8152 kmod-r8168
 
 $(eval $(call BuildTarget))
 


### PR DESCRIPTION
`DEFAULT:=y`会导致所有 target 都会选上