### PR TITLE
add check and format 'security' parameter in function  scan_app , and  function connect_ap add bssid option

### DIFF
--- a/package/lean/mt/luci-app-mtwifi/Makefile
+++ b/package/lean/mt/luci-app-mtwifi/Makefile
@@ -7,7 +7,7 @@ LUCI_TITLE:=LuCI support for mt wifi driver
 LUCI_DEPENDS:=@TARGET_ramips +mt_wifi
 LUCI_PKGARCH:=all
 PKG_VERSION:=1
-PKG_RELEASE:=15
+PKG_RELEASE:=16
 
 define Package/luci-app-mtwifi/conffiles
 /etc/wireless/mt7615/

--- a/package/lean/mt/luci-app-mtwifi/luasrc/controller/mtkwifi.lua
+++ b/package/lean/mt/luci-app-mtwifi/luasrc/controller/mtkwifi.lua
@@ -791,6 +791,9 @@ function apcli_connect(dev, vif)
         or cfgs.ApCliAuthMode == "WPA1PSKWPA2PSK" then
         os.execute("iwpriv "..vifname.." set ApCliWPAPSK="..cfgs.ApCliWPAPSK)
     end
+    if cfgs.ApCliBssid ~= nil then
+        os.execute("iwpriv "..vifname.." set ApCliBssid="..cfgs.ApCliBssid)
+    end
     os.execute("iwpriv "..vifname.." set ApCliSsid=\""..cfgs.ApCliSsid.."\"")
     os.execute("iwpriv "..vifname.." set ApCliEnable=1")
     luci.http.redirect(luci.dispatcher.build_url("admin", "network", "wifi"))

--- a/package/lean/mt/luci-app-mtwifi/luasrc/view/admin_mtk/mtk_wifi_apcli.htm
+++ b/package/lean/mt/luci-app-mtwifi/luasrc/view/admin_mtk/mtk_wifi_apcli.htm
@@ -86,6 +86,13 @@ local debug = 0
                 <td></td>
             </tr>
             <tr>
+                <td>BSSID</td>
+                <td>
+                    <input type="text" name="ApCliBssid" id="ApCliBssid" value="<%=cfgs.ApCliBssid%>"/>
+                </td>
+                <td><span style="color:green;">可选</span></td>
+            </tr>
+            <tr>
                 <td>上级无线信道</td>
                 <td>
                     <input type="text" name="Channel" id="Channel" value="<%=dev.Channel%>"/>
@@ -307,6 +314,7 @@ local debug = 0
 
     function choose_rootap(index) {
         document.getElementById("ApCliSsid").value=decode_ssid(ap_list[index].ssid);
+        document.getElementById("ApCliBssid").value=ap_list[index].bssid;
         document.getElementById("Channel").value=ap_list[index].channel;
         document.getElementById("ApCliAuthMode").value=ap_list[index].authmode;
         if (ap_list[index].authmode == "WPA2PSK"

--- a/package/lean/mt/luci-app-mtwifi/root/usr/lib/lua/mtkwifi.lua
+++ b/package/lean/mt/luci-app-mtwifi/root/usr/lib/lua/mtkwifi.lua
@@ -851,6 +851,10 @@ function mtkwifi.scan_ap(vifname)
             tmp.ssid = mtkwifi.__trim(string.sub(line, xx.SSID[1], xx.SSID[1]+xx.SSID[2]))
             tmp.bssid = string.upper(mtkwifi.__trim(string.sub(line, xx.BSSID[1], xx.BSSID[1]+xx.BSSID[2])))
             tmp.security = mtkwifi.__trim(string.sub(line, xx.Security[1], xx.Security[1]+xx.Security[2]))
+            tmp.security = string.gsub(tmp.security, "WPA1PSKWPA2PSK", "WPAPSKWPA2PSK")
+            if (string.find(tmp.security, "/") == nil) then
+                tmp.security = "OPEN" .. "/" .. tmp.security
+            end
             tmp.authmode = mtkwifi.__trim(string.split(tmp.security, "/")[1])
             tmp.encrypttype = mtkwifi.__trim(string.split(tmp.security, "/")[2] or "NONE")
             tmp.rssi = mtkwifi.__trim(string.sub(line, xx.Signal[1], xx.Signal[1]+xx.Signal[2]))


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
1. NEWIFI2D（新3路由）的5G，在使用`iwpriv`扫描周边无线热点时，所获取的`Security`有些不一样，表现主要有：‘WPAPSKWPA2PSK’显示为‘WPA1PSKWPA2PSK’，'OPEN/NONE'显示为'NONE‘，’OPEN/WEB‘显示为'WEB’，所以在scan_ap函数里处理Security信息时需要修改。
![1](https://user-images.githubusercontent.com/19186382/88556067-2768c380-d05b-11ea-8bb0-bc69f5d61b92.png)
![2](https://user-images.githubusercontent.com/19186382/88556072-29328700-d05b-11ea-96da-72866b4c85f6.png)

2. 添加bssid(ApCliBssid)选项（非强制使用），使用bssid，经过简单的测试，设置bssid可在多个相同cannel相同ssid中，连接目标路由，若在多个相同ssid的热点中，不存在指定bssid的热点，也会连接其它的热点。