### PR TITLE
xlnetacc: adjust iface event handling strategy

### DIFF
--- a/package/lean/luci-app-xlnetacc/root/etc/hotplug.d/iface/95-xlnetacc
+++ b/package/lean/luci-app-xlnetacc/root/etc/hotplug.d/iface/95-xlnetacc
@@ -5,9 +5,9 @@
 
 case "$ACTION" in
 	ifup)
-		/etc/init.d/xlnetacc start
+		/etc/init.d/xlnetacc restart
 		;;
 	ifdown)
-		/etc/init.d/xlnetacc stop
+		#/etc/init.d/xlnetacc stop
 		;;
 esac


### PR DESCRIPTION
出于以下两个原因，调整快鸟服务对于iface事件的处理策略：
1. 快鸟服务跟随系统启动，ifup事件使快鸟服务重复启动，出现2个快鸟脚本运行实例（原始脚本对于重复运行的判断失效，原因未知）。修改为restart后可保证快鸟服务启动前关闭正在运行的快鸟服务。
2. ifdown事件后不应该立即停止快鸟服务。iface下线后，快鸟脚本无法访问快鸟服务器进行账户注销。未正常注销的账户在外部ip变动后重新上线会触发812错误（12或24小时内无法提速）。因此ifdown事件触发后不停止快鸟服务，而是等iface重新上线（网络恢复正常）后重启服务，以此保证账户注销流程可以正常进行。

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
