### PR TITLE
hostapd: 默认禁用无线弱信号自动剔除功能

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -534,7 +534,7 @@ hostapd_set_bss_options() {
 	set_default maxassoc 0
 	set_default max_inactivity 0
 	set_default short_preamble 1
-	set_default disassoc_low_ack 1
+	set_default disassoc_low_ack 0
 	set_default skip_inactivity_poll 0
 	set_default hidden 0
 	set_default wmm 1


### PR DESCRIPTION
启用该功能有可能导致无线连接不稳定，经常自动掉线的问题。且未必所有无线驱动支持该功能
参考OpenWrt FAQ：
https://openwrt.org/faq/disconnected_due_to_excessive_missing_acks
https://openwrt.org/faq/deauthenticated_due_to_inactivity

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
