### PR TITLE
Coremark: use the general way to detect 64bit or not.

### DIFF
--- a/package/lean/coremark/Makefile
+++ b/package/lean/coremark/Makefile
@@ -37,10 +37,9 @@ endef
 
 DIR_ARCH:=linux
 
-ifeq ($(ARCH),x86_64)
+ifeq ($(CONFIG_ARCH_64BIT),y)
 	DIR_ARCH:=linux64
-endif
-ifeq ($(ARCH),aarch64)
+else ifeq ($(CONFIG_64BIT),y)
 	DIR_ARCH:=linux64
 endif
 


### PR DESCRIPTION
64bit架构不止这两类，
这样判断可能会更通用

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
