### PR TITLE
libnetfilter_conntrack: Update V1.0.8

### DIFF
--- a/package/libs/libnetfilter-conntrack/Makefile
+++ b/package/libs/libnetfilter-conntrack/Makefile
@@ -8,20 +8,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnetfilter_conntrack
-PKG_RELEASE:=2
+PKG_VERSION:=1.0.8
+PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://git.netfilter.org/libnetfilter_conntrack
-PKG_SOURCE_DATE:=2018-05-01
-PKG_SOURCE_VERSION:=3ccae9f5b2a9564cd63699ba60e54a46bc0d73b6
-PKG_MIRROR_HASH:=c978ef0fa5b7379de2909ca5d9c599ac63b4f8166f5971d58f6e074a922d996f
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:=https://www.netfilter.org/projects/libnetfilter_conntrack/files
+PKG_HASH:=0cd13be008923528687af6c6b860f35392d49251c04ee0648282d36b1faec1cf
 
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
-
-PKG_FIXUP:=autoreconf
-PKG_LICENSE:=GPL-2.0+
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_LICENSE_FILES:=COPYING
 
 PKG_INSTALL:=1
+PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

OpenWrt同时把`libnetfilter-cthelper`, `libnetfilter-cttimeout`, `libnetfilter-log`, `libnetfilter-queue` 软件包移动至 `package` 仓库
>Nothing in base uses this. This will be moved to packages where it is
used.
>
>Signed-off-by: Rosen Penev <rosenp@gmail.com>
 
依旧同步以上软件包还是移动至 `coolsnowwolf/package` 仓库？