### PR TITLE
hotfix: 修复多拨插件在不选择绑定wan口时不会自动生成跃点导致mawn3负载异常的问题

### DIFF
--- a/package/lean/luci-app-syncdial/root/bin/genwancfg
+++ b/package/lean/luci-app-syncdial/root/bin/genwancfg
@@ -86,11 +86,11 @@ pppoe_if_add() {
 	NEW_MACADDR=$(openssl rand -hex 6 | sed 's/\(..\)/\1:/g; s/.$//')
 	#gen wan if
 	uci set network.${1}=interface
-	uci set network.${1}.ifname=${2}
+	uci set network.${1}.ifname=${3}
 	uci set network.${1}.proto=pppoe
-	uci set network.${1}.username=${3}
-	uci set network.${1}.password=${4}
-	uci set network.${1}.metric=${5}
+	uci set network.${1}.username=${4}
+	uci set network.${1}.password=${5}
+	uci set network.${1}.metric=${2}
 	uci set network.${1}.macaddr=$NEW_MACADDR
 	#gen firewall
 	uci add_list firewall.@zone[1].network=${1}
@@ -227,11 +227,11 @@ if [ "$wannum" -gt 0 ]; then
 	do
 		[ "$old_frame" -eq 0 ] && macvlan_dev_add macvlan$i $pppoe_ifname
 		if [ "$bindwan" != "" -a "$bindwan" == "1" ]; then
-			pppoe_if_add vwan$i $pppoe_ifname $pppoe_user $pppoe_password $((40+$i))
+			pppoe_if_add vwan$i $((40+$i)) $pppoe_ifname $pppoe_user $pppoe_password 
 		else
-			pppoe_if_add vwan$i macvlan$i $pppoe_user $pppoe_password $((40+$i))
+			pppoe_if_add vwan$i $((40+$i)) macvlan$i $pppoe_user $pppoe_password 
 		fi
-		[ "$nomwan" -ne 1 ] && mwan_cfg_add vwan$i
+		[ "$nomwan" -ne 1 ] && mwan_cfg_add vwan$i $((40+$i))
 	done
 else
 	[ "$nomwan" -ne 1 ] && mwan_cfg_add $wanselect
@@ -261,11 +261,11 @@ fi
 		do
 			[ "$old_frame" -eq 0 ] && macvlan_dev_add macvlan$(($wannum+$i)) $pppoe_ifname2
 			if [ "$bindwan2" != "" -a "$bindwan2" == "1" ]; then
-				pppoe_if_add vwan$(($wannum+$i)) $pppoe_ifname2 $pppoe_user2 $pppoe_password2 $((60+$i))
+				pppoe_if_add vwan$(($wannum+$i)) $((60+$i)) $pppoe_ifname2 $pppoe_user2 $pppoe_password2 
 			else
-				pppoe_if_add vwan$(($wannum+$i)) macvlan$(($wannum+$i)) $pppoe_user2 $pppoe_password2 $((60+$i))
+				pppoe_if_add vwan$(($wannum+$i)) $((60+$i)) macvlan$(($wannum+$i)) $pppoe_user2 $pppoe_password2 
 			fi
-			[ "$nomwan" -ne 1 ] && mwan_cfg_add vwan$(($wannum+$i))
+			[ "$nomwan" -ne 1 ] && mwan_cfg_add vwan$(($wannum+$i)) $((60+$i)) 
 		done
 	else
 		[ "$nomwan" -ne 1 ] && mwan_cfg_add $wanselect2


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道 

创建多拨的时候，如果不选择绑定物理接口，不会自动生成跃点，这会导致mwan3去做负载的时候会出现掉线的问题