### PR TITLE
cypress-firmware: bump to v5.4.18-2020_0925

### DIFF
--- a/package/firmware/cypress-firmware/Makefile
+++ b/package/firmware/cypress-firmware/Makefile
@@ -10,13 +10,13 @@ include $(TOPDIR)/rules.mk
 UNPACK_CMD=unzip -q -p $(DL_DIR)/$(PKG_SOURCE) $(PKG_SOURCE_UNZIP) | gzip -dc | $(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 
 PKG_NAME:=cypress-firmware
-PKG_VERSION:=v5.4.18-2020_0402
+PKG_VERSION:=v5.4.18-2020_0925
 PKG_RELEASE:=3
 
 PKG_SOURCE_UNZIP:=cypress-firmware-$(PKG_VERSION).tar.gz
 PKG_SOURCE:=cypress-fmac-$(PKG_VERSION).zip
-PKG_SOURCE_URL:=https://community.cypress.com/gfawx74859/attachments/gfawx74859/resourcelibrary/1016/1/
-PKG_HASH:=b12b0570f462c2f3c26dde98b10235a845a7109037def1e7e51af728bcc1a958
+PKG_SOURCE_URL:=https://community.cypress.com/gfawx74859/attachments/gfawx74859/resourcelibrary/1030/1/
+PKG_HASH:=fb71c344e705f5bc9fdae3ce0fbfa299f0af0939ff3ec782aeca0308911d830d
 
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 
@@ -41,10 +41,10 @@ endef
 define Package/cypress-firmware-43012-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43012-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43012-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43012-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43012-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43012-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac43012-sdio.clm_blob
 endef
 
@@ -59,7 +59,7 @@ endef
 define Package/cypress-firmware-43340-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43340-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43340-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43340-sdio.bin
 endef
 
@@ -76,7 +76,7 @@ endef
 define Package/cypress-firmware-43362-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43362-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43362-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43362-sdio.bin
 endef
 
@@ -91,7 +91,7 @@ endef
 define Package/cypress-firmware-4339-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4339-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4339-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4339-sdio.bin
 endef
 
@@ -108,10 +108,10 @@ endef
 define Package/cypress-firmware-43430-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43430-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43430-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43430-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43430-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43430-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac43430-sdio.clm_blob
 endef
 
@@ -128,10 +128,10 @@ endef
 define Package/cypress-firmware-43455-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43455-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43455-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43455-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43455-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43455-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac43455-sdio.clm_blob
 endef
 
@@ -146,10 +146,10 @@ endef
 define Package/cypress-firmware-4354-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4354-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4354-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4354-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4354-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4354-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4354-sdio.clm_blob
 endef
 
@@ -164,10 +164,10 @@ endef
 define Package/cypress-firmware-4356-pcie/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4356-pcie.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4356-pcie.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4356-pcie.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4356-pcie.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4356-pcie.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4356-pcie.clm_blob
 endef
 
@@ -182,10 +182,10 @@ endef
 define Package/cypress-firmware-4356-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4356-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4356-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4356-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4356-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4356-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4356-sdio.clm_blob
 endef
 
@@ -200,10 +200,10 @@ endef
 define Package/cypress-firmware-43570-pcie/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43570-pcie.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43570-pcie.bin \
 		$(1)/lib/firmware/brcm/brcmfmac43570-pcie.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac43570-pcie.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac43570-pcie.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac43570-pcie.clm_blob
 endef
 
@@ -218,10 +218,10 @@ endef
 define Package/cypress-firmware-4359-pcie/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4359-pcie.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4359-pcie.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4359-pcie.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4359-pcie.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4359-pcie.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4359-pcie.clm_blob
 endef
 
@@ -236,10 +236,10 @@ endef
 define Package/cypress-firmware-4359-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4359-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4359-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4359-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4359-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4359-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4359-sdio.clm_blob
 endef
 
@@ -254,10 +254,10 @@ endef
 define Package/cypress-firmware-4373-sdio/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4373-sdio.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4373-sdio.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4373-sdio.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4373-sdio.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4373-sdio.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4373-sdio.clm_blob
 endef
 
@@ -272,10 +272,10 @@ endef
 define Package/cypress-firmware-4373-usb/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4373-usb.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4373-usb.bin \
 		$(1)/lib/firmware/brcm/brcmfmac4373-usb.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac4373.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac4373.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac4373.clm_blob
 endef
 
@@ -290,10 +290,10 @@ endef
 define Package/cypress-firmware-54591-pcie/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac54591-pcie.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac54591-pcie.bin \
 		$(1)/lib/firmware/brcm/brcmfmac54591-pcie.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac54591-pcie.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac54591-pcie.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac54591-pcie.clm_blob
 endef
 
@@ -308,10 +308,10 @@ endef
 define Package/cypress-firmware-89459-pcie/install
 	$(INSTALL_DIR) $(1)/lib/firmware/brcm
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac89459-pcie.bin \
+		$(PKG_BUILD_DIR)/firmware/cyfmac89459-pcie.bin \
 		$(1)/lib/firmware/brcm/brcmfmac89459-pcie.bin
 	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/firmware/brcmfmac89459-pcie.clm_blob \
+		$(PKG_BUILD_DIR)/firmware/cyfmac89459-pcie.clm_blob \
 		$(1)/lib/firmware/brcm/brcmfmac89459-pcie.clm_blob
 endef
 


### PR DESCRIPTION
仅在树莓派4B上测试过（增加了140-161信道的支持），文档链接：https://community.cypress.com/t5/Resource-Library/Cypress-Linux-WiFi-Driver-Release-FMAC-2020-09-25/ta-p/251089
