### PR TITLE
Verysync:version bump to v1.44

### DIFF
--- a/package/lean/verysync/Makefile
+++ b/package/lean/verysync/Makefile
@@ -35,7 +35,7 @@ PKG_NAME:=verysync
 ifneq ($(LATEST_VERSION),)
 	PKG_VERSION:=$(LATEST_VERSION)
 else
-	PKG_VERSION:=v1.4.3
+	PKG_VERSION:=v1.4.4
 endif
 
 PKG_RELEASE:=1


### PR DESCRIPTION
Because there is no v1.43 program file on the verysync server.
So version bump to v1.44 to fix some compile problems.

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
