### PR TITLE
dns2sock: use github source instead

### DIFF
--- a/package/lean/dns2socks/Makefile
+++ b/package/lean/dns2socks/Makefile
@@ -2,45 +2,32 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dns2socks
 PKG_VERSION:=2.1
-PKG_RELEASE:=20200218
+PKG_RELEASE:=1
 
-PKG_SOURCE:=SourceCode.zip
-PKG_SOURCE_SUBDIR:=DNS2SOCKS
-PKG_SOURCE_URL:=@SF/dns2socks
-PKG_MD5SUM:=ec82de936ad004cc940502cd2a1bff5b
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/kongfl888/dns2socks.git
+PKG_SOURCE_VERSION:=HEAD
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_LICENSE:=GPL-3.0
+PKG_MAINTAINER:=kongfl888 <kongfl888@outlook.com>
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
 
-PKG_MAINTAINER:=ghostmaker
-PKG_LICENSE:=BSD-3-Clause
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
-
-PKG_INSTALL:=1
 PKG_USE_MIPS16:=0
 PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/dns2socks/Default
+define Package/dns2socks
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=IP Addresses and Names
   TITLE:=The utility to resolve DNS requests via a SOCKS5 tunnel.
-  URL:=http://dns2socks.sourceforge.net/
-  MAINTAINER:=ghostmaker
+  URL:=https://sourceforge.net/projects/dns2socks/
   DEPENDS:=+libpthread
-endef
-
-define Package/dns2socks
-	$(call Package/dns2socks/Default)
 endef
 
 define Package/dns2socks/description
   This is a utility to resolve DNS requests via a SOCKS5 tunnel and caches the answers.
-endef
-
-define Build/Prepare
-	mkdir -p $(PKG_BUILD_DIR)
-	unzip $(DL_DIR)/$(PKG_SOURCE) -d $(PKG_BUILD_DIR)
 endef
 
 define Build/Compile
@@ -48,17 +35,14 @@ define Build/Compile
 	$(TARGET_CFLAGS) \
 	$(TARGET_CPPFLAGS) \
 	$(FPIC) \
-	-o $(PKG_BUILD_DIR)/$(PKG_SOURCE_SUBDIR)/$(PKG_NAME) \
-	$(PKG_BUILD_DIR)/$(PKG_SOURCE_SUBDIR)/DNS2SOCKS.c \
+	-o $(PKG_BUILD_DIR)/DNS2SOCKS/$(PKG_NAME) \
+	$(PKG_BUILD_DIR)/DNS2SOCKS/DNS2SOCKS.c \
 	$(TARGET_LDFLAGS) -pthread
-endef
-
-define Build/Install
 endef
 
 define Package/dns2socks/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(PKG_SOURCE_SUBDIR)/$(PKG_NAME) $(1)/usr/bin/dns2socks
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/DNS2SOCKS/$(PKG_NAME) $(1)/usr/bin/dns2socks
 endef
 
 $(eval $(call BuildPackage,dns2socks))


### PR DESCRIPTION
换用GitHub源避免SF重定向，减少出错 #5367（出错一次，编译的时间不止x2 〒▽〒）。

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
