### PR TITLE
修复ddns(dnspod)同一个域名同时有ipv6和ipv4时更新失败的问题

### DIFF
--- a/package/lean/ddns-scripts_dnspod/update_dnspod_cn.sh
+++ b/package/lean/ddns-scripts_dnspod/update_dnspod_cn.sh
@@ -6,7 +6,7 @@
 
 #检查外部调用工具
 WGET_SSL='wget'
-[ -n "$WGET_SSL" ] || write_log 13 "GNU Wget support is required to use Alibaba Cloud API. Please install first"
+[ -n "$WGET_SSL" ] || write_log 13 "GNU Wget support is required to use dnspod API. Please install first"
 
 # 变量声明
 local __URLBASE __HOST __DOMAIN __TYPE __CMDBASE __POST __POST1 __RECIP __RECID __value __TTL
@@ -115,7 +115,7 @@ update_domain() {
 #获取域名解析记录
 describe_domain() {
 	ret=0
-	__POST="login_token=$username,$password&format=json&domain=$__DOMAIN&sub_domain=$__HOST"
+	__POST="login_token=$username,$password&format=json&domain=$__DOMAIN&sub_domain=$__HOST&record_type=$__TYPE"
 	__POST1="$__POST&value=$__IP&record_type=$__TYPE&record_line_id=0"
 	dnspod_transfer 0
 	__TMP=`jsonfilter -i $DATFILE -e "@.records[@.type!='NS']"`


### PR DESCRIPTION
1. 当一个域名同时有A记录和AAAA记录时，在不需要更新时去更新，接口返回错误导致的脚本挂掉的问题，
接口报错信息：Error message:[记录已经存在，无需再次添加]
2. 文案明显错误修改

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ x] 我知道
