### PR TITLE
Update to frp 0.34.0 version

### DIFF
--- a/package/lean/frp/Makefile
+++ b/package/lean/frp/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=frp
-PKG_VERSION:=0.33.0
+PKG_VERSION:=0.34.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz


### PR DESCRIPTION
New
Support TLS certificate and mutual TLS authentication.
Support set max UDP package size, default is 1500.
New e2e test framework.
Fix
UDP and SUDP proxy don't support compression and encrytion.
Call server plugins in fixed order.

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
