### PR TITLE
Update to verysync 1.5.5 version

### DIFF
--- a/package/lean/verysync/Makefile
+++ b/package/lean/verysync/Makefile
@@ -35,7 +35,7 @@ PKG_NAME:=verysync
 ifneq ($(LATEST_VERSION),)
 	PKG_VERSION:=$(LATEST_VERSION)
 else
-	PKG_VERSION:=v1.4.3
+	PKG_VERSION:=v1.5.5
 endif
 
 PKG_RELEASE:=1


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

verysync官网删了1.4.3源码，更新最新1.55