### PR TITLE
判断变量wanif是否不为空字符串

### DIFF
--- a/package/lean/mt/drivers/mt_wifi/files/mt7615.lua
+++ b/package/lean/mt/drivers/mt_wifi/files/mt7615.lua
@@ -26,7 +26,7 @@ end
 function add_vif_into_lan(vif)
     local mtkwifi = require("mtkwifi")
     local wanif = mtkwifi.__trim(mtkwifi.read_pipe("uci get network.wan.ifname"))
-    if (string.match(vif, wanif)) then
+    if ('' ~= wanif and string.match(vif, wanif)) then
         return
     end
     local brvifs = mtkwifi.__trim(


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

进行有线桥接(Lan to Lan)时，常常会删除WAN接口，而当删除WAN接口后，变量wanif是空字符串，导致函数执行了return，从而导致函数没有对network.lan.ifname进行操作。