### PR TITLE
optimize the performance of obtaining CPU usage

### DIFF
--- a/package/lean/autocore/files/arm/index.htm
+++ b/package/lean/autocore/files/arm/index.htm
@@ -48,7 +48,7 @@
 
 		local user_info = luci.sys.exec("cat /proc/net/arp | grep 'br-lan' | grep '0x2' | wc -l")
 
-		local cpu_usage = (luci.sys.exec("expr 100 - $(top -n 1 | grep 'CPU:' | awk -F '%' '{print$4}' | awk -F ' ' '{print$2}')") or "6") .. "%"
+		local cpu_usage = luci.sys.exec("top -n1 | awk '/^CPU/ { printf(\"%d%%\", 100 - $8) }'") or "6%"
 		local cpu_info = luci.sys.exec("/sbin/cpuinfo") or "ARM Processor x 0 (233MHz, 2.3°C)"
 
 		local rv = {


### PR DESCRIPTION
After the optimization, we only need to open two processes each time we get cpu usage instead of the previous five.

Also, the front-end will keep refreshing the page to get the cpu usage, so this patch may improve the front-end response time to a certain extent

Preformance Test (on NanoPi R2s, repeat 1000 times):

Since `top` is very time consuming, we stored the results of `top -n1` first

```
root@OpenWrt:~# top -n1 > /tmp/top_tmp
root@OpenWrt:~# cat /tmp/top_tmp 
Mem: 238756K used, 776236K free, 12600K shrd, 37472K buff, 85516K cached
CPU:   0% usr   0% sys   0% nic 100% idle   0% io   0% irq   0% sirq
Load average: 0.47 0.23 0.09 1/130 6202
  PID  PPID USER     STAT   VSZ %VSZ %CPU COMMAND
...
```

Now we test the script performance

old command

```
root@OpenWrt:~# cat cpu_usage_lean 
#/bin/bash

for i in {0..1000}
do
cpu_usage=$(expr 100 - $(cat /tmp/top_tmp | grep 'CPU:' | awk -F '%' '{print$4}' | awk -F ' ' '{print$2}'))
done

root@OpenWrt:~# time bash ./cpu_usage_lean 
Command exited with non-zero status 1
real    0m 14.25s
user    0m 7.96s
sys     0m 20.33s
```

new command

```
root@OpenWrt:~# cat cpu_usage
#/bin/bash

for i in {0..1000}
do
cpu_usage=$(cat /tmp/top_tmp | awk '/^CPU/ { printf("%d%%", 100 - $8) }')
done

root@OpenWrt:~# time bash ./cpu_usage
real    0m 6.91s
user    0m 4.29s
sys     0m 6.06s
```

Signed-off-by: Chuck <fanck0605@qq.com>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
