### PR TITLE
npc: bump version to v0.26.8

### DIFF
--- a/package/lean/npc/Makefile
+++ b/package/lean/npc/Makefile
@@ -7,8 +7,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=npc
-PKG_VERSION:=0.26.7
-PKG_RELEASE:=2
+PKG_VERSION:=0.26.8
+PKG_RELEASE:=1
 
 ifeq ($(ARCH),mipsel)
 	NPC_ARCH:=mipsle


### PR DESCRIPTION
### NPC

* bump version to [v0.26.8](https://github.com/ehang-io/nps/releases/tag/v0.26.8)

* change logs => [nps-0.26.8](https://github.com/ehang-io/nps/releases/tag/v0.26.8)