### PR TITLE
ipq806x: add support for Arris RAC2V1A

### DIFF
--- a/package/boot/uboot-envtools/files/ipq806x
+++ b/package/boot/uboot-envtools/files/ipq806x
@@ -30,6 +30,7 @@ ubootenv_mtdinfo () {
 }
 
 case "$board" in
+arris,rac2v1a|\
 askey,rt4230w-rev6|\
 askey,rt4230w-rev9.3)
 	ubootenv_add_uci_config "/dev/mtd9" "0x0" "0x40000" "0x20000"

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -11,6 +11,11 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+arris,rac2v1a)
+	ucidef_set_interfaces_lan_wan "eth1" "eth2"
+	ucidef_add_switch "switch0" \
+		"1:lan" "2:lan" "3:lan" "4:lan" "6u@eth1" "0u@eth0"
+	;;
 askey,rt4230w-rev6 |\
 askey,rt4230w-rev9.3 |\
 asrock,g10 |\

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -25,6 +25,10 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-pci-0000:01:00.0.bin")
 	case $board in
+	arris,rac2v1a)
+		caldata_extract "0:ART" 0x1000 0x2f20
+		ath10k_patch_mac $(mtd_get_mac_binary fw_env 0x12)
+		;;
 	askey,rt4230w-rev6 |\
 	askey,rt4230w-rev9.3)
 		caldata_extract "0:ART" 0x1000 0x2f20
@@ -89,6 +93,10 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-pci-0001:01:00.0.bin")
 	case $board in
