### PR TITLE
本地编译make download加速大法

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -70,10 +70,15 @@ sub hash_cmd() {
 	return undef;
 }
 
-sub download_cmd($) {
+sub download_cmd {
 	my $url = shift;
 	my $have_curl = 0;
+	my $fn = shift;
+	my @mrs = @_;
+	my $murl = "'$url'";
 
+	my @chArray = ('a'..'z', 'A'..'Z', 0..9);
+	my $rfn = join '', map{ $chArray[int rand @chArray] } 0..9;
 	if (open CURL, '-|', 'curl', '--version') {
 		if (defined(my $line = readline CURL)) {
 			$have_curl = 1 if $line =~ /^curl /;
@@ -81,8 +86,12 @@ sub download_cmd($) {
 		close CURL;
 	}
 
+	for my $el (@mrs) {
+		$murl = $murl." '$el/$fn'";
+	}
+
 	return $have_curl
-		? (qw(curl -f --connect-timeout 20 --retry 5 --location --insecure), shellwords($ENV{CURL_OPTIONS} || ''), $url)
+		? ("aria2c --stderr $murl -c -x2 -s10 -j10 -k1M --server-stat-of=/dev/shm/spp --server-stat-if=/dev/shm/spp -d /dev/shm -o $rfn; cat /dev/shm/$rfn; rm /dev/shm/$rfn")
 		: (qw(wget --tries=5 --timeout=20 --no-check-certificate --output-document=-), shellwords($ENV{WGET_OPTIONS} || ''), $url)
 	;
 }
@@ -94,6 +103,7 @@ sub download
 {
 	my $mirror = shift;
 	my $download_filename = shift;
+	my @mrs = @_;
 
 	$mirror =~ s!/$!!;
 
@@ -140,7 +150,7 @@ sub download
 			}
 		};
 	} else {
-		my @cmd = download_cmd("$mirror/$download_filename");
+		my @cmd = download_cmd("$mirror/$download_filename", $download_filename, @mrs);
 		print STDERR "+ ".join(" ",@cmd)."\n";
 		open(FETCH_FD, '-|', @cmd) or die "Cannot launch curl or wget.\n";
 		$hash_cmd and do {
@@ -294,10 +304,11 @@ while (!-f "$target/$filename") {
 	my $mirror = shift @mirrors;
 	$mirror or die "No more mirrors to try - giving up.\n";
 
-	download($mirror, $url_filename);
+	download($mirror, $url_filename, @mirrors);
 	if (!-f "$target/$filename" && $url_filename ne $filename) {
-		download($mirror, $filename);
+		download($mirror, $filename, @mirrors);
 	}
+	@mirrors=();
 }
 
 $SIG{INT} = \&cleanup;


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道


这个就不要合并了，我的代码渣渣，感兴趣的拿去用就好了
简单说就是替换curl为aria2多线程抓取，原本是curl不断尝试各mirror抓包源码，一个失败的走下一个，改成了一次性把所有mirror喂给aria2，让aria2自己决定从哪抓取；并且aria2有一个特性，可以训练自己的[各服务器下载速度记忆](https://aria2.github.io/manual/en/html/aria2c.html#server-performance-profile)，在下一次抓取中自动选择更适合自己的mirror

测试效果就是不会提升云编译的make download速度，因为它速度已经够快了，
但是本地可以从40分钟以上缩短到十几分钟（我自己），很多时候可以直接吃满你的本地宽带。

**食用方法：**
 在 make download 之前执行，
```
wget https://github.com/coolsnowwolf/lede/pull/6526.patch
git apply 6526.patch
```

