### PR TITLE
Create 990-not-defined-errors-on-gcc10.patch

### DIFF
--- a/package/lean/shadowsocksr-libev/patches/990-not-defined-errors-on-gcc10.patch
+++ b/package/lean/shadowsocksr-libev/patches/990-not-defined-errors-on-gcc10.patch
@@ -1,0 +1,24 @@
+diff --git a/src/http.h b/src/http.h
+index 914815a..e312dd3 100644
+--- a/src/http.h
++++ b/src/http.h
+@@ -29,6 +29,6 @@
+ #include <stdio.h>
+ #include "protocol.h"
+ 
+-const protocol_t *const http_protocol;
++extern const protocol_t *const http_protocol;
+ 
+ #endif
+diff --git a/src/tls.h b/src/tls.h
+index 3998913..ddbee11 100644
+--- a/src/tls.h
++++ b/src/tls.h
+@@ -28,6 +28,6 @@
+ 
+ #include "protocol.h"
+ 
+-const protocol_t *const tls_protocol;
++extern const protocol_t *const tls_protocol;
+ 
+ #endif


### PR DESCRIPTION
This patch fixes the following error when we compile with GCC 10.

‘’openwrt/staging_dir/toolchain-aarch64_generic_gcc-10.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/10.2.0/../../../../aarch64-openwrt-linux-musl/bin/ld: ss_local-http.o:openwrt/build_dir/target-aarch64_generic_musl/shadowsocksr-libev/shadowsocksr-libev-2.5.6-d63ff863800a5645aca4309d5dd5962bd1e95543/src/http.h:32: multiple definition of `http_protocol'; ss_local-local.o:openwrt/build_dir/target-aarch64_generic_musl/shadowsocksr-libev/shadowsocksr-libev-2.5.6-d63ff863800a5645aca4309d5dd5962bd1e95543/src/http.h:32: first defined here

openwrt/staging_dir/toolchain-aarch64_generic_gcc-10.2.0_musl/lib/gcc/aarch64-openwrt-linux-musl/10.2.0/../../../../aarch64-openwrt-linux-musl/bin/ld: ss_local-tls.o:openwrt/build_dir/target-aarch64_generic_musl/shadowsocksr-libev/shadowsocksr-libev-2.5.6-d63ff863800a5645aca4309d5dd5962bd1e95543/src/tls.h:31: multiple definition of `tls_protocol'; ss_local-local.o:openwrt/build_dir/target-aarch64_generic_musl/shadowsocksr-libev/shadowsocksr-libev-2.5.6-d63ff863800a5645aca4309d5dd5962bd1e95543/src/tls.h:31: first defined here‘’

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
