### PR TITLE
ath79: domywifi_dw33d: support startup from breed

### DIFF
--- a/target/linux/ath79/dts/qca9558_domywifi_dw33d.dts
+++ b/target/linux/ath79/dts/qca9558_domywifi_dw33d.dts
@@ -132,6 +132,31 @@
 			};
 
 			partition@50000 {
+				label = "loader1";
+				reg = <0x50000 0x10000>;
+			};
+
+			partition@60000 {
+				compatible = "openwrt,okli";
+				label = "firmware";
+				reg = <0x60000 0xe20000>;
+			};
+
+			partition@e80000 {
+				label = "loader2";
+				reg = <0xe80000 0x10000>;
+			};
+
+			partition@e90000 {
+				label = "unused";
+				reg = <0xe90000 0x160000>;
+			};
+
+			/* firmware
+			 * oem-rootfs: 0x50000 0xe30000 ->loader1(64k) + kernel + rootfs
+			 * oem-kernel: 0xe80000 0x170000 ->loader2(64k)
+			 */
+			partition@1 {
 				label = "oem-firmware";
 				reg = <0x50000 0xfa0000>;
 			};
@@ -154,12 +179,12 @@
 		#size-cells = <1>;
 
 		partition@0 {
-			label = "kernel";
+			label = "nand-kernel";
 			reg = <0x0 0x500000>;
 		};
 
 		partition@500000 {
-			label = "ubi";
+			label = "nand-ubi";
 			reg = <0x500000 0x5b00000>;
 		};
 


### PR DESCRIPTION
Compiled-on: ath79, kernel 4.19 & 5.4
Run-tested-on: none

Fixes: #5267, #5299 