### PR TITLE
openssl: bump to 1.1.1k

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_BASE:=1.1.1
-PKG_BUGFIX:=j
+PKG_BUGFIX:=k
 PKG_VERSION:=$(PKG_BASE)$(PKG_BUGFIX)
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
@@ -21,11 +21,13 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:= \
 	https://mirrors.cloud.tencent.com/openssl/source/ \
 	https://mirrors.cloud.tencent.com/openssl/source/old/$(PKG_BASE)/ \
-	https://ftp.fi.muni.cz/pub/openssl/source/ \
-	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
 	https://www.openssl.org/source/ \
-	https://www.openssl.org/source/old/$(PKG_BASE)/
-PKG_HASH:=aaf2fcb575cdf6491b98ab4829abf78a3dec8402b8b81efc8f23c00d443981bf
+	https://www.openssl.org/source/old/$(PKG_BASE)/ \
+	https://ftp.fi.muni.cz/pub/openssl/source/ \
+	https://ftp.fi.muni.cz/pub/openssl/source/old/$(PKG_BASE)/ \
+	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
+	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/old/$(PKG_BASE)/
+PKG_HASH:=892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5
 
 PKG_LICENSE:=OpenSSL
 PKG_LICENSE_FILES:=LICENSE

--- a/package/libs/openssl/patches/430-e_devcrypto-make-the-dev-crypto-engine-dynamic.patch
+++ b/package/libs/openssl/patches/430-e_devcrypto-make-the-dev-crypto-engine-dynamic.patch
@@ -116,7 +116,7 @@ diff --git a/crypto/engine/eng_devcrypto.c b/engines/e_devcrypto.c
 similarity index 95%
 rename from crypto/engine/eng_devcrypto.c
 rename to engines/e_devcrypto.c
-index 0d420e50aa..3fcd81de7a 100644
+index 2c1b52d572..eff1ed3a7d 100644
 --- a/crypto/engine/eng_devcrypto.c
 +++ b/engines/e_devcrypto.c
 @@ -7,7 +7,7 @@
@@ -152,22 +152,6 @@ index 0d420e50aa..3fcd81de7a 100644
  
  /*
   * cipher/digest status & acceleration definitions
-@@ -341,6 +343,7 @@ static int cipher_ctrl(EVP_CIPHER_CTX *ctx, int type, int p1, void* p2)
-     struct cipher_ctx *to_cipher_ctx;
- 
-     switch (type) {
-+
-     case EVP_CTRL_COPY:
-         if (cipher_ctx == NULL)
-             return 1;
-@@ -702,7 +705,6 @@ static int digest_init(EVP_MD_CTX *ctx)
-         SYSerr(SYS_F_IOCTL, errno);
-         return 0;
-     }
--
-     return 1;
- }
- 
 @@ -1058,7 +1060,7 @@ static const ENGINE_CMD_DEFN devcrypto_cmds[] = {
          OPENSSL_MSTR(DEVCRYPTO_USE_SOFTWARE) "=allow all drivers, "
          OPENSSL_MSTR(DEVCRYPTO_REJECT_SOFTWARE)
@@ -177,7 +161,7 @@ index 0d420e50aa..3fcd81de7a 100644
      ENGINE_CMD_FLAG_NUMERIC},
  #endif
  
-@@ -1166,55 +1168,70 @@ static int devcrypto_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
+@@ -1166,32 +1168,22 @@ static int devcrypto_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
   *
   *****/
  
@@ -201,10 +185,12 @@ index 0d420e50aa..3fcd81de7a 100644
 +static int open_devcrypto(void)
  {
 -    ENGINE *e = NULL;
+     int fd;
+ 
 +    if (cfd >= 0)
 +        return 1;
- 
-     if ((cfd = open("/dev/crypto", O_RDWR, 0)) < 0) {
++
+     if ((fd = open("/dev/crypto", O_RDWR, 0)) < 0) {
  #ifndef ENGINE_DEVCRYPTO_DEBUG
          if (errno != ENOENT)
  #endif
@@ -212,6 +198,19 @@ index 0d420e50aa..3fcd81de7a 100644
 -        return;
 +        return 0;
      }
+ 
+ #ifdef CRIOGET
+@@ -1199,35 +1191,61 @@ void engine_load_devcrypto_int()
+         fprintf(stderr, "Could not create crypto fd: %s\n", strerror(errno));
+         close(fd);
+         cfd = -1;
+-        return;
++        return 0;
+     }
+     close(fd);
+ #else
+     cfd = fd;
+ #endif
  
 -    if ((e = ENGINE_new()) == NULL
 -        || !ENGINE_set_destroy_function(e, devcrypto_unload)) {
@@ -278,7 +277,7 @@ index 0d420e50aa..3fcd81de7a 100644
  /*
   * Asymmetric ciphers aren't well supported with /dev/crypto.  Among the BSD
   * implementations, it seems to only exist in FreeBSD, and regarding the
-@@ -1237,23 +1254,36 @@ void engine_load_devcrypto_int()
+@@ -1250,23 +1268,36 @@ void engine_load_devcrypto_int()
   */
  #if 0
  # ifndef OPENSSL_NO_RSA
@@ -324,7 +323,7 @@ index 0d420e50aa..3fcd81de7a 100644
          ENGINE_free(e);
          return;
      }
-@@ -1262,3 +1292,22 @@ void engine_load_devcrypto_int()
+@@ -1275,3 +1306,22 @@ void engine_load_devcrypto_int()
      ENGINE_free(e);          /* Loose our local reference */
      ERR_clear_error();
  }


### PR DESCRIPTION
This version fixes 2 security vulnerabilities, among other changes:

 - CVE-2021-3450: problem with verifying a certificate chain when using
   the X509_V_FLAG_X509_STRICT flag.

 - CVE-2021-3449: OpenSSL TLS server may crash if sent a maliciously
   crafted renegotiation ClientHello message from a client.