### PR TITLE
luci-app-syncdial: do not depend on openssl

### DIFF
--- a/package/lean/luci-app-syncdial/root/bin/genwancfg
+++ b/package/lean/luci-app-syncdial/root/bin/genwancfg
@@ -83,7 +83,7 @@ macvlan_dev_add() {
 #$1:接口名称 $2:设备名称 $3:账户 $4:密码 $5:网关跃点
 pppoe_if_add() {
 	#gen vwan macaddr
-	NEW_MACADDR=$(openssl rand -hex 6 | sed 's/\(..\)/\1:/g; s/.$//')
+	NEW_MACADDR=$(hexdump -n6 -e '/1 ":%02x"' /dev/random | sed s/^://g)
 	#gen wan if
 	uci set network.${1}=interface
 	uci set network.${1}.ifname=${3}


### PR DESCRIPTION
Use  hexdump -n6 -e '/1 ":%02x"' /dev/random | sed 's/^://g'  to get a random mac address, which only depend on busybox.

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
