### PR TITLE
fix RK3328 compile error on kernel 5.10.51

### DIFF
--- a/target/linux/rockchip/patches-5.10/101-dts-rockchip-add-usb3-controller-node-for-RK3328-SoCs.patch
+++ b/target/linux/rockchip/patches-5.10/101-dts-rockchip-add-usb3-controller-node-for-RK3328-SoCs.patch
@@ -26,20 +26,30 @@ use-case. You've been warned.
 
 --- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
-@@ -1003,6 +1003,33 @@
- 		status = "disabled";
+@@ -985,22 +985,30 @@
  	};
  
-+	usbdrd3: usb@ff600000 {
+ 	usbdrd3: usb@ff600000 {
+-		compatible = "rockchip,rk3328-dwc3", "snps,dwc3";
+-		reg = <0x0 0xff600000 0x0 0x100000>;
+-		interrupts = <GIC_SPI 67 IRQ_TYPE_LEVEL_HIGH>;
 +		compatible = "rockchip,rk3328-dwc3", "rockchip,rk3399-dwc3";
-+		clocks = <&cru SCLK_USB3OTG_REF>, <&cru SCLK_USB3OTG_SUSPEND>,
-+			 <&cru ACLK_USB3OTG>;
-+		clock-names = "ref_clk", "suspend_clk",
-+			      "bus_clk";
+ 		clocks = <&cru SCLK_USB3OTG_REF>, <&cru SCLK_USB3OTG_SUSPEND>,
+ 			 <&cru ACLK_USB3OTG>;
+ 		clock-names = "ref_clk", "suspend_clk",
+ 			      "bus_clk";
+-		dr_mode = "otg";
+-		phy_type = "utmi_wide";
+-		snps,dis-del-phy-power-chg-quirk;
+-		snps,dis_enblslpm_quirk;
+-		snps,dis-tx-ipgap-linecheck-quirk;
+-		snps,dis-u2-freeclk-exists-quirk;
+-		snps,dis_u2_susphy_quirk;
+-		snps,dis_u3_susphy_quirk;
 +		#address-cells = <2>;
 +		#size-cells = <2>;
 +		ranges;
-+		status = "disabled";
+ 		status = "disabled";
 +
 +		usbdrd_dwc3: dwc3@ff600000 {
 +			compatible = "snps,dwc3";
@@ -55,8 +65,6 @@ use-case. You've been warned.
 +			snps,dis-tx-ipgap-linecheck-quirk;
 +			status = "disabled";
 +		};
-+	};
-+
+ 	};
+ 
  	gic: interrupt-controller@ff811000 {
- 		compatible = "arm,gic-400";
- 		#interrupt-cells = <3>;


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ x] 我知道
在 https://github.com/coolsnowwolf/lede/commit/8575f72a6bc2720bc8fdc6e4e75c0da8adaa7317 升级了5.10.51之后nanopi r2s编译就报错通不过
改用 https://github.com/coolsnowwolf/lede/commit/a8ad0940bf17ddc07a138be6014c64b35f37e47a 里面的补丁就通过了