### PR TITLE
修复Orangepi R1 Plus 编译后不可用的问题

### DIFF
--- a/package/boot/uboot-rockchip/patches/103-rockchip-rk3328-Add-support-for-Orangepi-R1-Plus.patch
+++ b/package/boot/uboot-rockchip/patches/103-rockchip-rk3328-Add-support-for-Orangepi-R1-Plus.patch
@@ -1,6 +1,8 @@
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 700f02e2..a4a81369 100644
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -111,6 +111,7 @@ dtb-$(CONFIG_ROCKCHIP_RK3308) += \
+@@ -107,6 +107,7 @@ dtb-$(CONFIG_ROCKCHIP_RK3308) += \
  dtb-$(CONFIG_ROCKCHIP_RK3328) += \
  	rk3328-evb.dtb \
  	rk3328-nanopi-r2s.dtb \
@@ -8,60 +10,396 @@
  	rk3328-roc-cc.dtb \
  	rk3328-rock64.dtb \
  	rk3328-rock-pi-e.dtb
+diff --git a/arch/arm/dts/rk3328-orangepi-r1-plus-u-boot.dtsi b/arch/arm/dts/rk3328-orangepi-r1-plus-u-boot.dtsi
+new file mode 100644
+index 00000000..41593484
 --- /dev/null
 +++ b/arch/arm/dts/rk3328-orangepi-r1-plus-u-boot.dtsi
-@@ -0,0 +1,1 @@
-+#include "rk3328-nanopi-r2s-u-boot.dtsi"
+@@ -0,0 +1,34 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * (C) Copyright 2018-2019 Rockchip Electronics Co., Ltd
++ * (C) Copyright 2020 David Bauer
++ */
++
++#include "rk3328-u-boot.dtsi"
++#include "rk3328-sdram-ddr4-666.dtsi"
++/ {
++	chosen {
++		u-boot,spl-boot-order = "same-as-spl", &sdmmc, &emmc;
++	};
++};
++
++&gpio0 {
++	u-boot,dm-spl;
++};
++
++&pinctrl {
++	u-boot,dm-spl;
++};
++
++&sdmmc0m1_gpio {
++	u-boot,dm-spl;
++};
++
++&pcfg_pull_up_4ma {
++	u-boot,dm-spl;
++};
++
++/* Need this and all the pinctrl/gpio stuff above to set pinmux */
++&vcc_sd {
++	u-boot,dm-spl;
++};
+diff --git a/arch/arm/dts/rk3328-orangepi-r1-plus.dts b/arch/arm/dts/rk3328-orangepi-r1-plus.dts
+new file mode 100644
+index 00000000..b8dc25e6
 --- /dev/null
 +++ b/arch/arm/dts/rk3328-orangepi-r1-plus.dts
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,334 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+#include "rk3328-nanopi-r2s.dts"
++/*
++ * Copyright (c) 2020 David Bauer <mail@david-bauer.net>
++ */
++
++/dts-v1/;
++
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/gpio/gpio.h>
++#include "rk3328.dtsi"
 +
 +/ {
 +	model = "Xunlong Orange Pi R1 PLUS";
 +	compatible = "xunlong,orangepi-r1-plus", "rockchip,rk3328";
-+};
 +
-+&lan_led {
-+	label = "orangepi-r1-plus:green:lan";
-+};
++	chosen {
++		stdout-path = "serial2:1500000n8";
++	};
 +
-+&spi0 {
-+	max-freq = <48000000>;
-+	status = "okay";
++	gmac_clkin: external-gmac-clock {
++		compatible = "fixed-clock";
++		clock-frequency = <125000000>;
++		clock-output-names = "gmac_clkin";
++		#clock-cells = <0>;
++	};
 +
-+	flash@0 {
-+		compatible = "jedec,spi-nor";
-+		reg = <0>;
-+		spi-max-frequency = <10000000>;
++	vcc_sd: sdmmc-regulator {
++		compatible = "regulator-fixed";
++		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&sdmmc0m1_gpio>;
++		regulator-name = "vcc_sd";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_io>;
++	};
++
++	vcc_sdio: sdmmcio-regulator {
++		compatible = "regulator-gpio";
++		gpios = <&gpio1 RK_PD4 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		states = <1800000 0x1
++			  3300000 0x0>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&sdio_vcc_pin>;
++		regulator-always-on;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-name = "vcc_sdio";
++		regulator-settling-time-us = <5000>;
++		regulator-type = "voltage";
++		vin-supply = <&vcc_io>;
++	};
++
++	vcc_sys: vcc-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&led_pins>;
++
++		sys {
++			gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
++			label = "orangepi-r1-plus:red:sys";
++		};
++
++		lan {
++			gpios = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
++			label = "orangepi-r1-plus:green:lan";
++		};
++
++		wan {
++			gpios = <&gpio2 RK_PC2 GPIO_ACTIVE_HIGH>;
++			label = "orangepi-r1-plus:green:wan";
++		};
++	};
++
++	gpio_keys {
++		compatible = "gpio-keys-polled";
++		poll-interval = <100>;
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&button_pins>;
++
++		reset {
++			label = "Reset Button";
++			gpios = <&gpio0 RK_PA0 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_RESTART>;
++			debounce-interval = <50>;
++		};
 +	};
 +};
 +
