### PR TITLE
fix k3screenctrl depends

### DIFF
--- a/package/lean/k3screenctrl/Makefile
+++ b/package/lean/k3screenctrl/Makefile
@@ -19,7 +19,7 @@ TARGET_CFLAGS+= -D_GNU_SOURCE
 define Package/k3screenctrl
   SECTION:=utils
   CATEGORY:=Utilities
-  DEPENDS:=@TARGET_bcm53xx_DEVICE_phicomm-k3 +@KERNEL_DEVMEM
+  DEPENDS:=@TARGET_bcm53xx_generic_DEVICE_phicomm-k3 +@KERNEL_DEVMEM
   TITLE:=LCD screen controller on PHICOMM K3
   URL:=https://github.com/updateing/k3-screen-ctrl
 endef


### PR DESCRIPTION
解决target名称变化造成k3screenctrl无法选中编译问题

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ x ] 我知道
