### PR TITLE
使 DNSMASQ 缓存设置有效化

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.conf
+++ b/package/network/services/dnsmasq/files/dnsmasq.conf
@@ -35,3 +35,8 @@
 # "bert" another name, bertrand
 # The fields are <cname>,<target>
 #cname=bertand,bert
+
+neg-ttl=600
+# max-ttl=600
+min-cache-ttl=3600
+auth-ttl=3600


### PR DESCRIPTION
默认情况下 SSR PLUS DNS结果根本无法缓存(由于引入拒绝ipv6结果导致的问题)，nslookup & dig 延迟每次依然有200-300多.
dnsmasq处设置缓存依然无效，设置TTL也无效，应该是bug。
解决办法是手动指定缓存TTL为最大一小时。域名查询实测有效缓存0延迟。 

此变更仅使开启dnsmasq缓存的情况下正常工作。


