### PR TITLE
京东云RE-SP-01B Flash实际可用不足32M ，删除mini oem 两个分区 充分利用32M空间

### DIFF
--- a/target/linux/ramips/dts/mt7621_jdcloud_re-sp-01b.dts
+++ b/target/linux/ramips/dts/mt7621_jdcloud_re-sp-01b.dts
@@ -91,20 +91,9 @@
 			partition@50000 {
 				compatible = "denx,uimage";
 				label = "firmware";
-				reg = <0x50000 0x1ab0000>;
+				reg = <0x50000 0x1fb0000>;
 			};
 
-			partition@1b00000 {
-				label = "mini";
-				reg = <0x1b00000 0x400000>;
-				read-only;
-			};
-
-			partition@1f00000 {
-				label = "oem";
-				reg = <0x1f00000 0x100000>;
-				read-only;
-			};
 		};
 	};
 };

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -513,7 +513,7 @@ endef
 TARGET_DEVICES += jcg_y2
 
 define Device/jdcloud_re-sp-01b
-  IMAGE_SIZE := 27328k
+  IMAGE_SIZE := 32448k
   DEVICE_VENDOR := JDCloud
   DEVICE_MODEL := RE-SP-01B
   DEVICE_PACKAGES := kmod-fs-ext4 kmod-mt7603 kmod-mt7615e kmod-sdhci-mt7620 \


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x ] 我知道
 
修改dts文件删除mini oem 两个分区 ,修改IMAGE_SIZE := 32448k