### PR TITLE
luci-app-ssrserver-python: improve status check

### DIFF
--- a/package/lean/luci-app-ssrserver-python/luasrc/controller/ssrs.lua
+++ b/package/lean/luci-app-ssrserver-python/luasrc/controller/ssrs.lua
@@ -15,7 +15,7 @@ end
 
 function act_status()
   local e={}
-  e.running=luci.sys.call("ps | grep server.py |grep -v grep >/dev/null") == 0
+  e.running=luci.sys.call("ps -w | grep ssrs.json |grep -v grep >/dev/null") == 0
   luci.http.prepare_content("application/json")
   luci.http.write_json(e)
 end


### PR DESCRIPTION
Running `ps` via luci.exec directly will cause no output
to compare as `ps` cannot detect the size of screen, adding
`-w` to solve this.

Fixes: 0e285c3037c3481d0c1b7a7c672a6ca5692ef35f ("add lean's package")