### PR TITLE
luci-app-xlnetacc: 删除非必要依赖luci-compat

### DIFF
--- a/package/lean/default-settings/Makefile
+++ b/package/lean/default-settings/Makefile
@@ -21,7 +21,7 @@ define Package/default-settings
   CATEGORY:=LuCI
   TITLE:=LuCI support for Default Settings
   PKGARCH:=all
-  DEPENDS:=+luci-base +luci +luci-compat +@LUCI_LANG_zh-cn
+  DEPENDS:=+luci-base +luci +@LUCI_LANG_zh-cn
 endef
 
 define Package/default-settings/description

--- a/package/lean/luci-app-xlnetacc/Makefile
+++ b/package/lean/luci-app-xlnetacc/Makefile
@@ -12,7 +12,7 @@ define Package/$(PKG_NAME)
 	SUBMENU:=3. Applications
 	TITLE:=LuCI Support for XLNetAcc
 	PKGARCH:=all
-	DEPENDS:=+jshn +curl +openssl-util +luci-compat
+	DEPENDS:=+jshn +curl +openssl-util
 	MAINTAINER:=Sense <sensec@gmail.com>
 endef
 


### PR DESCRIPTION
当前源码采用旧版luci，luci-compat此兼容包只配合新版luci使用

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
