### PR TITLE
ramips: crypto: Fix with Mediatek EIP93 Crypto Engine for MT7621 SoC

### DIFF
--- a/package/lean/mtk-eip93/patches/0001-Fix-compilation-issues.patch
+++ b/package/lean/mtk-eip93/patches/0001-Fix-compilation-issues.patch
@@ -1,0 +1,37 @@
+From d789256e237343f17097eed7ef29be554b5a2265 Mon Sep 17 00:00:00 2001
+From: ailick <277498654@qq.com>
+Date: Sat, 31 Jul 2021 00:49:23 +0800
+Subject: [PATCH] Fix compilation issues
+
+---
+ eip93-prng.c | 1 +
+ eip93-ring.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/eip93-prng.c b/eip93-prng.c
+index 9c02522..87cd4dc 100644
+--- a/eip93-prng.c
++++ b/eip93-prng.c
+@@ -5,6 +5,7 @@
+  * Richard van Schagen <vschagen@cs.com>
+  */
+ 
++#include <linux/dma-mapping.h>
+ #include "eip93-common.h"
+ #include "eip93-core.h"
+ #include "eip93-regs.h"
+diff --git a/eip93-ring.c b/eip93-ring.c
+index fff5c0b..b553bba 100644
+--- a/eip93-ring.c
++++ b/eip93-ring.c
+@@ -5,6 +5,7 @@
+  * Richard van Schagen <vschagen@cs.com>
+  */
+ 
++#include <linux/device.h>
+ #include "eip93-common.h"
+ #include "eip93-core.h"
+ 
+-- 
+2.30.2
+

--- a/target/linux/ramips/patches-5.10/999-crypto-eip93-fix.patch
+++ b/target/linux/ramips/patches-5.10/999-crypto-eip93-fix.patch
@@ -1,0 +1,14 @@
+--- a/include/linux/crypto.h	2021-07-19 15:45:03.000000000 +0800
++++ b/include/linux/crypto.h	2021-07-31 00:41:39.404278501 +0800
+@@ -101,6 +101,11 @@
+ #define CRYPTO_NOLOAD			0x00008000
+ 
+ /*
++ * Transform masks and values (for crt_flags).
++ */
++#define CRYPTO_TFM_RES_BAD_KEY_LEN   	0x00200000
++
++/*
+  * The algorithm may allocate memory during request processing, i.e. during
+  * encryption, decryption, or hashing.  Users can request an algorithm with this
+  * flag unset if they can't handle memory allocation failures.

--- a/target/linux/ramips/patches-5.4/999-crypto-eip93-fix.patch
+++ b/target/linux/ramips/patches-5.4/999-crypto-eip93-fix.patch
@@ -1,0 +1,14 @@
+--- a/include/linux/crypto.h	2021-06-23 20:42:55.000000000 +0800
++++ b/include/linux/crypto.h	2021-07-31 00:41:29.404278501 +0800
+@@ -101,6 +101,11 @@
+ #define CRYPTO_NOLOAD			0x00008000
+ 
+ /*
++ * Transform masks and values (for crt_flags).
++ */
++#define CRYPTO_TFM_RES_BAD_KEY_LEN   	0x00200000
++
++/*
+  * The algorithm may allocate memory during request processing, i.e. during
+  * encryption, decryption, or hashing.  Users can request an algorithm with this
+  * flag unset if they can't handle memory allocation failures.


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ x ] 我知道
```
[ 21.618327] cryptodev: driver 1.11 loaded.
[ 21.636856] fuse: init (API version 7.32)
[ 21.651666] usbcore: registered new interface driver cdc_wdm
[ 21.661299] Loading modules backported from Linux version v5.10.42-0-g65859eca4dff
[ 21.668918] Backport generated by backports.git v5.10.42-1-0-gbee5c545
[ 21.680346] mtk-eip93 1e004000.crypto: PRNG initialized
[ 21.693268] mtk-eip93 1e004000.crypto: EIP93 initialized succesfull
```