### PR TITLE
ramips: ralink: rename some functions

### DIFF
--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_debugfs.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_debugfs.c
@@ -33,7 +33,7 @@ static const char *mtk_foe_packet_type_str[] = {
 #define IPV4_HNAPT                      0
 #define IPV4_HNAT                       1
 #define IS_IPV4_HNAPT(x)	(((x)->bfib1.pkt_type == IPV4_HNAPT) ? 1: 0)
-struct mtk_eth *_eth;
+static struct mtk_eth *_eth;
 #define es(entry)		(mtk_foe_entry_state_str[entry->bfib1.state])
 //#define ei(entry, end)		(MTK_PPE_TBL_SZ - (int)(end - entry))
 #define ei(entry, end)		(MTK_PPE_ENTRY_CNT - (int)(end - entry))
@@ -99,7 +99,7 @@ static const struct file_operations mtk_ppe_debugfs_foe_fops = {
 	.release = single_release,
 };
 
-int mtk_ppe_debugfs_init(struct mtk_eth *eth)
+int ra_ppe_debugfs_init(struct mtk_eth *eth)
 {
 	struct dentry *root;
 

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -961,7 +961,7 @@ static int fe_poll_rx(struct napi_struct *napi, int budget,
 					       RX_DMA_VID(trxd.rxd3));
 
 #ifdef CONFIG_NET_RALINK_OFFLOAD
-		if (mtk_offload_check_rx(priv, skb, trxd.rxd4) == 0) {
+		if (ra_offload_check_rx(priv, skb, trxd.rxd4) == 0) {
 #endif
 			stats->rx_packets++;
 			stats->rx_bytes += pktlen;
@@ -1309,7 +1309,7 @@ static int fe_open(struct net_device *dev)
 	fe_int_enable(priv->soc->tx_int | priv->soc->rx_int);
 	netif_start_queue(dev);
 #ifdef CONFIG_NET_RALINK_OFFLOAD
-	mtk_ppe_probe(priv);
+	ra_ppe_probe(priv);
 #endif
 
 	return 0;
@@ -1348,7 +1348,7 @@ static int fe_stop(struct net_device *dev)
 	fe_free_dma(priv);
 
 #ifdef CONFIG_NET_RALINK_OFFLOAD
-	mtk_ppe_remove(priv);
+	ra_ppe_remove(priv);
 #endif
 
 	return 0;

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.h
@@ -519,14 +519,14 @@ static inline void *priv_netdev(struct fe_priv *priv)
 	return (char *)priv - ALIGN(sizeof(struct net_device), NETDEV_ALIGN);
 }
 
-int mtk_ppe_probe(struct fe_priv *eth);
-void mtk_ppe_remove(struct fe_priv *eth);
+int ra_ppe_probe(struct fe_priv *eth);
+void ra_ppe_remove(struct fe_priv *eth);
 int mtk_flow_offload(struct fe_priv *eth,
 		     enum flow_offload_type type,
 		     struct flow_offload *flow,
 		     struct flow_offload_hw_path *src,
 		     struct flow_offload_hw_path *dest);
-int mtk_offload_check_rx(struct fe_priv *eth, struct sk_buff *skb, u32 rxd4);
+int ra_offload_check_rx(struct fe_priv *eth, struct sk_buff *skb, u32 rxd4);
 
 
 #endif /* FE_ETH_H */

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_offload.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_offload.c
@@ -301,7 +301,7 @@ static int mtk_init_foe_table(struct mtk_eth *eth)
 	return 0;
 }
 
-static int mtk_ppe_start(struct mtk_eth *eth)
+static int ra_ppe_start(struct mtk_eth *eth)
 {
 	int ret;
 
@@ -425,7 +425,7 @@ static int mtk_ppe_busy_wait(struct mtk_eth *eth)
 	return -ETIMEDOUT;
 }
 
-static int mtk_ppe_stop(struct mtk_eth *eth)
+static int ra_ppe_stop(struct mtk_eth *eth)
 {
 	u32 r1 = 0, r2 = 0;
 	int i;
@@ -501,7 +501,7 @@ static void mtk_offload_keepalive(struct fe_priv *eth, unsigned int hash)
 	rcu_read_unlock();
 }
 
-int mtk_offload_check_rx(struct fe_priv *eth, struct sk_buff *skb, u32 rxd4)
+int ra_offload_check_rx(struct fe_priv *eth, struct sk_buff *skb, u32 rxd4)
 {
 	unsigned int hash;
 
@@ -519,22 +519,22 @@ int mtk_offload_check_rx(struct fe_priv *eth, struct sk_buff *skb, u32 rxd4)
 	}
 }
 
-int mtk_ppe_probe(struct mtk_eth *eth)
+int ra_ppe_probe(struct mtk_eth *eth)
 {
 	int err;
 
-	err = mtk_ppe_start(eth);
+	err = ra_ppe_start(eth);
 	if (err)
 		return err;
 
-	err = mtk_ppe_debugfs_init(eth);
+	err = ra_ppe_debugfs_init(eth);
 	if (err)
 		return err;
 
 	return 0;
 }
 
-void mtk_ppe_remove(struct mtk_eth *eth)
+void ra_ppe_remove(struct mtk_eth *eth)
 {
-	mtk_ppe_stop(eth);
+	ra_ppe_stop(eth);
 }

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_offload.h
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_offload.h
@@ -255,6 +255,6 @@ enum mtk_foe_cpu_reason {
 #define MTK_PPE_TBL_SZ			\
 			(MTK_PPE_ENTRY_CNT * sizeof(struct mtk_foe_entry))
 
-int mtk_ppe_debugfs_init(struct mtk_eth *eth);
+int ra_ppe_debugfs_init(struct mtk_eth *eth);
 
 


### PR DESCRIPTION
fix #5693, fix #5695 , fix #5696 , fix #5702 