### PR TITLE
r8152: introduce r8152/r8153 driver from vendor

### DIFF
--- a/package/lean/r8152/Makefile
+++ b/package/lean/r8152/Makefile
@@ -1,0 +1,54 @@
+#Download realtek r8152 linux driver from official site [https://www.realtek.com/en/component/zoo/category/network-interface-controllers-10-100-1000m-gigabit-ethernet-usb-3-0-software]
+#Unpack source file
+#Replace orginal Makefile with this file
+#Put this source to 'package' folder of OpenWRT/LEDE SDK
+#Build(make menuconfig, make defconfig, make)
+
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=r8152
+PKG_VERSION:=2.14
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/wget/realtek-r8152-linux/tar.gz/v$(PKG_VERSION)?
+PKG_HASH:=617c159eb72355c240be3f78971e5a01c9dffe5545a7ae76bb2bd87bb7a346ed
+
+PKG_BUILD_DIR:=$(KERNEL_BUILD_DIR)/realtek-$(PKG_NAME)-linux-$(PKG_VERSION)
+
+PKG_MAINTAINTER:=Tianling Shen <cnsztl@immortalwrt.org>
+
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/usb-net-rtl8152-vendor
+  TITLE:=Kernel module for USB-to-Ethernet Realtek convertors
+  SUBMENU:=USB Support
+  VERSION:=$(LINUX_VERSION)+$(PKG_VERSION)-$(BOARD)-$(PKG_RELEASE)
+  DEPENDS:=+kmod-usb-net
+  CONFLICTS:=kmod-usb-net-rtl8152
+  FILES:= $(PKG_BUILD_DIR)/r8152.ko
+  AUTOLOAD:=$(call AutoProbe,r8152)
+endef
+
+define KernelPackage/usb-net-rtl8152-vendor/description
+  Kernel module for Realtek RTL8152/RTL8153 Based USB Ethernet Adapters
+endef
+
+R8152_MAKEOPTS= -C $(PKG_BUILD_DIR) \
+		PATH="$(TARGET_PATH)" \
+		ARCH="$(LINUX_KARCH)" \
+		CROSS_COMPILE="$(TARGET_CROSS)" \
+		TARGET="$(HAL_TARGET)" \
+		TOOLPREFIX="$(KERNEL_CROSS)" \
+		TOOLPATH="$(KERNEL_CROSS)" \
+		KERNELPATH="$(LINUX_DIR)" \
+		KERNELDIR="$(LINUX_DIR)" \
+		LDOPTS=" " \
+		DOMULTI=1
+
+define Build/Compile
+	+$(MAKE) $(PKG_JOBS) $(R8152_MAKEOPTS) modules
+endef
+
+$(eval $(call KernelPackage,usb-net-rtl8152-vendor))

--- a/package/lean/r8152/patches/100-add-LED-configuration-from-OF.patch
+++ b/package/lean/r8152/patches/100-add-LED-configuration-from-OF.patch
@@ -1,0 +1,74 @@
+From 82985725e071f2a5735052f18e109a32aeac3a0b Mon Sep 17 00:00:00 2001
+From: David Bauer <mail@david-bauer.net>
+Date: Sun, 26 Jul 2020 02:38:31 +0200
+Subject: [PATCH] add LED configuration from OF
+
+This adds the ability to configure the LED configuration register using
+OF. This way, the correct value for board specific LED configuration can
+be determined.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+---
+ r8152.c | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+--- a/r8152.c
++++ b/r8152.c
+@@ -17,6 +17,7 @@
+ #include <linux/mii.h>
+ #include <linux/ethtool.h>
+ #include <linux/usb.h>
++#include <linux/of.h>
+ #include <linux/crc32.h>
+ #include <linux/if_vlan.h>
+ #include <linux/uaccess.h>
+@@ -9736,6 +9737,22 @@ static void rtl_tally_reset(struct r8152
+ 	ocp_write_word(tp, MCU_TYPE_PLA, PLA_RSTTALLY, ocp_data);
+ }
+ 
++static int r8152_led_configuration(struct r8152 *tp)
++{
++	u32 led_data;
++	int ret;
++
++	ret = of_property_read_u32(tp->udev->dev.of_node, "realtek,led-data",
++								&led_data);
++
++	if (ret)
++		return ret;
++	
++	ocp_write_word(tp, MCU_TYPE_PLA, PLA_LEDSEL, led_data);
++
++	return 0;
++}
++
+ static void r8152b_init(struct r8152 *tp)
+ {
+ 	u32 ocp_data;
+@@ -9797,6 +9814,8 @@ static void r8152b_init(struct r8152 *tp
+ 	ocp_data = ocp_read_word(tp, MCU_TYPE_USB, USB_USB_CTRL);
+ 	ocp_data &= ~(RX_AGG_DISABLE | RX_ZERO_EN);
+ 	ocp_write_word(tp, MCU_TYPE_USB, USB_USB_CTRL, ocp_data);
++
++	r8152_led_configuration(tp);
+ }
+ 
+ static void r8153_init(struct r8152 *tp)
+@@ -9937,6 +9956,8 @@ static void r8153_init(struct r8152 *tp)
+ 		tp->coalesce = COALESCE_SLOW;
+ 		break;
+ 	}
++
++	r8152_led_configuration(tp);
+ }
+ 
+ static void r8153b_init(struct r8152 *tp)
+@@ -10026,6 +10047,8 @@ static void r8153b_init(struct r8152 *tp
+ 	rtl_tally_reset(tp);
+ 
+ 	tp->coalesce = 15000;	/* 15 us */
++
++	r8152_led_configuration(tp);
+ }
+ 
+ static void r8153c_init(struct r8152 *tp)


### PR DESCRIPTION
This is the vendor driver for r8152/r8153 series USB ethernet adapter, it may be
better than the driver from kernel mainline, or be worse. It's depending on your
use-case.

Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>