+	arris,rac2v1a)
+		caldata_extract "0:ART" 0x5000 0x2f20
+		ath10k_patch_mac $(mtd_get_mac_binary fw_env 0xc)
+		;;
 	askey,rt4230w-rev6 |\
 	askey,rt4230w-rev9.3)
 		caldata_extract "0:ART" 0x5000 0x2f20

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -10,6 +10,7 @@ platform_check_image() {
 
 platform_do_upgrade() {
 	case "$(board_name)" in
+	arris,rac2v1a |\
 	askey,rt4230w-rev6 |\
 	askey,rt4230w-rev9.3 |\
 	compex,wpq864 |\

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-rac2v1a.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-rac2v1a.dts
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qcom-ipq8065.dtsi"
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Arris RAC2V1A";
+	compatible = "arris,rac2v1a", "qcom,ipq8065", "qcom,ipq8064";
+
+	memory@0 {
+		reg = <0x42000000 0x1e000000>;
+		device_type = "memory";
+	};
+
+	aliases {
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_red;
+	};
+
+	chosen {
+		bootargs = "rootfstype=squashfs noinitrd";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+			wakeup-source;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&qcom_pinmux 65 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+			wakeup-source;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&qcom_pinmux 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_blue: status_blue {
+			label = "blue:status";
+			gpios = <&qcom_pinmux 8 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&qcom_pinmux {
+	button_pins: button_pins {
+		mux {
+			pins = "gpio54", "gpio65";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
+
+	led_pins: led_pins {
+		mux {
+			pins = "gpio7", "gpio8";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-down;
+		};
+	};
+
+	rgmii2_pins: rgmii2_pins {
+		tx {
+			pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32";
+			input-disable;
+		};
+	};
+
+	spi_pins: spi_pins {
+		cs {
+			pins = "gpio20";
+			drive-strength = <12>;
+		};
+	};
+};
+
+&gsbi5 {
+	qcom,mode = <GSBI_PROT_SPI>;
+	status = "okay";
+
+	spi@1a280000 {
+		status = "okay";
+
+		pinctrl-0 = <&spi_pins>;
+		pinctrl-names = "default";
+
+		cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
+
+		flash@0 {
+			compatible = "everspin,mr25h256";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			spi-max-frequency = <40000000>;
+			reg = <0>;
+		};
+	};
+};
+
+&nand_controller {
+	status = "okay";
+
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+
+	nand@0 {
+		reg = <0>;
+		compatible = "qcom,nandcs";
+
+		nand-ecc-strength = <4>;
+		nand-bus-width = <8>;
+		nand-ecc-step-size = <512>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:SBL1";
+				reg = <0x0000000 0x0040000>;
+				read-only;
+			};
+			partition@40000 {
+				label = "0:MIBIB";
+				reg = <0x0040000 0x0140000>;
+				read-only;
+			};
+			partition@180000 {
+				label = "0:SBL2";
+				reg = <0x0180000 0x0140000>;
+				read-only;
+			};
+			partition@2c0000 {
+				label = "0:SBL3";
+				reg = <0x02c0000 0x0280000>;
+				read-only;
+			};
+			partition@540000 {
+				label = "0:DDRCONFIG";
+				reg = <0x0540000 0x0120000>;
+				read-only;
+			};
+			partition@660000 {
+				label = "0:SSD";
+				reg = <0x0660000 0x0120000>;
+				read-only;
+			};
+			partition@780000 {
+				label = "0:TZ";
+				reg = <0x0780000 0x0280000>;
+				read-only;
+			};
+			partition@a00000 {
+				label = "0:RPM";
+				reg = <0x0a00000 0x0280000>;
+				read-only;
+			};
+			partition@c80000 {
+				label = "0:APPSBL";
+				reg = <0x0c80000 0x0500000>;
+				read-only;
+			};
+			partition@1180000 {
+				label = "0:APPSBLENV";
+				reg = <0x1180000 0x0080000>;
+			};
+			partition@1200000 {
+				label = "0:ART";
+				reg = <0x1200000 0x0140000>;
+				read-only;
+			};
+			partition@1340000 {
+				label = "rootfs_1";
+				reg = <0x1340000 0x4000000>;
+			};
+			partition@5340000 {
+				label = "0:BOOTCONFIG";
+				reg = <0x5340000 0x0060000>;
+				read-only;
+			};
+			partition@53a0000 {
+				label = "0:SBL2_1";
+				reg = <0x53a0000 0x0140000>;
+				read-only;
+			};
+			partition@54e0000 {
+				label = "0:SBL3_1";
+				reg = <0x54e0000 0x0280000>;
+				read-only;
+			};
+			partition@5760000 {
+				label = "0:DDRCONFIG_1";
+				reg = <0x5760000 0x0120000>;
+				read-only;
+			};
+			partition@5880000 {
+				label = "0:SSD_1";
+				reg = <0x5880000 0x0120000>;
+				read-only;
+			};
+			partition@59a0000 {
+				label = "0:TZ_1";
+				reg = <0x59a0000 0x0280000>;
+				read-only;
+			};
+			partition@5c20000 {
+				label = "0:RPM_1";
+				reg = <0x5c20000 0x0280000>;
+				read-only;
+			};
+			partition@5ea0000 {
+				label = "0:BOOTCONFIG1";
+				reg = <0x5ea0000 0x0060000>;
+				read-only;
+			};
+			partition@5f00000 {
+				label = "0:APPSBL_1";
+				reg = <0x5f00000 0x0500000>;
+				read-only;
+			};
+			partition@6400000 {
+				label = "ubi";
+				reg = <0x6400000 0x4000000>;
+			};
+			fw_env: partition@a400000 {
+				label = "fw_env";
+				reg = <0xa400000 0x0100000>;
+				read-only;
+			};
+			partition@a500000 {
+				label = "config";
+				reg = <0xa500000 0x0800000>;
+				read-only;
+			};
+			partition@ad00000 {
+				label = "PKI";
+				reg = <0xad00000 0x0200000>;
+				read-only;
+			};
+			partition@af00000 {
+				label = "scfgmgr";
+				reg = <0xaf00000 0x0100000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio0_pins>;
+	pinctrl-names = "default";
+
+	phy0: ethernet-phy@0 {
+		reg = <0x0>;
+		qca,ar8327-initvals = <
+			0x00004 0x7600000   /* PAD0_MODE */
+			0x00008 0x1000000   /* PAD5_MODE */
+			0x0000c 0x80        /* PAD6_MODE */
+			0x000e4 0xaa545     /* MAC_POWER_SEL */
+			0x000e0 0xc74164de  /* SGMII_CTRL */
+			0x0007c 0x4e        /* PORT0_STATUS */
+			0x00094 0x4e        /* PORT6_STATUS */
+			>;
+	};
+
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+
+	phy7: ethernet-phy@7 {
+		reg = <7>;
+	};
+};
+
+&gmac0 {
+	status = "okay";
+	phy-mode = "rgmii";
+	qcom,id = <0>;
+	phy-handle = <&phy4>;
+
+	pinctrl-0 = <&rgmii2_pins>;
+	pinctrl-names = "default";
+
+	mtd-mac-address = <&fw_env 0x18>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	phy-mode = "sgmii";
+	qcom,id = <1>;
+
+	mtd-mac-address = <&fw_env 0x0>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&gmac3 {
+	status = "okay";
+	phy-mode = "sgmii";
+	qcom,id = <3>;
+	phy-handle = <&phy7>;
+
+	mtd-mac-address = <&fw_env 0x6>;
+};
+
+&adm_dma {
+	status = "okay";
+};
+
+&usb3_0 {
+	status = "okay";
+	clocks = <&gcc USB30_1_MASTER_CLK>;
+};
+
+&usb3_1 {
+	status = "okay";
+	clocks = <&gcc USB30_0_MASTER_CLK>;
+};
+
+&pcie0 {
+	status = "okay";
+	reset-gpio = <&qcom_pinmux 3 GPIO_ACTIVE_HIGH>;
+	pinctrl-0 = <&pcie0_pins>;
+	pinctrl-names = "default";
+};
+
+&pcie1 {
+	status = "okay";
+	reset-gpio = <&qcom_pinmux 48 GPIO_ACTIVE_HIGH>;
+	pinctrl-0 = <&pcie1_pins>;
+	pinctrl-names = "default";
+	max-link-speed = <1>;
+};

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -101,6 +101,20 @@ define Device/ZyXELImage
 	IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-to $$$$(BLOCKSIZE) | sysupgrade-tar rootfs=$$$$@ | append-metadata
 endef
 
+define Device/arris_rac2v1a
+	$(call Device/LegacyImage)
+	DEVICE_VENDOR := Arris
+	DEVICE_MODEL := RAC2V1A
+	DEVICE_ALT0_VENDOR := Arris
+	DEVICE_ALT0_MODEL := TR4400-AC
+	SOC := qcom-ipq8065
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	KERNEL_IN_UBI := 1
+	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct ath10k-firmware-qca99x0-ct
+endef
+TARGET_DEVICES += arris_rac2v1a
+
 define Device/askey_rt4230w
 	$(call Device/LegacyImage)
 	DEVICE_VENDOR := Askey

--- a/target/linux/ipq806x/patches-5.10/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-5.10/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -907,8 +907,30 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -907,8 +907,31 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-ipq4019-ap.dk04.1-c3.dtb \
  	qcom-ipq4019-ap.dk07.1-c1.dtb \
  	qcom-ipq4019-ap.dk07.1-c2.dtb \
@@ -35,6 +35,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq8065-nbg6817.dtb \
 +	qcom-ipq8065-r7800.dtb \
 +	qcom-ipq8065-xr500.dtb \
++	qcom-ipq8065-rac2v1a.dtb \
 +	qcom-ipq8065-rt4230w-rev6.dtb \
 +	qcom-ipq8065-rt4230w-rev9.3.dtb \
 +	qcom-ipq8068-ecw5410.dtb \

--- a/target/linux/ipq806x/patches-5.4/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-5.4/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -842,7 +842,29 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -842,7 +842,30 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-ipq4019-ap.dk04.1-c3.dtb \
  	qcom-ipq4019-ap.dk07.1-c1.dtb \
  	qcom-ipq4019-ap.dk07.1-c2.dtb \
@@ -34,6 +34,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq8065-nbg6817.dtb \
 +	qcom-ipq8065-r7800.dtb \
 +	qcom-ipq8065-xr500.dtb \
++	qcom-ipq8065-rac2v1a.dtb \
 +	qcom-ipq8065-rt4230w-rev6.dtb \
 +	qcom-ipq8065-rt4230w-rev9.3.dtb \
 +	qcom-ipq8068-ecw5410.dtb \


### PR DESCRIPTION
```
This commit add support for Arris RAC2V1A (aka TR4400-AC).

Hardware specs:
  SoC: Qualcomm IPQ8065
  RAM: 256 MB DDR3
  Flash: 512 MB NAND
  WiFi1: Qualcomm QCA9983 2.4 GHz
  WiFi2: Qualcomm QCA9984 5 GHz
  Ethernet1: AR8033 PHY -> Wan
  Ethernet2: QCA8337 Switch -> Lan 1~4
  LED: Status (red / blue)
  USB: 1x USB 3.0 Type-A
  Button: Reset, WPS
  Power: DC 12V,2.5A

Installation:
  Interrupt U-Boot, tftpboot initramfs image,
  than sysupgrade to openwrt.
```
Very thanks for asushugo's help.
Warning: Do not try to enable nss driver, this will cause the kernel to crash.
