### PR TITLE
增加对海凌科7621模块的支持

### DIFF
--- a/target/linux/ramips/dts/mt7621_hlk_mt7621a-module.dts
+++ b/target/linux/ramips/dts/mt7621_hlk_mt7621a-module.dts
@@ -17,7 +17,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <25000000>;
+		spi-max-frequency = <44000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ramips/dts/mt7621_hlk_mt7621a-module.dts
+++ b/target/linux/ramips/dts/mt7621_hlk_mt7621a-module.dts
@@ -1,0 +1,88 @@
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+/ {
+	compatible = "hlk,mt7621a-module", "mediatek,mt7621-soc";
+	model = "HLK MT7621A Module";
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1fb0000>;
+			};
+		};
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "uart3";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1193,3 +1193,10 @@ define Device/zio_freezio
 	kmod-usb-ledtrig-usbport wpad-openssl
 endef
 TARGET_DEVICES += zio_freezio
+
+define Device/hlk_mt7621a-module
+  IMAGE_SIZE := 32448k
+  DEVICE_VENDOR := HLK
+  DEVICE_MODEL := HLK MT7621A MODULE
+endef
+TARGET_DEVICES += hlk_mt7621a-module


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

1. [模块描述地址](https://detail.tmall.com/item.htm?spm=a230r.1.14.118.23b053f7nSTVpc&id=607916979618&ns=1&abbucket=16)
2. 模块仅包含1.8v电源、256M DDR3、32M SPI NOR Flash 和 MT7621A。
3. Flash布局与小娱C5一致，频率应该是44MHz，因为最新breed和pbboot都识别为44MHz，且新编译的固件能启动。
4. 第一次使用Git的pr功能，也是第一次修改相关文件，操作如有不当请指出😊