### PR TITLE
使用github actions cache缓存工具链， 加速你的云编译项目，让你做更快的男人

### DIFF
--- a/.github/workflows/openwrt-ci.yml
+++ b/.github/workflows/openwrt-ci.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           ref: master
 
+      - name: cache
+        uses: klever1988/cachewrtbuild@main
+        with:
+          ccache: 'true'
+
       - name: Space cleanup
         env:
           DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/openwrt-ci.yml
+++ b/.github/workflows/openwrt-ci.yml
@@ -29,11 +29,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: master
+          fetch-depth: 0
 
       - name: cache
         uses: klever1988/cachewrtbuild@main
-        with:
-          ccache: 'true'
 
       - name: Space cleanup
         env:

--- a/.github/workflows/openwrt-ci.yml
+++ b/.github/workflows/openwrt-ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: cache
         uses: klever1988/cachewrtbuild@main
-        with: |
+        with:
           ccache: 'true'
 
       - name: Space cleanup

--- a/.github/workflows/openwrt-ci.yml
+++ b/.github/workflows/openwrt-ci.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: cache
         uses: klever1988/cachewrtbuild@main
+        with: |
+          ccache: 'true'
 
       - name: Space cleanup
         env:
@@ -55,7 +57,7 @@ jobs:
           ./scripts/feeds install -a
 
       - name: Generate configuration file
-        run: make defconfig
+        run: echo -e 'CONFIG_DEVEL=y\nCONFIG_CCACHE=y' >> .config; make defconfig
 
       - name: Make download
         run: |


### PR DESCRIPTION
壁画不多直接上效果，最短25分钟完成
<img width="80%" src="https://user-images.githubusercontent.com/56048681/131760574-d7aef8a4-7a1b-4520-938a-48b9d6407f99.png" />
简单原理就是，
github给actions提供了5gb的高速缓存空间，
使用这个空间缓存工具链的编译进度，
可以节省掉不必要的40多分钟耗时。

食用方法：（参考pr）
在你的openwrt-ci.yml actions/checkout段尾部加入
```yaml
          fetch-depth: 0
```
（因为工具使用了tools和toolchain的commit id决定是否更新缓存，所以需要全量拉取代码）

随后添加工具调用，即可
```yaml
      - name: cache
        uses: klever1988/cachewrtbuild@main
```

第一次编译不会有变化，因为你的仓库还没有缓存，随后的编译作业就会从你仓库拉去第一次编译生成的缓存，跳过无意义的工具链编译时间。
可用参数和默认值：
```yaml
      - name: cache
        uses: klever1988/cachewrtbuild@main
        with:
          #是否一并缓存.ccache目录，如果你启用了ccache。这是唯一的常用参数，其他三个用于除错，一般不需要调整
          ccache: false

          #是否缓存工具链目录
          toolchain: true

          #是否跳过工具链编译
          skip: true

          #清空缓存
          clean: false
```

建议在make menuconfig或者
```bash
echo -e 'CONFIG_DEVEL=y\nCONFIG_CCACHE=y' >> .config; make defconfig
```
开启ccache获得进一步的加速时间。

**_使用[P3TERX/Actions-OpenWrt](https://github.com/P3TERX/Actions-OpenWrt)编译的筒子们，因为你们yml的checkout段并不是检出openwrt源代码，而是检出你们的编译脚本。所以应该把uses段放在真正的clone openwrt源码代码段之后，并且用prefix参数声明openwrt源码路径，比如_**

```yaml
    - name: Clone source code
      working-directory: /workdir
      run: |
        df -hT $PWD
        git clone $REPO_URL -b $REPO_BRANCH openwrt
        ln -sf /workdir/openwrt $GITHUB_WORKSPACE/openwrt
    - name: Cache
      uses: klever1988/cachewrtbuild@main
      with:
        ccache: 'true'
        prefix: ${{ github.workspace }}/openwrt
```