### PR TITLE
Revert "Add broken-flash-reset flag to Youku YK-L1"

### DIFF
--- a/target/linux/ramips/dts/mt7620a_youku_yk1.dts
+++ b/target/linux/ramips/dts/mt7620a_youku_yk1.dts
@@ -78,7 +78,6 @@
 		spi-max-frequency = <25000000>;
 		broken-flash-reset;
 		m25p,fast-read;
-		broken-flash-reset;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
This reverts commit 90bd81e0991046927634bf74830ec1c835d83e85.

The commit 90bd81e is a duplicate of b132179.

Fixes: #6388
Fixes: #6406

Signed-off-by: CN_SZTL <cnsztl@project-openwrt.eu.org>