### PR TITLE
Update gen_config.lua

### DIFF
--- a/package/lean/luci-app-v2ray-server/luasrc/model/cbi/v2ray_server/api/gen_config.lua
+++ b/package/lean/luci-app-v2ray-server/luasrc/model/cbi/v2ray_server/api/gen_config.lua
@@ -125,9 +125,9 @@ function gen_config(user)
                         header = {
                             type = user.tcp_guise,
                             request = (user.tcp_guise == "http") and {
-                                path = {user.tcp_guise_http_path} or {"/"},
+                                path = user.tcp_guise_http_path or {"/"},
                                 headers = {
-                                    Host = {user.tcp_guise_http_host} or {}
+                                    Host = user.tcp_guise_http_host or {}
                                 }
                             } or nil
                         }


### PR DESCRIPTION
修复HTTP伪装时生成错误的配置文件。

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x ] 我知道


脚本错误，会导致server无法启动。