-+&sys_led {
-+	gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
-+	label = "orangepi-r1-plus:red:sys";
++&cpu0 {
++	cpu-supply = <&vdd_arm>;
 +};
 +
-+&sys_led_pin {
-+	rockchip,pins = <3 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++&cpu1 {
++	cpu-supply = <&vdd_arm>;
 +};
 +
-+&uart1 {
++&cpu2 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu3 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&gmac2io {
++	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
++	assigned-clock-parents = <&gmac_clkin>, <&gmac_clkin>;
++	clock_in_out = "input";
++	phy-supply = <&vcc_io>;
++	phy-handle = <&rtl8211e>;
++	phy-mode = "rgmii";
++	pinctrl-names = "default";
++	pinctrl-0 = <&rgmiim1_pins>;
++	snps,aal;
++	snps,reset-gpio = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
++	snps,reset-active-low;
++	snps,reset-delays-us = <0 10000 50000>;
++	tx_delay = <0x24>;
++	rx_delay = <0x18>;
++	status = "okay";
++
++	mdio {
++		compatible = "snps,dwmac-mdio";
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		rtl8211e: ethernet-phy@0 {
++			reg = <0>;
++		};
++	};
++};
++
++&i2c1 {
++	status = "okay";
++
++	rk805: rk805@18 {
++		compatible = "rockchip,rk805";
++		reg = <0x18>;
++		interrupt-parent = <&gpio2>;
++		interrupts = <6 IRQ_TYPE_LEVEL_LOW>;
++		#clock-cells = <1>;
++		clock-output-names = "xin32k", "rk805-clkout2";
++		gpio-controller;
++		#gpio-cells = <2>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_int_l>;
++		rockchip,system-power-controller;
++		wakeup-source;
++
++		vcc1-supply = <&vcc_sys>;
++		vcc2-supply = <&vcc_sys>;
++		vcc3-supply = <&vcc_sys>;
++		vcc4-supply = <&vcc_sys>;
++		vcc5-supply = <&vcc_io>;
++		vcc6-supply = <&vcc_sys>;
++
++		regulators {
++			vdd_logic: DCDC_REG1 {
++				regulator-name = "vdd_logic";
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-ramp-delay = <12500>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++
++			vdd_arm: DCDC_REG2 {
++				regulator-name = "vdd_arm";
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-ramp-delay = <12500>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <950000>;
++				};
++			};
++
++			vcc_ddr: DCDC_REG3 {
++				regulator-name = "vcc_ddr";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_io: DCDC_REG4 {
++				regulator-name = "vcc_io";
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vcc_18: LDO_REG1 {
++				regulator-name = "vcc_18";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc18_emmc: LDO_REG2 {
++				regulator-name = "vcc18_emmc";
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_10: LDO_REG3 {
++				regulator-name = "vdd_10";
++				regulator-min-microvolt = <1000000>;
++				regulator-max-microvolt = <1000000>;
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++		};
++	};
++};
++
++&io_domains {
++	status = "okay";
++
++	vccio1-supply = <&vcc_io>;
++	vccio2-supply = <&vcc18_emmc>;
++	vccio3-supply = <&vcc_sdio>;
++	vccio4-supply = <&vcc_18>;
++	vccio5-supply = <&vcc_io>;
++	vccio6-supply = <&vcc_io>;
++	pmuio-supply = <&vcc_io>;
++};
++
++&pinctrl {
++	leds {
++		led_pins: led-pins {
++			rockchip,pins = <3 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>,
++							<2 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>,
++							<2 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	button {
++		button_pins: button-pins {
++			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pmic {
++		pmic_int_l: pmic-int-l {
++			rockchip,pins = <2 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	sd {
++		sdio_vcc_pin: sdio-vcc-pin {
++			rockchip,pins = <1 RK_PD4 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++};
++
++&sdmmc {
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	disable-wp;
++	max-frequency = <150000000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_dectn &sdmmc0_bus4>;
++	vmmc-supply = <&vcc_sd>;
++	vqmmc-supply = <&vcc_sdio>;
 +	status = "okay";
 +};
 +
-+&wan_led {
-+	label = "orangepi-r1-plus:green:wan";
++&tsadc {
++	rockchip,hw-tshut-mode = <0>;
++	rockchip,hw-tshut-polarity = <0>;
++	status = "okay";
 +};
++
++&uart2 {
++	status = "okay";
++};
++
++&u2phy {
++	status = "okay";
++
++	u2phy_host: host-port {
++		status = "okay";
++	};
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
+diff --git a/board/rockchip/evb_rk3328/MAINTAINERS b/board/rockchip/evb_rk3328/MAINTAINERS
+index 14fda46e..612c785b 100644
 --- a/board/rockchip/evb_rk3328/MAINTAINERS
 +++ b/board/rockchip/evb_rk3328/MAINTAINERS
 @@ -12,6 +12,13 @@ F:      configs/nanopi-r2s-rk3328_defconfig
  F:      arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi
  F:      arch/arm/dts/rk3328-nanopi-r2s.dts
  
-+ORANGEPI-R1-PLUS-RK3328
-+M:      Shenzhen Xunlong Software CO.,Limited <zhao_steven@263.net>
++orangepi-r1-plus-RK3328
++M:      Zhao <zhao_steven@263.net>
 +S:      Maintained
 +F:      configs/orangepi-r1-plus-rk3328_defconfig
 +F:      arch/arm/dts/rk3328-orangepi-r1-plus-u-boot.dtsi
@@ -70,9 +408,12 @@
  ROC-RK3328-CC
  M:      Loic Devulder <ldevulder@suse.com>
  M:      Chen-Yu Tsai <wens@csie.org>
+diff --git a/configs/orangepi-r1-plus-rk3328_defconfig b/configs/orangepi-r1-plus-rk3328_defconfig
+new file mode 100644
+index 00000000..5389db20
 --- /dev/null
 +++ b/configs/orangepi-r1-plus-rk3328_defconfig
-@@ -0,0 +1,98 @@
+@@ -0,0 +1,99 @@
 +CONFIG_ARM=y
 +CONFIG_ARCH_ROCKCHIP=y
 +CONFIG_SYS_TEXT_BASE=0x00200000
@@ -87,7 +428,7 @@
 +CONFIG_NR_DRAM_BANKS=1
 +CONFIG_DEBUG_UART_BASE=0xFF130000
 +CONFIG_DEBUG_UART_CLOCK=24000000
-+CONFIG_SYSINFO=y
++CONFIG_SMBIOS_PRODUCT_NAME="orangepi_r1plus_rk3328"
 +CONFIG_DEBUG_UART=y
 +CONFIG_TPL_SYS_MALLOC_F_LEN=0x800
 +# CONFIG_ANDROID_BOOT_IMAGE is not set
@@ -171,3 +512,4 @@
 +CONFIG_SPL_TINY_MEMSET=y
 +CONFIG_TPL_TINY_MEMSET=y
 +CONFIG_ERRNO_STR=y
++CONFIG_SMBIOS_MANUFACTURER="pine64"

--- a/target/linux/rockchip/patches-5.4/202-rockchip-rk3328-Add-support-for-OrangePi-R1-Plus.patch
+++ b/target/linux/rockchip/patches-5.4/202-rockchip-rk3328-Add-support-for-OrangePi-R1-Plus.patch
@@ -1,3 +1,5 @@
+diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
+index 3d011c4e6..23373c752 100644
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
 @@ -2,6 +2,7 @@
@@ -8,45 +10,424 @@
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock64.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-roc-cc.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-evb-act8846.dtb
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus.dts b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus.dts
+new file mode 100644
+index 000000000..7e4e9d7b4
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus.dts
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,415 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-+#include "rk3328-nanopi-r2s.dts"
++/*
++ * Copyright (c) 2020 David Bauer <mail@david-bauer.net>
++ */
++
++/dts-v1/;
++
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/gpio/gpio.h>
++#include "rk3328.dtsi"
 +
 +/ {
-+	model = "Xunlong Orange Pi R1 PLUS";
++	model = "Orange Pi R1 PLUS";
 +	compatible = "xunlong,orangepi-r1-plus", "rockchip,rk3328";
-+};
 +
-+&lan_led {
-+	label = "orangepi-r1-plus:green:lan";
-+};
++	aliases {
++		led-boot = &sys_led;
++		led-failsafe = &sys_led;
++		led-running = &sys_led;
++		led-upgrade = &sys_led;
++	};
 +
-+&spi0 {
-+	max-freq = <48000000>;
-+	status = "okay";
++	chosen {
++		stdout-path = "serial2:1500000n8";
++	};
 +
-+	flash@0 {
-+		compatible = "jedec,spi-nor";
-+		reg = <0>;
-+		spi-max-frequency = <10000000>;
++	gmac_clk: gmac-clock {
++		compatible = "fixed-clock";
++		clock-frequency = <125000000>;
++		clock-output-names = "gmac_clkin";
++		#clock-cells = <0>;
++	};
++
++	keys {
++		compatible = "gpio-keys";
++		pinctrl-0 = <&reset_button_pin>;
++		pinctrl-names = "default";
++
++		reset {
++			label = "reset";
++			gpios = <&gpio0 RK_PA0 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_RESTART>;
++			debounce-interval = <50>;
++		};
++	};
++
++	vcc_rtl8153: vcc-rtl8153-regulator {
++		compatible = "regulator-fixed";
++		gpio = <&gpio2 RK_PC6 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&rtl8153_en_drv>;
++		regulator-always-on;
++		regulator-name = "vcc_rtl8153";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		enable-active-high;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-0 = <&lan_led_pin>,  <&sys_led_pin>, <&wan_led_pin>;
++		pinctrl-names = "default";
++
++		lan_led: led-0 {
++			gpios = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
++			label = "orangepi-r1-plus:green:lan";
++		};
++
++		sys_led: led-1 {
++			gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
++			label = "orangepi-r1-plus:red:sys";
++		};
++
++		wan_led: led-2 {
++			gpios = <&gpio2 RK_PC2 GPIO_ACTIVE_HIGH>;
++			label = "orangepi-r1-plus:green:wan";
++		};
++	};
++
++	vcc_io_sdio: sdmmcio-regulator {
++		compatible = "regulator-gpio";
++		enable-active-high;
++		gpios = <&gpio1 RK_PD4 GPIO_ACTIVE_HIGH>;
++		pinctrl-0 = <&sdio_vcc_pin>;
++		pinctrl-names = "default";
++		regulator-name = "vcc_io_sdio";
++		regulator-always-on;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-settling-time-us = <5000>;
++		regulator-type = "voltage";
++		startup-delay-us = <2000>;
++		states = <1800000 0x1
++			  3300000 0x0>;
++		vin-supply = <&vcc_io_33>;
++	};
++
++	vcc_sd: sdmmc-regulator {
++		compatible = "regulator-fixed";
++		gpio = <&gpio0 RK_PD6 GPIO_ACTIVE_LOW>;
++		pinctrl-0 = <&sdmmc0m1_gpio>;
++		pinctrl-names = "default";
++		regulator-name = "vcc_sd";
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_io_33>;
++	};
++
++	vdd_5v: vdd-5v {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_5v";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
 +	};
 +};
 +
-+&sys_led {
-+	gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
-+	label = "orangepi-r1-plus:red:sys";
++&cpu0 {
++	cpu-supply = <&vdd_arm>;
 +};
 +
-+&sys_led_pin {
-+	rockchip,pins = <3 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++&cpu1 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu2 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu3 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&gmac2io {
++	assigned-clocks = <&cru SCLK_MAC2IO>, <&cru SCLK_MAC2IO_EXT>;
++	assigned-clock-parents = <&gmac_clk>, <&gmac_clk>;
++	clock_in_out = "input";
++	phy-handle = <&rtl8211e>;
++	phy-mode = "rgmii";
++	phy-supply = <&vcc_io_33>;
++	pinctrl-0 = <&rgmiim1_pins>;
++	pinctrl-names = "default";
++	rx_delay = <0x18>;
++	snps,aal;
++	tx_delay = <0x24>;
++	status = "okay";
++
++	mdio {
++		compatible = "snps,dwmac-mdio";
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		rtl8211e: ethernet-phy@1 {
++			compatible = "ethernet-phy-id001c.c915",
++				     "ethernet-phy-ieee802.3-c22";
++			reg = <1>;
++			pinctrl-0 = <&eth_phy_reset_pin>;
++			pinctrl-names = "default";
++			reset-assert-us = <10000>;
++			reset-deassert-us = <50000>;
++			reset-gpios = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&i2c1 {
++	status = "okay";
++
++	rk805: pmic@18 {
++		compatible = "rockchip,rk805";
++		reg = <0x18>;
++		interrupt-parent = <&gpio1>;
++		interrupts = <24 IRQ_TYPE_LEVEL_LOW>;
++		#clock-cells = <1>;
++		clock-output-names = "xin32k", "rk805-clkout2";
++		gpio-controller;
++		#gpio-cells = <2>;
++		pinctrl-0 = <&pmic_int_l>;
++		pinctrl-names = "default";
++		rockchip,system-power-controller;
++		wakeup-source;
++
++		vcc1-supply = <&vdd_5v>;
++		vcc2-supply = <&vdd_5v>;
++		vcc3-supply = <&vdd_5v>;
++		vcc4-supply = <&vdd_5v>;
++		vcc5-supply = <&vcc_io_33>;
++		vcc6-supply = <&vdd_5v>;
++
++		regulators {
++			vdd_log: DCDC_REG1 {
++				regulator-name = "vdd_log";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++
++			vdd_arm: DCDC_REG2 {
++				regulator-name = "vdd_arm";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <712500>;
++				regulator-max-microvolt = <1450000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <950000>;
++				};
++			};
++
++			vcc_ddr: DCDC_REG3 {
++				regulator-name = "vcc_ddr";
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_io_33: DCDC_REG4 {
++				regulator-name = "vcc_io_33";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vcc_18: LDO_REG1 {
++				regulator-name = "vcc_18";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc18_emmc: LDO_REG2 {
++				regulator-name = "vcc18_emmc";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_10: LDO_REG3 {
++				regulator-name = "vdd_10";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1000000>;
++				regulator-max-microvolt = <1000000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1000000>;
++				};
++			};
++		};
++	};
++
++	usb {
++		rtl8153_en_drv: rtl8153-en-drv {
++			rockchip,pins = <2 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&io_domains {
++	pmuio-supply = <&vcc_io_33>;
++	vccio1-supply = <&vcc_io_33>;
++	vccio2-supply = <&vcc18_emmc>;
++	vccio3-supply = <&vcc_io_sdio>;
++	vccio4-supply = <&vcc_18>;
++	vccio5-supply = <&vcc_io_33>;
++	vccio6-supply = <&vcc_io_33>;
++	status = "okay";
++};
++
++&pinctrl {
++	button {
++		reset_button_pin: reset-button-pin {
++			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	ethernet-phy {
++		eth_phy_reset_pin: eth-phy-reset-pin {
++			rockchip,pins = <1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	leds {
++		lan_led_pin: lan-led-pin {
++			rockchip,pins = <2 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		sys_led_pin: sys-led-pin {
++			rockchip,pins = <0 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		wan_led_pin: wan-led-pin {
++			rockchip,pins = <2 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pmic {
++		pmic_int_l: pmic-int-l {
++			rockchip,pins = <1 RK_PD0 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++
++	sd {
++		sdio_vcc_pin: sdio-vcc-pin {
++			rockchip,pins = <1 RK_PD4 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++};
++
++&pwm2 {
++	status = "okay";
++};
++
++&sdmmc {
++	bus-width = <4>;
++	cap-sd-highspeed;
++	disable-wp;
++	pinctrl-0 = <&sdmmc0_clk>, <&sdmmc0_cmd>, <&sdmmc0_dectn>, <&sdmmc0_bus4>;
++	pinctrl-names = "default";
++	//sd-uhs-sdr12;
++	//sd-uhs-sdr25;
++	//sd-uhs-sdr50;
++	//sd-uhs-sdr104;
++	vmmc-supply = <&vcc_sd>;
++	vqmmc-supply = <&vcc_io_sdio>;
++	status = "okay";
++};
++
++&tsadc {
++	rockchip,hw-tshut-mode = <0>;
++	rockchip,hw-tshut-polarity = <0>;
++	status = "okay";
++};
++
++&u2phy {
++	status = "okay";
++};
++
++&u2phy_host {
++	status = "okay";
++};
++
++&u2phy_otg {
++	status = "okay";
 +};
 +
 +&uart1 {
 +	status = "okay";
 +};
 +
-+&wan_led {
-+	label = "orangepi-r1-plus:green:wan";
++&uart2 {
++	status = "okay";
++};
++
++&usb20_otg {
++	status = "okay";
++	dr_mode = "host";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usbdrd3 {
++	status = "okay";
++};
++
++&usbdrd_dwc3 {
++	dr_mode = "host";
++	status = "okay";
++
++	usb-eth@2 {
++		compatible = "realtek,rtl8153";
++		reg = <2>;
++
++		realtek,led-data = <0x87>;
++	};
 +};


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x ] 我知道
这个主要是之前大神提供的Orangepi R1 Plus的支持，我编译之后一直不可用。然后经过自己试验，把香橙派官方那个内核和uboot的内容整合进来了，改完之后，可以正常编译，R1 Plus可以正常使用了。