### PR TITLE
dnsfilter单个订阅不去重

### DIFF
--- a/package/lean/luci-app-dnsfilter/root/usr/share/dnsfilter/dnsfilter
+++ b/package/lean/luci-app-dnsfilter/root/usr/share/dnsfilter/dnsfilter
@@ -28,6 +28,7 @@ down(){
 	F=$G/ad_new.conf
 	rm -rf $G
 	mkdir -p $G $P
+	COUNT_URL=0
 	for i in $U;do
 		X=1
 		while ! uclient-fetch --no-check-certificate --timeout=5 --continue -O $F $i;do
@@ -49,9 +50,10 @@ down(){
 		fi
 		[ "$X" = "`md5sum $G/rules.conf 2>/dev/null | awk '{print$1}'`" -a "$Y" = "`md5sum $G/host 2>/dev/null | awk '{print$1}'`" ] && echo "`eval $E` [Conversion $i Failed]"
 		echo $i >> $G/url
+		let COUNT_URL++
 	done
 	[ -s $G/host ] && sed -e '/:/d' -e '/ 0.0.0.0/d' -e '/255.255.255.255/d' -e '/ local/d' -e 's:127.0.0.1 :address=/:' -e 's:0.0.0.0 :address=/:' -e 's:$:/:' $G/host >> $G/rules.conf
-	[ -s $G/rules.conf ] && sed -i -e 's:/127.0.0.1$:/:' -e 's:/0.0.0.0$:/:' $G/rules.conf && echo "`sort -u $G/rules.conf`" > $G/rules.conf
+	[ -s $G/rules.conf ] && sed -i -e 's:/127.0.0.1$:/:' -e 's:/0.0.0.0$:/:' $G/rules.conf && [ $COUNT_URL -gt 1 ] && echo "`sort -u $G/rules.conf`" > $G/rules.conf
 	[ -s $G/url ] && echo "`sort -u $G/url`" > $G/url
 	if [ -s $G/rules.conf ];then
 		echo "`eval $E` [$B Successful]"


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
小内存设备，比如64M的K2等，dnsfilter订阅1MB+的文件时，更新规则失败，从日志看是OOM了。
加了个单url订阅不排序去重的判断，目前dnsfilter可以用了，但订阅多时还是会运行失败。
看看有没有更好的解决办法，让代码更健壮写。
```log
Sat Jul 10 12:32:53 2021 kern.warn kernel: [ 5666.893961] 16384 pages RAM
Sat Jul 10 12:32:53 2021 kern.warn kernel: [ 5666.899556] 0 pages HighMem/MovableOnly
Sat Jul 10 12:32:53 2021 kern.warn kernel: [ 5666.907214] 1857 pages reserved
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5666.913593] Tasks state (memory values in pages):
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5666.923060] [  pid  ]   uid  tgid total_vm      rss pgtables_bytes swapents oom_score_adj name
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5666.940330] [    534]    81   534      317       21    12288        0             0 ubusd
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5666.956656] [    535]     0   535      236        9    12288        0             0 askfirst
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5666.973509] [   1254]   514  1254      326       42    20480        0             0 logd
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5666.989643] [   1302]     0  1302      400       26    20480        0             0 rpcd
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.005772] [   1643]     0  1643     1321       80    24576        0             0 hostapd
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.022452] [   1644]     0  1644     1342      107    24576        0             0 wpa_supplicant
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.040419] [   1702]     0  1702      450       38    20480        0             0 netifd
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.056915] [   1750]     0  1750      371       31    20480        0             0 odhcpd
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.073416] [   1952]     0  1952      409       35    20480        0             0 uhttpd
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.089914] [   2124]     0  2124      407       30    16384        0             0 nlbwmon
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.106564] [   2240]     0  2240      288       11    16384        0             0 dropbear
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.123419] [   3417]     0  3417      314       12    12288        0             0 ntpd
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.140260] [   8848]     0  8848      314       11    12288        0             0 crond
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.156623] [  10903]     0 10903      313       10    16384        0             0 udhcpc
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.173136] [  10904]     0 10904      268       14    12288        0             0 odhcp6c
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.190389] [  13474]     0 13474      313       10    12288        0             0 udhcpc
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.206917] [  13475]     0 13475      268       13    16384        0             0 odhcp6c
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.223626] [  16312]     0 16312      303       24    20480        0             0 dropbear
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.240566] [  16315]     0 16315      316       13    20480        0             0 ash
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.256544] [  23127]     0 23127      320       17    20480        0             0 sh
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.272326] [  23168]   453 23168      537      202    20480        0             0 dnsmasq
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.289006] [  23317]     0 23317     5273     4959    36864        0             0 sort
Sat Jul 10 12:32:53 2021 kern.info kernel: [ 5667.305137] oom-kill:constraint=CONSTRAINT_NONE,nodemask=(null),global_oom,task_memcg=/,task=sort,pid=23317,uid=0
Sat Jul 10 12:32:53 2021 kern.err kernel: [ 5667.325655] Out of memory: Killed process 23317 (sort) total-vm:21092kB, anon-rss:19832kB, file-rss:4kB, shmem-rss:0kB, UID:0 pgtables:36kB oom_score_adj:0
Sat Jul 10 12:32:53 2021 kern.debug kernel: [ 5667.362174] ieee80211 phy0: failed to copy skb for wlan0
Sat Jul 10 12:32:53 2021 kern.debug kernel: [ 5667.372862] ieee80211 phy0: failed to copy skb for wlan0
Sat Jul 10 12:32:53 2021 kern.debug kernel: [ 5667.383509] ieee80211 phy0: failed to copy skb for wlan0
Sat Jul 10 12:32:53 2021 kern.debug kernel: [ 5667.394144] ieee80211 phy0: failed to copy skb for wlan0
Sat Jul 10 12:32:53 2021 kern.debug kernel: [ 5667.404776] ieee80211 phy0: failed to copy skb for wlan0
```