### PR TITLE
qca-nss-ecm-64: resolve the cpu high load regarding ecm

### DIFF
--- a/package/qca/nss/qca-nss-ecm-64/patches/205-resolve-high-load.patch
+++ b/package/qca/nss/qca-nss-ecm-64/patches/205-resolve-high-load.patch
@@ -1,0 +1,61 @@
+From 6924b71ed809b37fffd74d6428a8ca83e5919746 Mon Sep 17 00:00:00 2001
+From: Dirk Buchwalder <buchwalder@posteo.de>
+Date: Sun, 27 Jun 2021 16:52:39 +0200
+Subject: [PATCH] qca-nss-ecm: resolve the cpu high load regarding ecm
+
+If using ECM, cpu load goes up (around 1.0) and stucks there.
+This is due to using uninterruptible sleep function,
+the patch changes this to interruptible sleep function.
+
+Signed-off-by: Dirk Buchwalder buchwalder@posteo.de
+---
+ frontends/nss/ecm_nss_ipv4.c | 4 ++--
+ frontends/nss/ecm_nss_ipv6.c | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/frontends/nss/ecm_nss_ipv4.c b/frontends/nss/ecm_nss_ipv4.c
+index e00553c..94b39cd 100644
+--- a/frontends/nss/ecm_nss_ipv4.c
++++ b/frontends/nss/ecm_nss_ipv4.c
+@@ -2471,7 +2471,7 @@ static void ecm_nss_ipv4_stats_sync_req_work(struct work_struct *work)
+ 	}
+ 	spin_unlock_bh(&ecm_nss_ipv4_lock);
+ 
+-	usleep_range(ECM_NSS_IPV4_STATS_SYNC_UDELAY - 100, ECM_NSS_IPV4_STATS_SYNC_UDELAY);
++	msleep_interruptible(ECM_NSS_IPV4_STATS_SYNC_UDELAY / 1000);
+ 
+ 	/*
+ 	 * If index is 0, we are starting a new round, but if we still have time remain
+@@ -2485,7 +2485,7 @@ static void ecm_nss_ipv4_stats_sync_req_work(struct work_struct *work)
+ 		}
+ 
+ 		if (time_after(ecm_nss_ipv4_next_req_time, current_jiffies)) {
+-			msleep(jiffies_to_msecs(ecm_nss_ipv4_next_req_time - current_jiffies));
++			msleep_interruptible(jiffies_to_msecs(ecm_nss_ipv4_next_req_time - current_jiffies));
+ 		}
+ 		ecm_nss_ipv4_roll_check_jiffies = jiffies;
+ 		ecm_nss_ipv4_next_req_time = ecm_nss_ipv4_roll_check_jiffies + ECM_NSS_IPV4_STATS_SYNC_PERIOD;
+diff --git a/frontends/nss/ecm_nss_ipv6.c b/frontends/nss/ecm_nss_ipv6.c
+index 82e739f..30af050 100644
+--- a/frontends/nss/ecm_nss_ipv6.c
++++ b/frontends/nss/ecm_nss_ipv6.c
+@@ -2210,7 +2210,7 @@ static void ecm_nss_ipv6_stats_sync_req_work(struct work_struct *work)
+ 	}
+ 	spin_unlock_bh(&ecm_nss_ipv6_lock);
+ 
+-	usleep_range(ECM_NSS_IPV6_STATS_SYNC_UDELAY - 100, ECM_NSS_IPV6_STATS_SYNC_UDELAY);
++	msleep_interruptible(ECM_NSS_IPV6_STATS_SYNC_UDELAY / 1000);
+ 
+ 	/*
+ 	 * If index is 0, we are starting a new round, but if we still have time remain
+@@ -2224,7 +2224,7 @@ static void ecm_nss_ipv6_stats_sync_req_work(struct work_struct *work)
+ 		}
+ 
+ 		if (time_after(ecm_nss_ipv6_next_req_time, current_jiffies)) {
+-			msleep(jiffies_to_msecs(ecm_nss_ipv6_next_req_time - current_jiffies));
++			msleep_interruptible(jiffies_to_msecs(ecm_nss_ipv6_next_req_time - current_jiffies));
+ 		}
+ 		ecm_nss_ipv6_roll_check_jiffies = jiffies;
+ 		ecm_nss_ipv6_next_req_time = ecm_nss_ipv6_roll_check_jiffies + ECM_NSS_IPV6_STATS_SYNC_PERIOD;
+-- 
+2.31.1


### PR DESCRIPTION
If using ECM, cpu load goes up (around 1.0) and stucks there.
This is due to using uninterruptible sleep function,
the patch changes this to interruptible sleep function.

Authored-by: Dirk Buchwalder buchwalder@posteo.de

Credit to: Tianling Shen cnsztl@immortalwrt.org

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
