### PR TITLE
RcloneNg: bump version from 0.4.0 to 0.5.0

### DIFF
--- a/package/lean/rclone-ng/Makefile
+++ b/package/lean/rclone-ng/Makefile
@@ -10,7 +10,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rclone-ng
-PKG_VERSION:=0.4.0
+PKG_VERSION:=0.5.0
 PKG_RELEASE:=1
 
 
@@ -22,7 +22,7 @@ include $(INCLUDE_DIR)/package.mk
 PKG_SOURCE:=RcloneNg-v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/ElonH/RcloneNg/releases/download/v$(PKG_VERSION)/
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
-PKG_HASH:=d974d5476b89281dcc14b0081e26f286041dd799898bc6b163d349d504056bd1
+PKG_HASH:=0b4916ddd0bacb5b358dc8d36b64c30f4182c0ace3eb06cda94b6578c419dcd9
 
 define Package/$(PKG_NAME)
 	SECTION:=net


### PR DESCRIPTION
ChangeLog：https://github.com/ElonH/RcloneNg/releases/tag/v0.5.0