### PR TITLE
充分使用wndr4300的flash空间。不修改的话只剩4MB 空闲，修改后有60MB空闲

### DIFF
--- a/target/linux/ar71xx/image/ubinize-wndr4300.ini
+++ b/target/linux/ar71xx/image/ubinize-wndr4300.ini
@@ -11,6 +11,7 @@ vol_type=dynamic
 vol_name=rootfs
 # Autoresize volume at first mount
 # vol_flags=autoresize
+vol_size=128MiB
 
 [rootfs_data]
 # Volume mode (other option is static)


### PR DESCRIPTION
wndr4300路由器内部的内存有128MB可以使用，但是刷openwrt固件中有部分被保留无法使用。修改rootfs后可以释放这部分空间。已经过我本人测试。该改动只会影响wndr4300 v1路由器
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ v] 我知道
