### PR TITLE
mtwifi: mt7615: fix multi-profile merge

### DIFF
--- a/package/lean/mt/drivers/mt_wifi/files/dbdc.l1profile.dat
+++ b/package/lean/mt/drivers/mt_wifi/files/dbdc.l1profile.dat
@@ -1,12 +1,12 @@
 Default
 INDEX0=MT7615
-INDEX0_profile_path=/etc/wireless/mt7615/mt7615.1.2G.dat;/etc/wireless/mt7615/mt7615.1.5G.dat
+INDEX0_profile_path=/etc/wireless/mt7615/mt7615.1.5G.dat;/etc/wireless/mt7615/mt7615.1.2G.dat
 INDEX0_EEPROM_offset=0x0
 INDEX0_EEPROM_size=0x4000
 INDEX0_EEPROM_name=e2p
-INDEX0_main_ifname=rax0;ra0
-INDEX0_ext_ifname=rax;ra
-INDEX0_wds_ifname=wdsx;wds
-INDEX0_apcli_ifname=apclix;apcli
+INDEX0_main_ifname=ra0;rax0
+INDEX0_ext_ifname=ra;rax
+INDEX0_wds_ifname=wds;wdsx
+INDEX0_apcli_ifname=apcli;apclix
 INDEX0_single_sku_path=/etc_ro/Wireless/SingleSKU_mt7615e-sku.dat
 INDEX0_bf_sku_path=/etc_ro/Wireless/SingleSKU_mt7615e-sku-bf.dat

--- a/package/lean/mt/drivers/mt_wifi/files/mt7615.lua
+++ b/package/lean/mt/drivers/mt_wifi/files/mt7615.lua
@@ -176,8 +176,8 @@ function mt7615_restart(devname)
     local nixio = require("nixio")
     nixio.syslog("debug", "mt7615_restart called!")
     mt7615_down(devname)
-    os.execute("rmmod mt7615")
-    os.execute("modprobe mt7615")
+    os.execute("rmmod mt_wifi")
+    os.execute("modprobe mt_wifi")
     mt7615_up(devname)
 end
 


### PR DESCRIPTION
设备：k2p

当前很多无线配置无法生效或者莫名其妙，例如配置CountryRegion、Channel或者AutoChannelSelect。

经过调查发现驱动在内部会对两个配置文件作合并。合并双配置文件的时候，如果编译开启了DEFAULT_5G_PROFILE，会假设l1profile的profile_path中第一个为5g配置，第二个为2g配置。依据此顺序从两个文件提取需要的设置。目前默认提供的l1profile的顺序是2g5g，导致很多配置项实际上采纳了对方配置文件的内容，产生了混乱。

修改后配置功能正常。

麻烦@AmadeusGhost 看看有没有什么问题。

应该也能解决这个评论提到的问题：
https://github.com/coolsnowwolf/lede/issues/5002#issuecomment-696463636

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

References:
- https://github.com/coolsnowwolf/lede/blob/099439f051a8b2393554eb26cec2df074f653fae/package/lean/mt/drivers/mt7615d/Makefile#L52
- https://github.com/coolsnowwolf/lede/blob/099439f051a8b2393554eb26cec2df074f653fae/package/lean/mt/drivers/mt7615d/src/mt_wifi/os/linux/rt_profile.c#L211
