### PR TITLE
添加机型： 荣欣RX_WT-600

### DIFF
--- a/target/linux/ramips/dts/mt7621_RX_WT-600.dts
+++ b/target/linux/ramips/dts/mt7621_RX_WT-600.dts
@@ -1,0 +1,171 @@
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "RX,WT-600", "mediatek,mt7621-soc";
+	model = "WT-600";
+
+	aliases {
+		led-boot = &led_power_blue;
+		led-failsafe = &led_power_blue;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_blue;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power-amber {
+			label = "amber:power";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_blue: power-blue {
+			label = "blue:power";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		internet-amber {
+			label = "amber:internet";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		internet-blue {
+			label = "blue:internet";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			label = "blue:wlan2g";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g {
+			label = "blue:wlan5g";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			label = "blue:usb";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>, <&ehci_port2>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		power_usb3 {
+			gpio-export,name = "power_usb3";
+			gpio-export,output = <1>;
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <45000000>;
+		broken-flash-reset;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1fb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&pcie1 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+	};
+};
+
+&ethernet {
+	compatible = "mediatek,ralink-mt7621-eth";
+	mediatek,switch = <&gsw>;
+	mtd-mac-address = <&factory 0xe000>;
+};
+
+&switch0 {
+	/delete-property/ compatible;
+	phy-mode = "rgmii";
+};
+
+&gsw {
+	compatible = "mediatek,ralink-mt7621-gsw";
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "uart2", "uart3";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -385,6 +385,16 @@ define Device/d-team_newifi-d2
 endef
 TARGET_DEVICES += d-team_newifi-d2
 
+define Device/RX_WT-600
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 32448k
+  DEVICE_VENDOR := WT
+  DEVICE_MODEL := 600
+  DEVICE_PACKAGES := kmod-mt7603e kmod-mt76x2e kmod-usb2 kmod-usb3 kmod-usb-storage kmod-usb-storage-extras \
+	kmod-usb-ledtrig-usbport luci-app-mtwifi -wpad-openssl
+endef
+TARGET_DEVICES += RX_WT-600
+
 define Device/d-team_pbr-m1
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := PandoraBox

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -24,6 +24,11 @@ d-team,newifi-d2)
 	ucidef_set_led_netdev "wlan2g" "WiFi 2.4GHz" "blue:wlan2g" "ra0"
 	ucidef_set_led_netdev "wlan5g" "WiFi 5GHz" "blue:wlan5g" "rai0"
 	;;
+RX,WT-600)
+	ucidef_set_led_switch "internet" "internet" "amber:internet" "switch0" "0x10"
+	ucidef_set_led_netdev "wlan2g" "WiFi 2.4GHz" "blue:wlan2g" "ra0"
+	ucidef_set_led_netdev "wlan5g" "WiFi 5GHz" "blue:wlan5g" "rai0"
+	;;
 d-team,pbr-m1)
 	ucidef_set_led_netdev "internet" "internet" "blue:internet" "wan"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -43,6 +43,11 @@ ramips_setup_interfaces()
 			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan:5" "6@eth0"
 		ucidef_set_interface_lan "eth0.1 ra0 rai0"
 		;;
+	RX,WT-600)
+		ucidef_add_switch "switch0" \
+			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan:5" "6@eth0"
+		ucidef_set_interface_lan "eth0.1 ra0 rai0"
+		;;
 	dlink,dir-867-a1|\
 	dlink,dir-878-a1|\
 	dlink,dir-882-a1|\
@@ -149,6 +154,10 @@ ramips_setup_macs()
 		lan_mac=$wan_mac
 		;;
 	d-team,newifi-d2)
+		lan_mac=$(cat /sys/class/net/eth0/address)
+		wan_mac=$(mtd_get_mac_binary factory 0xe006)
+		;;
+	RX,WT-600)
 		lan_mac=$(cat /sys/class/net/eth0/address)
 		wan_mac=$(mtd_get_mac_binary factory 0xe006)
 		;;


### PR DESCRIPTION
添加机型： 荣欣RX_WT-600

1.【新增文件】

./target/linux/ramips/dts/mt7621_RX_WT-600.dts

2.【修改文件-添加RX_WT-600型号】

./target/linux/ramips/image/mt7621.mk

./target/linux/ramips/mt7621/base-files/etc/board.d/02_network

./target/linux/ramips/mt7621/base-files/etc/board.d/01_leds

RX_WT-600配置：
CPU：	MediaTek MT7621AT
内存：128MB
闪存： 32MB
5.8G：	MT7612EN
2.4G：	MT7603EN
LLLLW：MT7530  1000Mbps
USB2.0*1 
USB3.0*1
