### PR TITLE
Bump mt76 from 2020-08-22 to 2020-08-25

### DIFF
--- a/package/kernel/mt76/Makefile
+++ b/package/kernel/mt76/Makefile
@@ -8,9 +8,9 @@ PKG_LICENSE_FILES:=
 
 PKG_SOURCE_URL:=https://github.com/openwrt/mt76
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_DATE:=2020-08-22
-PKG_SOURCE_VERSION:=8c7c1a207d25cd880c7f54d3fe86e82f14d6ecda
-PKG_MIRROR_HASH:=0411bc634cb4065f748754e02758c172a4c65298696667f198c41d580d165d69
+PKG_SOURCE_DATE:=2020-08-25
+PKG_SOURCE_VERSION:=b36d7ae096a3d8c7d6a8a246f2e8a471a467041e
+PKG_MIRROR_HASH:=da35e999f1bd50ce7061125ccb976129c8485e3593521206831380846953d3cf
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_BUILD_PARALLEL:=1
@@ -333,6 +333,7 @@ define KernelPackage/mt76x2u/install
 	$(INSTALL_DIR) $(1)/lib/firmware/mediatek
 	ln -sf ../mt7662.bin $(1)/lib/firmware/mediatek/mt7662u.bin
 	ln -sf ../mt7662_rom_patch.bin $(1)/lib/firmware/mediatek/mt7662u_rom_patch.bin
+	echo mt76-usb disable_usb_sg=1 > $(1)/etc/modules.d/mt76-usb
 endef
 
 define KernelPackage/mt7603/install


### PR DESCRIPTION
This update fix clients can not get correct IP address on mt76x2u
Then add disable_usb_sg module parameter to fix wireless devices crash when multi-devices connect to mt76x2u devices (Line 336)
Details: https://github.com/openwrt/mt76/issues/405#issuecomment-665737497
