### PR TITLE
optimize the performance of obtaining CPU temperature

### DIFF
--- a/package/lean/autocore/files/arm/sbin/cpuinfo
+++ b/package/lean/autocore/files/arm/sbin/cpuinfo
@@ -17,7 +17,7 @@ fi
 if grep -q "ipq40xx" "/etc/openwrt_release"; then
 	sys_temp="$(sensors | grep -Eo '\+[0-9]+.+C' | sed ':a;N;$!ba;s/\n/ /g;s/+//g')"
 else
-	sys_temp="$(awk "BEGIN{printf (\"%.1f\n\",$(cat /sys/class/thermal/thermal_zone0/temp)/1000) }")°C"
+	sys_temp="$(awk '{ printf("%.1f °C", $0 / 1000) }' /sys/class/thermal/thermal_zone0/temp)"
 fi
 
 echo -n "${cpu_arch} x ${cpu_cores} (${cpu_freq}, ${sys_temp})"


### PR DESCRIPTION
Preformance Test (on NanoPi R2s, repeat 1000 times):

old command:
```
root@OpenWrt:~# cat cpu_temp_lean 
#/bin/bash

for i in {0..1000}
do
temp="$(awk "BEGIN{printf (\"%.1f\n\",$(cat /sys/class/thermal/thermal_zone0/temp)/1000) }")°C"
done

root@OpenWrt:~# time bash ./cpu_temp_lean 
real    0m 9.20s
user    0m 3.29s
sys     0m 6.24s
```

new command:
```
root@OpenWrt:~# cat cpu_temp
#/bin/bash

for i in {0..1000}
do
temp="$(awk '{ printf("%.1f °C", $0 / 1000) }' /sys/class/thermal/thermal_zone0/temp)"
done

root@OpenWrt:~# time bash ./cpu_temp
real    0m 5.57s
user    0m 1.78s
sys     0m 3.97s
```

Signed-off-by: Chuck <fanck0605@qq.com>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
