### PR TITLE
优酷路由宝在5.4内核不能软重启

### DIFF
--- a/target/linux/ramips/dts/mt7620a_youku_yk1.dts
+++ b/target/linux/ramips/dts/mt7620a_youku_yk1.dts
@@ -77,6 +77,7 @@
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 		m25p,fast-read;
+		broken-flash-reset;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
虽然估计 1202 年了没多少人用这个百兆 MTK 垃圾了，不过胜在便宜。之前自己编译了刷进去发现一重启就卡死（所有灯熄灭之后就没动静了必须插拔电源），查了一下是 32M 闪存的问题，退回 4.14 内核并给 M25P80.c 打了补丁之后凑合用，后来重温某个傻逼的弱智言论的时候无意中发现 32MB 闪存在 5.4 内核给 dts 加个 `broken-flash-reset` 的标志就好了，测试了一下确实，因为优酷路由宝确实原厂就是有 32MB 闪存（没硬改过）所以这个改动合并进来应该没啥大问题...？

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
