### PR TITLE
kernel: bump 5.4 to 5.4.70

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -8,11 +8,11 @@ endif
 
 LINUX_VERSION-4.14 = .195
 LINUX_VERSION-4.19 = .138
-LINUX_VERSION-5.4 = .69
+LINUX_VERSION-5.4 = .70
 
 LINUX_KERNEL_HASH-4.14.195 = 394f28798670240baacd9e2cce521fbd79f8da5e1fc191695b0e11381445a021
 LINUX_KERNEL_HASH-4.19.138 = d15c27d05f6c527269b75b30cc72972748e55720e7e00ad8abbaa4fe3b1d5e02
-LINUX_KERNEL_HASH-5.4.69 = a8b31d716b397303a183e42ad525ff2871024a43e3ea530d0fdf73b7f9d27da7
+LINUX_KERNEL_HASH-5.4.70 = c0b3d8085c5ba235df38b00b740e053659709e8a5ca21957a239f6bc22c45007
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -8,11 +8,11 @@ endif
 
 LINUX_VERSION-4.14 = .195
 LINUX_VERSION-4.19 = .138
-LINUX_VERSION-5.4 = .70
+LINUX_VERSION-5.4 = .71
 
 LINUX_KERNEL_HASH-4.14.195 = 394f28798670240baacd9e2cce521fbd79f8da5e1fc191695b0e11381445a021
 LINUX_KERNEL_HASH-4.19.138 = d15c27d05f6c527269b75b30cc72972748e55720e7e00ad8abbaa4fe3b1d5e02
-LINUX_KERNEL_HASH-5.4.70 = c0b3d8085c5ba235df38b00b740e053659709e8a5ca21957a239f6bc22c45007
+LINUX_KERNEL_HASH-5.4.71 = 737049ef3cf38d46ee3b377354336cdbc1c4dd95b4e54975a70716f96c8d6cc7
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))


### PR DESCRIPTION
All modifications made by update_kernel.sh

Build system: x86_64
Build-tested: ipq806x/R7800, ath79/generic, bcm27xx/bcm2711
Run-tested: ipq806x/R7800

No dmesg regressions, everything functional

Signed-off-by: John Audia <graysky@archlinux.us>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
