### PR TITLE
Revert "mtwifi: enable autoload by default"

### DIFF
--- a/package/lean/mt/drivers/mt7603e/Makefile
+++ b/package/lean/mt/drivers/mt7603e/Makefile
@@ -38,7 +38,6 @@ define KernelPackage/mt7603e
   TITLE:=MTK wifi AP driver
   DEPENDS:=@TARGET_ramips
   FILES:=$(PKG_BUILD_DIR)/mt7603_wifi_ap/mt7603e.ko
-  AUTOLOAD:=$(call AutoLoad,91,mt7603e)
   SUBMENU:=Wireless Drivers
   MENU:=1
 endef

--- a/package/lean/mt/drivers/mt7612e/Makefile
+++ b/package/lean/mt/drivers/mt7612e/Makefile
@@ -26,7 +26,6 @@ define KernelPackage/mt76x2e
   TITLE:=MTK MT76x2e wifi AP driver
   DEPENDS:=@TARGET_ramips
   FILES:=$(PKG_BUILD_DIR)/mt76x2_ap/mt76x2_ap.ko
-  AUTOLOAD:=$(call AutoLoad,90,mt76x2_ap)
   SUBMENU:=Wireless Drivers
   MENU:=1
 endef

--- a/package/lean/mt/drivers/mt7615d/Makefile
+++ b/package/lean/mt/drivers/mt7615d/Makefile
@@ -188,7 +188,7 @@ ifneq ($(CONFIG_MTK_WHNAT_SUPPORT), )
   AUTOLOAD:=$(call AutoProbe,mt_wifi mt_whnat)
 else
   FILES:=$(PKG_BUILD_DIR)/mt_wifi_ap/mt_wifi.ko
-  AUTOLOAD:=$(call AutoLoad,90,mt_wifi)
+  AUTOLOAD:=$(call AutoProbe,mt_wifi)
 endif
   SUBMENU:=Wireless Drivers
   MENU:=1

--- a/package/lean/mt/drivers/mt_wifi/Makefile
+++ b/package/lean/mt/drivers/mt_wifi/Makefile
@@ -42,6 +42,7 @@ define Package/mt_wifi/install
 	$(INSTALL_DIR) $(1)/lib/wifi/
 	$(INSTALL_DIR) $(1)/etc/wireless/mt7615/
 	$(INSTALL_DIR) $(1)/etc_ro/Wireless/RT2860AP/
+	$(INSTALL_DIR) $(1)/lib/preinit/
 ifeq ($(CONFIG_MTK_CHIP_MT7603E_MT7612E),y)
 	$(INSTALL_BIN) ./files/7603_7612-l1profile.dat $(1)/etc/wireless/l1profile.dat
 	$(INSTALL_BIN) ./files/mt7603.dat $(1)/etc/wireless/mt7615/mt7615.1.dat
@@ -65,6 +66,7 @@ endif
 	$(INSTALL_BIN) ./files/SingleSKU_BF.dat $(1)/etc_ro/Wireless/RT2860AP/
 	$(INSTALL_BIN) ./files/mt7615.lua $(1)/lib/wifi
 	$(INSTALL_BIN) ./files/firmware.sh $(1)/etc/init.d/
+	$(INSTALL_BIN) ./files/91_load_wifi.sh $(1)/lib/preinit/
 endef
 
 $(eval $(call BuildPackage,mt_wifi))

--- a/package/lean/mt/drivers/mt_wifi/files/91_load_wifi.sh
+++ b/package/lean/mt/drivers/mt_wifi/files/91_load_wifi.sh
@@ -1,0 +1,9 @@
+. /lib/functions.sh
+
+load_wifi() {
+	local kernel_version=$(uname -r)
+	[ -e "/lib/modules/$kernel_version/mt7603e.ko" ] && modprobe mt7603e
+	[ -e "/lib/modules/$kernel_version/mt76x2_ap.ko" ] && modprobe mt76x2_ap
+}
+
+boot_hook_add preinit_main load_wifi


### PR DESCRIPTION
This reverts commit 653b7e432e5ce9c5b3721fe71e91b94861ad6408 due to
the combination of the mtwifi driver for mt603 and mt7615 will cause
some modules to fail to load normally, fix #6044 .