### PR TITLE
if wan iface set to apcli0 or apclii0 while wireless relay, add them …

### DIFF
--- a/package/lean/mt/drivers/mt_wifi/files/mt7615.lua
+++ b/package/lean/mt/drivers/mt_wifi/files/mt7615.lua
@@ -25,6 +25,10 @@ end
 
 function add_vif_into_lan(vif)
     local mtkwifi = require("mtkwifi")
+    local wanif = mtkwifi.__trim(mtkwifi.read_pipe("uci get network.wan.ifname"))
+    if (string.match(vif, wanif)) then
+        return
+    end
     local brvifs = mtkwifi.__trim(
         mtkwifi.read_pipe("uci get network.lan.ifname"))
     if not string.match(brvifs, esc(vif)) then
@@ -98,6 +102,7 @@ function mt7615_up(devname)
     end
 
     os.execute(" rm -rf /tmp/mtk/wifi/mt7615*.need_reload")
+    os.execute("/etc/init.d/network restart")
 end
 
 function mt7615_down(devname)


### PR DESCRIPTION
…to lan should be avoided

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x ] 我知道

我在使用无线中继的时候，发现如果使用中继接口作为wan的接口时，现有驱动还是会将该接口加入lan口，导致wan口获取不到ip地址，这是我实测可以解决的改动