### PR TITLE
ipq806x: add support for askey rt4230w 256m nand version

### DIFF
--- a/package/boot/uboot-envtools/files/ipq806x
+++ b/package/boot/uboot-envtools/files/ipq806x
@@ -30,7 +30,8 @@ ubootenv_mtdinfo () {
 }
 
 case "$board" in
-askey,rt4230w-rev6)
+askey,rt4230w-rev6|\
+askey,rt4230w-rev9.3)
 	ubootenv_add_uci_config "/dev/mtd9" "0x0" "0x40000" "0x20000"
 	;;
 edgecore,ecw5410)

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -12,6 +12,7 @@ board=$(board_name)
 
 case "$board" in
 askey,rt4230w-rev6 |\
+askey,rt4230w-rev9.3 |\
 asrock,g10 |\
 nec,wg2600hp)
 	ucidef_add_switch "switch0" \

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -25,7 +25,8 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-pci-0000:01:00.0.bin")
 	case $board in
-	askey,rt4230w-rev6)
+	askey,rt4230w-rev6 |\
+	askey,rt4230w-rev9.3)
 		caldata_extract "0:ART" 0x1000 0x2f20
 		;;
 	asrock,g10)
@@ -88,7 +89,8 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-pci-0001:01:00.0.bin")
 	case $board in
