### PR TITLE
Fix go unblockmusic can't change provider

### DIFF
--- a/package/lean/luci-app-unblockmusic/root/etc/init.d/unblockmusic
+++ b/package/lean/luci-app-unblockmusic/root/etc/init.d/unblockmusic
@@ -188,7 +188,7 @@ start()
     if [ $FLAC -eq 1 ]; then
       ENABLE_FLAC="-b "
     fi
-    UnblockNeteaseMusic $ENABLE_FLAC -p 5200 -sp 5201 -m 0 -c /usr/share/UnblockNeteaseMusicGo/server.crt -k /usr/share/UnblockNeteaseMusicGo/server.key -m 0 -e -sl ${SEARCHLIMIT} -l /tmp/unblockmusic.log &
+    UnblockNeteaseMusic $musictype $ENABLE_FLAC -p 5200 -sp 5201 -c /usr/share/UnblockNeteaseMusicGo/server.crt -k /usr/share/UnblockNeteaseMusicGo/server.key -m 0 -e -sl ${SEARCHLIMIT} -l /tmp/unblockmusic.log &
     echo "$(date -R) # UnblockNeteaseMusic Golang Version (http:5200, https:5201)" >>/tmp/unblockmusic.log
   else
     kill -9 $(busybox ps -w | grep 'sleep 60m' | grep -v grep | awk '{print $1}') >/dev/null 2>&1


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [X] 我知道

之前网易解锁的go版没有在启动命令中添加-o参数导致无法更换音源
并且代码中有两个-m重复，删除了多余的一个
