### PR TITLE
UnblockNeteaseMusic: Change source to 1715173329

### DIFF
--- a/package/lean/UnblockNeteaseMusic/Makefile
+++ b/package/lean/UnblockNeteaseMusic/Makefile
@@ -9,13 +9,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=UnblockNeteaseMusic
 PKG_VERSION:=0.25.3
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_LICENSE:=MIT
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/nondanee/UnblockNeteaseMusic.git
-PKG_SOURCE_VERSION:=1193e29a2c8f72c738d2988d5cf5afbb2fee7463
+PKG_SOURCE_URL:=https://github.com/1715173329/UnblockNeteaseMusic.git
+PKG_SOURCE_VERSION:=7fe969342c2a977f00a4a7b6a275ffae04ffffea
 
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)
 PKG_SOURCE:=$(PKG_SOURCE_SUBDIR)-$(PKG_VERSION).tar.gz

--- a/package/lean/luci-app-unblockmusic/Makefile
+++ b/package/lean/luci-app-unblockmusic/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-unblockmusic
 PKG_VERSION:=2.3.5
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_CONFIG_DEPENDS := \
 	CONFIG_UnblockNeteaseMusic_Go \

--- a/package/lean/luci-app-unblockmusic/luasrc/model/cbi/unblockmusic/unblockmusic.lua
+++ b/package/lean/luci-app-unblockmusic/luasrc/model/cbi/unblockmusic/unblockmusic.lua
@@ -69,7 +69,7 @@ o.description = translate("每天自动检测并更新到最新版本")
 o:depends("apptype", "nodejs")
 
 download_certificate=s:option(DummyValue,"opennewwindow",translate("HTTPS 证书"))
-download_certificate.description = translate("<input type=\"button\" class=\"btn cbi-button cbi-button-apply\" value=\"下载CA根证书\" onclick=\"window.open('https://raw.githubusercontent.com/nondanee/UnblockNeteaseMusic/master/ca.crt')\" /><br />Mac/iOS客户端需要安装 CA根证书并信任<br />iOS系统需要在“设置 -> 通用 -> 关于本机 -> 证书信任设置”中，信任 UnblockNeteaseMusic Root CA <br />Linux 设备请在启用时加入 --ignore-certificate-errors 参数")
+download_certificate.description = translate("<input type=\"button\" class=\"btn cbi-button cbi-button-apply\" value=\"下载CA根证书\" onclick=\"window.open('https://raw.githubusercontent.com/1715173329/UnblockNeteaseMusic/enhanced/ca.crt')\" /><br />Mac/iOS客户端需要安装 CA根证书并信任<br />iOS系统需要在“设置 -> 通用 -> 关于本机 -> 证书信任设置”中，信任 UnblockNeteaseMusic Root CA <br />Linux 设备请在启用时加入 --ignore-certificate-errors 参数")
 
 local ver = fs.readfile("/usr/share/UnblockNeteaseMusic/core_ver") or "0.00"
 

--- a/package/lean/luci-app-unblockmusic/root/usr/share/UnblockNeteaseMusic/update_core.sh
+++ b/package/lean/luci-app-unblockmusic/root/usr/share/UnblockNeteaseMusic/update_core.sh
@@ -10,7 +10,7 @@ function clean_log(){
 }
 
 function check_latest_version(){
-	latest_ver="$(wget-ssl --no-check-certificate -O- https://github.com/nondanee/UnblockNeteaseMusic/commits/master |tr -d '\n' |grep -Eo 'commit\/[0-9a-z]+' |sed -n 1p |sed 's#commit/##g')"
+	latest_ver="$(wget-ssl --no-check-certificate -O- https://github.com/1715173329/UnblockNeteaseMusic/commits/enhanced |tr -d '\n' |grep -Eo 'commit\/[0-9a-z]+' |sed -n 1p |sed 's#commit/##g')"
 	[ -z "${latest_ver}" ] && echo -e "\nFailed to check latest version, please try again later." >>/tmp/unblockmusic_update.log && exit 1
 	if [ ! -e "/usr/share/UnblockNeteaseMusic/local_ver" ]; then
 		clean_log
@@ -36,12 +36,12 @@ function update_core(){
 	mkdir -p "/tmp/unblockneteasemusic/core" >/dev/null 2>&1
 	rm -rf /tmp/unblockneteasemusic/core/* >/dev/null 2>&1
 
-	wget-ssl --no-check-certificate -t 1 -T 10 -O  /tmp/unblockneteasemusic/core/core.tar.gz "https://github.com/nondanee/UnblockNeteaseMusic/archive/master.tar.gz"  >/dev/null 2>&1
+	wget-ssl --no-check-certificate -t 1 -T 10 -O  /tmp/unblockneteasemusic/core/core.tar.gz "https://github.com/1715173329/UnblockNeteaseMusic/archive/enhanced.tar.gz"  >/dev/null 2>&1
 	tar -zxf "/tmp/unblockneteasemusic/core/core.tar.gz" -C "/tmp/unblockneteasemusic/core/" >/dev/null 2>&1
 	if [ -e "/usr/share/UnblockNeteaseMusic/ca.crt" ] && [ -e "/usr/share/UnblockNeteaseMusic/server.crt" ] && [ -e "/usr/share/UnblockNeteaseMusic/server.key" ] ; then
-		rm -f /tmp/unblockneteasemusic/core/UnblockNeteaseMusic-master/ca.crt /tmp/unblockneteasemusic/core/UnblockNeteaseMusic-master/server.crt /tmp/unblockneteasemusic/core/UnblockNeteaseMusic-master/server.key
+		rm -f /tmp/unblockneteasemusic/core/UnblockNeteaseMusic-enhanced/ca.crt /tmp/unblockneteasemusic/core/UnblockNeteaseMusic-enhanced/server.crt /tmp/unblockneteasemusic/core/UnblockNeteaseMusic-enhanced/server.key
 	fi
-	cp -a /tmp/unblockneteasemusic/core/UnblockNeteaseMusic-master/* "/usr/share/UnblockNeteaseMusic/"
+	cp -a /tmp/unblockneteasemusic/core/UnblockNeteaseMusic-enhanced/* "/usr/share/UnblockNeteaseMusic/"
 	rm -rf "/tmp/unblockneteasemusic" >/dev/null 2>&1
 
 	if [ ! -e "/usr/share/UnblockNeteaseMusic/app.js" ]; then


### PR DESCRIPTION
编译前需要删除dl/UnblockNeteaseMusic-0.25.3.tar.gz再编译
更新固件前需要ssh进去OpenWrt，删掉/lib/upgrade/keep.d/unblockmusic后再更新
这样才能覆盖掉原有的证书