-	askey,rt4230w-rev6)
+	askey,rt4230w-rev6 |\
+	askey,rt4230w-rev9.3)
 		caldata_extract "0:ART" 0x5000 0x2f20
 		;;
 	asrock,g10)

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -11,6 +11,7 @@ platform_check_image() {
 platform_do_upgrade() {
 	case "$(board_name)" in
 	askey,rt4230w-rev6 |\
+	askey,rt4230w-rev9.3 |\
 	compex,wpq864 |\
 	netgear,d7800 |\
 	netgear,r7500 |\

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-rt4230w-rev9.3.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-rt4230w-rev9.3.dts
@@ -4,10 +4,10 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	model = "Askey RT4230W REV6";
-	compatible = "askey,rt4230w-rev6", "qcom,ipq8065", "qcom,ipq8064";
+	model = "Askey RT4230W REV9.3";
+	compatible = "askey,rt4230w-rev9.3", "qcom,ipq8065", "qcom,ipq8064";
 };
 
 &ubi {
-	reg = <0x2400000 0x1a000000>;
+	reg = <0x2400000 0xdc00000>;
 };

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-rt4230w.dtsi
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-rt4230w.dtsi
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qcom-ipq8065.dtsi"
+#include <dt-bindings/input/input.h>
+
+/ {
+	memory@0 {
+		reg = <0x42000000 0x3e000000>;
+		device_type = "memory";
+	};
+
+	aliases {
+		led-boot = &ledctrl3;
+		led-failsafe = &ledctrl1;
+		led-running = &ledctrl2;
+		led-upgrade = &ledctrl3;
+	};
+
+	chosen {
+		bootargs = "rootfstype=squashfs noinitrd";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&qcom_pinmux 68 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		ledctrl1: ledctrl1 {
+			label = "ledctrl1";
+			gpios = <&qcom_pinmux 22 GPIO_ACTIVE_HIGH>;
+		};
+
+		ledctrl2: ledctrl2 {
+			label = "ledctrl2";
+			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_HIGH>;
+		};
+
+		ledctrl3: ledctrl3 {
+			label = "ledctrl3";
+			gpios = <&qcom_pinmux 24 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&qcom_pinmux {
+	button_pins: button_pins {
+		mux {
+			pins = "gpio54", "gpio68";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
+
+	led_pins: led_pins {
+		mux {
+			pins = "gpio22", "gpio23", "gpio24";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-down;
+		};
+	};
+
+	rgmii2_pins: rgmii2_pins {
+		mux {
+			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31",
+				"gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62";
+			function = "rgmii2";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		tx {
+			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32";
+			input-disable;
+		};
+	};
+
+	spi_pins: spi_pins {
+		cs {
+			pins = "gpio20";
+			drive-strength = <12>;
+		};
+	};
+};
+
+&gsbi5 {
+	qcom,mode = <GSBI_PROT_SPI>;
+	status = "okay";
+
+	spi4: spi@1a280000 {
+		status = "okay";
+
+		pinctrl-0 = <&spi_pins>;
+		pinctrl-names = "default";
+
+		cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
+
+		m25p80@0 {
+			compatible = "everspin,mr25h256";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			spi-max-frequency = <40000000>;
+			reg = <0>;
+		};
+	};
+};
+
+&nand_controller {
+	status = "okay";
+
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+
+	nand@0 {
+		reg = <0>;
+		compatible = "qcom,nandcs";
+
+		nand-ecc-strength = <4>;
+		nand-bus-width = <8>;
+		nand-ecc-step-size = <512>;
+
+		nand-is-boot-medium;
+		qcom,boot_pages_size = <0x1180000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:SBL1";
+				reg = <0x0000000 0x0040000>;
+				read-only;
+			};
+			partition@40000 {
+				label = "0:MIBIB";
+				reg = <0x0040000 0x0140000>;
+				read-only;
+			};
+			partition@180000 {
+				label = "0:SBL2";
+				reg = <0x0180000 0x0140000>;
+				read-only;
+			};
+			partition@2c0000 {
+				label = "0:SBL3";
+				reg = <0x02c0000 0x0280000>;
+				read-only;
+			};
+			partition@540000 {
+				label = "0:DDRCONFIG";
+				reg = <0x0540000 0x0120000>;
+				read-only;
+			};
+			partition@660000 {
+				label = "0:SSD";
+				reg = <0x0660000 0x0120000>;
+				read-only;
+			};
+			partition@780000 {
+				label = "0:TZ";
+				reg = <0x0780000 0x0280000>;
+				read-only;
+			};
+			partition@a00000 {
+				label = "0:RPM";
+				reg = <0x0a00000 0x0280000>;
+				read-only;
+			};
+			partition@c80000 {
+				label = "0:APPSBL";
+				reg = <0x0c80000 0x0500000>;
+				read-only;
+			};
+			partition@1180000 {
+				label = "0:APPSBLENV";
+				reg = <0x1180000 0x0080000>;
+			};
+			ART: partition@1200000 {
+				label = "0:ART";
+				reg = <0x1200000 0x0140000>;
+				read-only;
+			};
+			partition@1340000 {
+				label = "0:BOOTCONFIG";
+				reg = <0x1340000 0x0060000>;
+				read-only;
+			};
+			partition@13a0000 {
+				label = "0:SBL2_1";
+				reg = <0x13a0000 0x0140000>;
+				read-only;
+			};
+			partition@14e0000 {
+				label = "0:SBL3_1";
+				reg = <0x14e0000 0x0280000>;
+				read-only;
+			};
+			partition@1760000 {
+				label = "0:DDRCONFIG_1";
+				reg = <0x1760000 0x0120000>;
+				read-only;
+			};
+			partition@1880000 {
+				label = "0:SSD_1";
+				reg = <0x1880000 0x0120000>;
+				read-only;
+			};
+			partition@19a0000 {
+				label = "0:TZ_1";
+				reg = <0x19a0000 0x0280000>;
+				read-only;
+			};
+			partition@1c20000 {
+				label = "0:RPM_1";
+				reg = <0x1c20000 0x0280000>;
+				read-only;
+			};
+			partition@1ea0000 {
+				label = "0:BOOTCONFIG1";
+				reg = <0x1ea0000 0x0060000>;
+				read-only;
+			};
+			partition@1f00000 {
+				label = "0:APPSBL_1";
+				reg = <0x1f00000 0x0500000>;
+				read-only;
+			};
+			ubi: partition@2400000 {
+				label = "ubi";
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio0_pins>;
+	pinctrl-names = "default";
+
+	phy0: ethernet-phy@0 {
+		reg = <0x0>;
+		qca,ar8327-initvals = <
+			0x00004 0x7600000   /* PAD0_MODE */
+			0x00008 0x1000000   /* PAD5_MODE */
+			0x0000c 0x80        /* PAD6_MODE */
+			0x000e4 0xaa545     /* MAC_POWER_SEL */
+			0x000e0 0xc74164de  /* SGMII_CTRL */
+			0x0007c 0x4e        /* PORT0_STATUS */
+			0x00094 0x4e        /* PORT6_STATUS */
+			0x00050 0xcf02cf02  /* LED_CTRL_0 */
+			0x00054 0xc832c832  /* LED_CTRL_1 */
+			>;
+	};
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&gmac0 {
+	status = "okay";
+	compatible = "qcom,nss-gmac";
+	reg = <0x37000000 0x200000>;
+	interrupts = <GIC_SPI 220 IRQ_TYPE_LEVEL_HIGH>;
+	phy-mode = "rgmii";
+	qcom,id = <0>;
+	qcom,pcs-chanid = <0>;
+	qcom,phy-mdio-addr = <0>;
+	qcom,poll-required = <0>;
+	qcom,rgmii-delay = <1>;
+	qcom,phy_mii_type = <0>;
+	qcom,emulation = <0>;
+	qcom,forced-speed = <1000>;
+	qcom,forced-duplex = <1>;
+	qcom,socver = <0>;
+	qcom,irq = <255>;
+	mdiobus = <&mdio0>;
+
+	mtd-mac-address = <&ART 0x0>;
+
+	pinctrl-0 = <&rgmii2_pins>;
+	pinctrl-names = "default";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	compatible = "qcom,nss-gmac";
+	reg = <0x37200000 0x200000>;
+	interrupts = <GIC_SPI 223 IRQ_TYPE_LEVEL_HIGH>;
+	phy-mode = "sgmii";
+	qcom,id = <1>;
+	qcom,pcs-chanid = <1>;
+	qcom,phy-mdio-addr = <4>;
+	qcom,poll-required = <0>;	/* no polling */
+	qcom,rgmii-delay = <0>;
+	qcom,phy_mii_type = <1>;
+	qcom,emulation = <0>;
+	qcom,forced-speed = <1000>;
+	qcom,forced-duplex = <1>;
+	qcom,socver = <0>;
+	qcom,irq = <258>;
+	mdiobus = <&mdio0>;
+
+	mtd-mac-address = <&ART 0x6>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&adm_dma {
+	status = "okay";
+};
+
+&usb3_0 {
+	status = "okay";
+	clocks = <&gcc USB30_1_MASTER_CLK>;
+};
+
+&usb3_1 {
+	status = "okay";
+	clocks = <&gcc USB30_0_MASTER_CLK>;
+};
+
+&pcie0 {
+	status = "okay";
+	reset-gpio = <&qcom_pinmux 3 GPIO_ACTIVE_HIGH>;
+	pinctrl-0 = <&pcie0_pins>;
+	pinctrl-names = "default";
+};
+
+&pcie1 {
+	status = "okay";
+	reset-gpio = <&qcom_pinmux 48 GPIO_ACTIVE_HIGH>;
+	pinctrl-0 = <&pcie1_pins>;
+	pinctrl-names = "default";
+	max-link-speed = <1>;
+};

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -101,18 +101,28 @@ define Device/ZyXELImage
 	IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-to $$$$(BLOCKSIZE) | sysupgrade-tar rootfs=$$$$@ | append-metadata
 endef
 
-define Device/askey_rt4230w-rev6
+define Device/askey_rt4230w
 	$(call Device/LegacyImage)
 	DEVICE_VENDOR := Askey
 	DEVICE_MODEL := RT4230W
-	DEVICE_VARIANT := REV6
 	SOC := qcom-ipq8065
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
-	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct
 	KERNEL_IN_UBI := 1
+	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct
+endef
+
+define Device/askey_rt4230w-rev6
+	$(call Device/askey_rt4230w)
+	DEVICE_VARIANT := REV6
 endef
 TARGET_DEVICES += askey_rt4230w-rev6
+
+define Device/askey_rt4230w-rev9.3
+	$(call Device/askey_rt4230w)
+	DEVICE_VARIANT := REV9.3
+endef
+TARGET_DEVICES += askey_rt4230w-rev9.3
 
 define Device/asrock_g10
 	$(call Device/FitImage)

--- a/target/linux/ipq806x/patches-5.10/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-5.10/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -907,8 +907,29 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -907,8 +907,30 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-ipq4019-ap.dk04.1-c3.dtb \
  	qcom-ipq4019-ap.dk07.1-c1.dtb \
  	qcom-ipq4019-ap.dk07.1-c2.dtb \
@@ -36,6 +36,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq8065-r7800.dtb \
 +	qcom-ipq8065-xr500.dtb \
 +	qcom-ipq8065-rt4230w-rev6.dtb \
++	qcom-ipq8065-rt4230w-rev9.3.dtb \
 +	qcom-ipq8068-ecw5410.dtb \
  	qcom-msm8660-surf.dtb \
  	qcom-msm8960-cdp.dtb \

--- a/target/linux/ipq806x/patches-5.4/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-5.4/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -842,7 +842,28 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -842,7 +842,29 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-ipq4019-ap.dk04.1-c3.dtb \
  	qcom-ipq4019-ap.dk07.1-c1.dtb \
  	qcom-ipq4019-ap.dk07.1-c2.dtb \
@@ -35,6 +35,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq8065-r7800.dtb \
 +	qcom-ipq8065-xr500.dtb \
 +	qcom-ipq8065-rt4230w-rev6.dtb \
++	qcom-ipq8065-rt4230w-rev9.3.dtb \
 +	qcom-ipq8068-ecw5410.dtb \
  	qcom-msm8660-surf.dtb \
  	qcom-msm8960-cdp.dtb \


### PR DESCRIPTION
The difference between flashing:
```
Interrupt U-Boot and run these commands:

  setenv bootcmd "setenv mtdids nand0=nand0 && set mtdparts
  mtdparts=nand0:0xDC00000@0x2400000(firmware) && ubi part firmware &&
  ubi read 0x44000000 kernel 0x6e0000 && bootm"
  saveenv
```