### PR TITLE
linux: improve exFAT support

### DIFF
--- a/package/kernel/exfat/Makefile
+++ b/package/kernel/exfat/Makefile
@@ -1,0 +1,55 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=exfat
+PKG_VERSION:=5.8.4
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/namjaejeon/linux-exfat-oot/tar.gz/$(PKG_VERSION)?
+PKG_HASH:=47162495bdf9a7e02d6142dfcd4364d7325a4cf75a0439926cf9e8a9d959627b
+
+PKG_MAINTAINER:=
+PKG_LICENSE:=GPL-2.0-only
+
+#PKG_BUILD_PARALLEL:=1
+#PKG_USE_MIPS16:=0
+
+# exfat-oot's makefile needs this to know where to build the kernel module
+#export KERNELDIR:=$(LINUX_DIR)
+
+include $(INCLUDE_DIR)/package.mk
+#include $(INCLUDE_DIR)/kernel-defaults.mk
+
+TAR_OPTIONS+= --strip-components 1
+TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
+
+define KernelPackage/fs-exfat
+  SECTION:=kernel
+  CATEGORY:=Kernel modules
+  SUBMENU:=Filesystems
+  TITLE:=exFAT kernel module
+  FILES:=$(PKG_BUILD_DIR)/exfat.ko
+  AUTOLOAD:=$(call AutoProbe,exfat)
+  DEPENDS:=+kmod-nls-base
+endef
+
+define KernelPackage/exfat/description
+  This package provides the kernel module for exfat.
+endef
+
+define Build/Compile
+	$(KERNEL_MAKE) M="$(PKG_BUILD_DIR)" \
+	EXTRA_CFLAGS="$(EXTRA_CFLAGS)" \
+	$(PKG_EXTRA_KCONFIG) \
+	CONFIG_EXFAT_FS=m \
+	modules
+#	$(MAKE) -C $(KERNEL_BUILD_DIR)/linux-$(LINUX_VERSION) M="$(PKG_BUILD_DIR)" modules
+endef
+
+$(eval $(call KernelPackage,fs-exfat))

--- a/package/kernel/exfat/patches/010-fstream.patch
+++ b/package/kernel/exfat/patches/010-fstream.patch
@@ -1,0 +1,23 @@
+--- a/super.c
++++ b/super.c
+@@ -292,14 +292,14 @@ static const struct fs_parameter_spec exfat_param_specs[] = {
+ #endif
+ 	fsparam_flag("discard",			Opt_discard),
+ 	fsparam_s32("time_offset",		Opt_time_offset),
+-	__fsparam(NULL, "utf8",			Opt_utf8, fs_param_deprecated,
+-		  NULL),
+-	__fsparam(NULL, "debug",		Opt_debug, fs_param_deprecated,
+-		  NULL),
++	__fsparam(NULL, "utf8",			Opt_utf8, fs_param_deprecated
++		  ),
++	__fsparam(NULL, "debug",		Opt_debug, fs_param_deprecated
++		  ),
+ 	__fsparam(fs_param_is_u32, "namecase",	Opt_namecase,
+-		  fs_param_deprecated, NULL),
++		  fs_param_deprecated),
+ 	__fsparam(fs_param_is_u32, "codepage",	Opt_codepage,
+-		  fs_param_deprecated, NULL),
++		  fs_param_deprecated),
+ 	{}
+ };
+ 

--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -163,30 +163,6 @@ endef
 $(eval $(call KernelPackage,fs-efivarfs))
 
 
-define KernelPackage/fs-exfat
-  SUBMENU:=$(FS_MENU)
-  TITLE:=exFAT filesystem support
-  KCONFIG:= \
-	CONFIG_EXFAT_FS \
-	CONFIG_EXFAT_DONT_MOUNT_VFAT=y \
-	CONFIG_EXFAT_DISCARD=y \
-	CONFIG_EXFAT_DELAYED_SYNC=n \
-	CONFIG_EXFAT_KERNEL_DEBUG=n \
-	CONFIG_EXFAT_DEBUG_MSG=n \
-	CONFIG_EXFAT_DEFAULT_CODEPAGE=437 \
-	CONFIG_EXFAT_DEFAULT_IOCHARSET="utf8"
-  FILES:=$(LINUX_DIR)/drivers/staging/exfat/exfat.ko
-  AUTOLOAD:=$(call AutoLoad,30,exfat,1)
-  DEPENDS:=@!(LINUX_4_14||LINUX_4_19) +kmod-nls-base
-endef
-
-define KernelPackage/fs-exfat/description
- Kernel module for exFAT filesystem support
-endef
-
-$(eval $(call KernelPackage,fs-exfat))
-
-
 define KernelPackage/fs-exportfs
   SUBMENU:=$(FS_MENU)
   TITLE:=exportfs kernel server support

--- a/package/lean/automount/Makefile
+++ b/package/lean/automount/Makefile
@@ -17,7 +17,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/automount
   TITLE:=Mount autoconfig hotplug script.
   MAINTAINER:=Lean
-  DEPENDS:=+block-mount +kmod-usb-storage +kmod-usb-storage-extras +!TARGET_ramips:kmod-usb-storage-uas +kmod-fs-vfat +kmod-fs-ext4 +!LINUX_5_4:kmod-fs-exfat0 +LINUX_5_4:kmod-fs-exfat +antfs-mount
+  DEPENDS:=+block-mount +kmod-usb-storage +kmod-usb-storage-extras +!TARGET_ramips:kmod-usb-storage-uas +kmod-fs-vfat +kmod-fs-ext4 +kmod-fs-exfat +antfs-mount
 endef
 
 define Package/automount/description


### PR DESCRIPTION
In openwrt/openwrt@cd41234:
```
Namjae Jeon:
Hm... exfat in 5.4 kernel  that we did crap shit long time ago is
contributed by someone who we don't know.
This version is unstable and low quality code. We have been improving
it continuously.
and staging version exfat is removed from linux 5.7 kernel.

linux exfat oot  version is a backport of exfat in linux 5.7 kernel to
support lower version kernel, and it is a real.
You can see the patch history fro linux-exfat-oot.
this version support timezone and boot sector verification feature newly.
and better filesystem structure and much clean code quality that
reviewed by high profile kernel developers. and add many bug fixes.
And this version is officially maintained by me and kernel guys.

I would not recommend to use staging exfat version.
```