### PR TITLE
linux-firmware: intel: Downgrade wifi firmware version for k4.19

### DIFF
--- a/package/firmware/linux-firmware/intel.mk
+++ b/package/firmware/linux-firmware/intel.mk
@@ -73,7 +73,7 @@ $(eval $(call BuildPackage,iwlwifi-firmware-iwl3160))
 Package/iwlwifi-firmware-iwl3168 = $(call Package/firmware-default,Intel Wireless 3168 firmware)
 define Package/iwlwifi-firmware-iwl3168/install
 	$(INSTALL_DIR) $(1)/lib/firmware
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/iwlwifi-3168-29.ucode $(1)/lib/firmware
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/iwlwifi-3168-27.ucode $(1)/lib/firmware
 endef
 $(eval $(call BuildPackage,iwlwifi-firmware-iwl3168))
 
@@ -157,14 +157,14 @@ $(eval $(call BuildPackage,iwlwifi-firmware-iwl8265))
 Package/iwlwifi-firmware-iwl9000 = $(call Package/firmware-default,Intel Wireless 9000 firmware)
 define Package/iwlwifi-firmware-iwl9000/install
 	$(INSTALL_DIR) $(1)/lib/firmware
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/iwlwifi-9000-pu-b0-jf-b0-46.ucode $(1)/lib/firmware
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/iwlwifi-9000-pu-b0-jf-b0-38.ucode $(1)/lib/firmware
 endef
 $(eval $(call BuildPackage,iwlwifi-firmware-iwl9000))
 
 Package/iwlwifi-firmware-iwl9260 = $(call Package/firmware-default,Intel Wireless 9260 firmware)
 define Package/iwlwifi-firmware-iwl9260/install
 	$(INSTALL_DIR) $(1)/lib/firmware
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/iwlwifi-9260-th-b0-jf-b0-46.ucode $(1)/lib/firmware
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/iwlwifi-9260-th-b0-jf-b0-38.ucode $(1)/lib/firmware
 endef
 $(eval $(call BuildPackage,iwlwifi-firmware-iwl9260))
 


### PR DESCRIPTION
Q：你知道这是`pull request`吗？
* [x] 我知道

降级Intel无线网卡的固件版本以修复9260AC、3168AC无线网卡在4.19内核上iwlwifi驱动模块报固件加载失败的错误。