### PR TITLE
ramips: add support for JCG Y2

### DIFF
--- a/package/lean/mt/drivers/mt7615d/config.in
+++ b/package/lean/mt/drivers/mt7615d/config.in
@@ -47,7 +47,9 @@ endchoice
 
 choice
 	prompt "Choose Second WiFi Interface"
-	default MTK_SECOND_IF_NONE if TARGET_ramips_mt7621_DEVICE_phicomm_k2p || PACKAGE_kmod-mt7603e
+	default MTK_SECOND_IF_NONE if PACKAGE_kmod-mt7603e
+	default MTK_SECOND_IF_NONE if TARGET_ramips_mt7621_DEVICE_jcg_y2
+	default MTK_SECOND_IF_NONE if TARGET_ramips_mt7621_DEVICE_phicomm_k2p
 	default MTK_SECOND_IF_MT7615E
 
 config MTK_SECOND_IF_NONE
@@ -273,12 +275,14 @@ config MTK_DBDC_MODE
 	depends on MTK_CHIP_MT7615E || MTK_CHIP_MT7626
 	select MULTI_PROFILE_SUPPORT
 	select DEFAULT_5G_PROFILE
+	default y if TARGET_ramips_mt7621_DEVICE_jcg_y2
 	default y if TARGET_ramips_mt7621_DEVICE_phicomm_k2p
 	default n
 
 config MTK_MULTI_PROFILE_SUPPORT
 	bool "Multi Profile Support"
 	depends on MTK_DBDC_MODE
+	default y if TARGET_ramips_mt7621_DEVICE_jcg_y2
 	default y if TARGET_ramips_mt7621_DEVICE_phicomm_k2p
 	default n
 
@@ -286,6 +290,7 @@ config MTK_DEFAULT_5G_PROFILE
 	bool "5G default profile for DBDC"
 	depends on MTK_DBDC_MODE
 #	depends on MTK_MULTI_PROFILE_SUPPORT
+	default y if TARGET_ramips_mt7621_DEVICE_jcg_y2
 	default y if TARGET_ramips_mt7621_DEVICE_phicomm_k2p
 	default n
 

--- a/package/lean/mt/drivers/mt_wifi/config.in
+++ b/package/lean/mt/drivers/mt_wifi/config.in
@@ -19,6 +19,7 @@ config MTK_CHIP_MT7615E
 config MTK_CHIP_MT7615E_DBDC
 	bool "MTK_CHIP_MT7615E_DBDC"
 	depends on MTK_CHIP_MT7615E
+	default y if TARGET_ramips_mt7621_DEVICE_jcg_y2
 	default y if TARGET_ramips_mt7621_DEVICE_phicomm_k2p
 	default n
 

--- a/target/linux/ramips/dts/mt7621_jcg_y2.dts
+++ b/target/linux/ramips/dts/mt7621_jcg_y2.dts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "jcg,y2", "mediatek,mt7621-soc";
+	model = "JCG Y2";
+
+	aliases {
+		led-boot = &led_internet;
+		led-failsafe = &led_internet;
+		led-upgrade = &led_internet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_internet: internet {
+			label = "y2:blue:internet";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&ethernet {
+	compatible = "mediatek,ralink-mt7621-eth";
+	mediatek,switch = <&gsw>;
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&switch0 {
+	/delete-property/ compatible;
+	phy-mode = "rgmii";
+};
+
+&gsw {
+	compatible = "mediatek,ralink-mt7621-gsw";
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -500,6 +500,18 @@ define Device/jcg_jhr-ac876m
 endef
 TARGET_DEVICES += jcg_jhr-ac876m
 
+define Device/jcg_y2
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 16064k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | jcg-header 95.1
+  JCG_MAXSIZE := 16064k
+  DEVICE_VENDOR := JCG
+  DEVICE_MODEL := Y2
+  DEVICE_PACKAGES := kmod-mt7615d kmod-usb3 luci-app-mtwifi
+endef
+TARGET_DEVICES += jcg_y2
+
 define Device/jdcloud_re-sp-01b
   IMAGE_SIZE := 27328k
   DEVICE_VENDOR := JDCloud

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -36,7 +36,8 @@ motorola,mr2600)
 	ucidef_set_led_netdev "wlan2g" "WiFi 2.4GHz" "$boardname:green:wlan2g" "ra0"
 	ucidef_set_led_netdev "wlan5g" "WiFi 5GHz" "$boardname:green:wlan5g" "rai0"
 	;;
-gehua,ghl-r-001)
+gehua,ghl-r-001|\
+jcg,y2)
 	ucidef_set_led_switch "internet" "internet" "$boardname:blue:internet" "switch0" "0x10"
 	;;
 gnubee,gb-pc1|\

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -36,6 +36,11 @@ ramips_setup_interfaces()
 	gnubee,gb-pc2)
 		ucidef_set_interface_lan "lan1 lan2"
 		;;
+	jcg,y2)
+		ucidef_add_switch "switch0" \
+			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "6@eth0"
+		ucidef_set_interface_lan "eth0.1 ra0 rax0"
+		;;
 	linksys,re6500|\
 	netgear,wac104)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
@@ -136,6 +141,11 @@ ramips_setup_macs()
 	iodata,wnpr2600g)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env wanaddr)
 		label_mac=$wan_mac
+		;;
+	jcg,y2)
+		lan_mac=$(cat /sys/class/net/eth0/address)
+		wan_mac=$(mtd_get_mac_binary factory 0xe006)
+		label_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
 	linksys,ea7500-v2)
 		lan_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)


### PR DESCRIPTION
```
JCG Y2 is an AC1300M router

Hardware specs:
  SoC: MediaTek MT7621AT
  Flash: Winbond W25Q128JVSQ 16MiB
  RAM: Nanya NT5CB128M16 256MiB
  2.4GHz: MT7615D 2x2
  5GHz: MT7615D 2x2
  Ethernet: 1 x WAN and 4 x LAN
  LED: POWER, INTERNET, 2.4G, 5G
  USB: 1 x 3.0
  Button: Reset

Flash instructions:
  Upload factory.bin in stock firmware's upgrade page.
```