### PR TITLE
rockchip: nanopi-r4s: use vendor driver for PCIe ethernet adapter

### DIFF
--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -20,7 +20,7 @@ define Device/friendlyarm_nanopi-r4s
   DEVICE_MODEL := NanoPi R4S
   SOC := rk3399
   IMAGE/sysupgrade.img.gz := boot-common | boot-script nanopi-r4s | pine64-img | gzip | append-metadata
-  DEVICE_PACKAGES := kmod-r8169
+  DEVICE_PACKAGES := kmod-r8168
 endef
 
 define Device/friendlyarm_nanopi-r4s-1gb


### PR DESCRIPTION
Vendor driver seems to be better than the one from kernel mainline.

Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>