### PR TITLE
Fix baidupcs-web file name to fit i386 device

### DIFF
--- a/package/lean/baidupcs-web/Makefile
+++ b/package/lean/baidupcs-web/Makefile
@@ -30,7 +30,7 @@ endef
 STRIP:=true
 
 ifeq ($(ARCH),i386)
-	PKG_ARCH_BAIDUPCS-WEB:=86
+	PKG_ARCH_BAIDUPCS-WEB:=386
 endif
 
 ifeq ($(ARCH),x86_64)


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

在编译适用于 x86_generic (x86 平台 32 位) 设备固件的过程中，进行到下载 baidupcs-web 源码包这一步时出现 "文件不存在" 的错误，经核对为文件名问题，故修复~