### PR TITLE
ramips: improve support for dir878/882

### DIFF
--- a/package/lean/mt/drivers/mt7615d/config.in
+++ b/package/lean/mt/drivers/mt7615d/config.in
@@ -744,7 +744,7 @@ config MTK_BAND_STEERING
 
 config MTK_LED_CONTROL_SUPPORT
 	bool "LED Control Support"
-	default n
+	default y
 
 config MTK_WLAN_HOOK
        bool "WLAN hook Support"

--- a/target/linux/ramips/dts/mt7621_dlink_dir-878-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-878-a1.dts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include "mt7621_dlink_dir-878-a1.dtsi"
+#include "mt7621_dlink_dir.dtsi"
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
@@ -31,12 +31,6 @@
 		net_green {
 			label = "dir-878-a1:green:net";
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
-		};
-		usb {
-		label = "dir-878-a1:green:usb";
-		gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
-		trigger-sources = <&xhci_ehci_port1>, <&ehci_port2>;
-		linux,default-trigger = "usbport";
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dir-882-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-882-a1.dts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include "mt7621_dlink_dir-878-a1.dtsi"
+#include "mt7621_dlink_dir.dtsi"
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
@@ -32,11 +32,12 @@
 			label = "dir-882-a1:green:net";
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 		};
+
 		usb {
-		label = "dir-882-a1:green:usb";
-		gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
-		trigger-sources = <&xhci_ehci_port1>, <&ehci_port2>;
-		linux,default-trigger = "usbport";
+			label = "dir-882-a1:green:usb";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>, <&ehci_port2>;
+			linux,default-trigger = "usbport";
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7621_dlink_dir.dtsi
+++ b/target/linux/ramips/dts/mt7621_dlink_dir.dtsi
@@ -14,6 +14,7 @@
 		led-upgrade = &led_power_green;
 		label-mac-device = &gmac0;
 	};
+
 	chosen {
 		bootargs = "console=ttyS0,57600";
 	};
@@ -147,7 +148,7 @@
 
 &state_default {
 	gpio {
-		groups = "uart3", "jtag", "wdt";
+		groups = "i2c", "uart3", "jtag", "wdt";
 		function = "gpio";
 	};
 };

--- a/target/linux/ramips/dts/mt7621_motorola_mr2600.dts
+++ b/target/linux/ramips/dts/mt7621_motorola_mr2600.dts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include "mt7621_dlink_dir-878-a1.dtsi"
+#include "mt7621_dlink_dir.dtsi"
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
@@ -32,11 +32,12 @@
 			label = "mr2600:green:net";
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 		};
+
 		usb {
-		label = "mr2600:green:usb";
-		gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
-		trigger-sources = <&xhci_ehci_port1>, <&ehci_port2>;
-		linux,default-trigger = "usbport";
+			label = "mr2600:green:usb";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>, <&ehci_port2>;
+			linux,default-trigger = "usbport";
 		};
 	};
 };

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -242,7 +242,8 @@ define Device/dlink_dir-882-a1
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-882
   DEVICE_VARIANT := A1
-  DEVICE_PACKAGES := kmod-mt7615d luci-app-mtwifi uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615d kmod-usb3 kmod-usb-ledtrig-usbport \
+	luci-app-mtwifi uboot-envtools
 endef
 TARGET_DEVICES += dlink_dir-882-a1
 
@@ -592,7 +593,8 @@ define Device/motorola_mr2600
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Motorola
   DEVICE_MODEL := MR2600
-  DEVICE_PACKAGES := kmod-mt7615d luci-app-mtwifi uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615d kmod-usb3 kmod-usb-ledtrig-usbport
+	luci-app-mtwifi uboot-envtools
 endef
 TARGET_DEVICES += motorola_mr2600
 
@@ -795,7 +797,7 @@ define Device/phicomm_k2p
   DEVICE_VENDOR := Phicomm
   DEVICE_MODEL := K2P
   SUPPORTED_DEVICES += k2p
-  DEVICE_PACKAGES := kmod-mt7615d luci-app-mtwifi kmod-mt_wifi
+  DEVICE_PACKAGES := kmod-mt7615d luci-app-mtwifi
 endef
 TARGET_DEVICES += phicomm_k2p
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -26,11 +26,15 @@ d-team,pbr-m1|\
 gehua,ghl-r-001)
 	ucidef_set_led_netdev "internet" "internet" "$boardname:blue:internet" "wan"
 	;;
-dlink,dir-860l-b1|\
-dlink,dir-882-a1|\
+dlink,dir-860l-b1)
+	ucidef_set_led_netdev "wan" "wan" "$boardname:green:net" "wan"
+	;;
 dlink,dir-878-a1|\
+dlink,dir-882-a1|\
 motorola,mr2600)
 	ucidef_set_led_netdev "wan" "wan" "$boardname:green:net" "wan"
+	ucidef_set_led_netdev "wlan2g" "WiFi 2.4GHz" "$boardname:green:wlan2g" "ra0"
+	ucidef_set_led_netdev "wlan5g" "WiFi 5GHz" "$boardname:green:wlan5g" "rai0"
 	;;
 gnubee,gb-pc1|\
 gnubee,gb-pc2)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -50,8 +50,8 @@ ramips_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan"
 		;;
 	netgear,r6850|\
-	dlink,dir-882-a1|\
 	dlink,dir-878-a1|\
+	dlink,dir-882-a1|\
 	motorola,mr2600)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 ra0 rai0" "wan"
 		;;


### PR DESCRIPTION
Added missing i2c groups and usb packages. Turn on the mt7615's leds support will not affect the machine without wifi led.