### PR TITLE
修复dns无法启用

### DIFF
--- a/package/lean/luci-app-sfe/root/etc/init.d/sfe
+++ b/package/lean/luci-app-sfe/root/etc/init.d/sfe
@@ -128,7 +128,7 @@ pdnsd_genconfig() {
 	EOF
 
 	[ -d /var/sbin ] || mkdir -p /var/sbin
-	[ -f /var/sbin/dnscache ] || ln -s /usr/sbin/pdnsd /var/sbin/dnscache
+	[ -f /var/sbin/dnscache ] || ln -s /usr/bin/pdnsd /var/sbin/dnscache
 }
 
 change_dns() {


### PR DESCRIPTION
 pdnsd文件现在已经在/usr/bin目录了。

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ x] 我知道
