### PR TITLE
ipq807x: improve support for ZTE MF269

### DIFF
--- a/target/linux/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq807x/base-files/etc/board.d/02_network
@@ -21,8 +21,9 @@ ipq807x_setup_interfaces()
 		;;
 	zte,mf269)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
-		ucidef_set_interface_macaddr "lan" "$(macaddr_add $(mtd_get_mac_binary "mac" 0x0) 1)"
-		ucidef_set_interface_macaddr "wan" "$(mtd_get_mac_binary "mac" 0x0)"
+		hw_mac_addr=$(mtd_get_mac_binary "mac" 0x0)
+		ucidef_set_interface_macaddr "wan" "$hw_mac_addr"
+		ucidef_set_interface_macaddr "lan" "$(macaddr_add $hw_mac_addr 1)"
 		;;
 	*)
 		echo "Unsupported hardware. Network interfaces not initialized"

--- a/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8071-mf269.dts
+++ b/target/linux/ipq807x/files/arch/arm64/boot/dts/qcom/ipq8071-mf269.dts
@@ -1,7 +1,8 @@
-// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (c) 2021, ZhiPing */
+
 /dts-v1/;
-/* Copyright (c) 2020 The Linux Foundation. All rights reserved.
- */
+
 #include "ipq8074.dtsi"
 #include "ipq8074-ac-cpu.dtsi"
 #include "ipq8074-ac-nss.dtsi"
@@ -10,23 +11,24 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	#address-cells = <0x2>;
-	#size-cells = <0x2>;
+	#address-cells = <2>;
+	#size-cells = <2>;
+
 	model = "ZTE MF269";
 	compatible = "zte,mf269", "qcom,ipq8074";
 	interrupt-parent = <&intc>;
 
 	aliases {
-		led-boot = &power;
-		led-failsafe = &power;
-		led-running = &power;
-		led-upgrade = &power;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
 		serial0 = &blsp1_uart5;
 	};
 
 	chosen {
-		stdout-path = "serial0";
-		bootargs-append = " ubi.mtd=rootfs root=/dev/ubiblock0_1 rootfstype=squashfs";
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=/dev/ubiblock0_1";
 	};
 
 	reserved-memory {
@@ -35,708 +37,38 @@
 		/delete-node/ m3_dump@51000000;
 	};
 
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&tlmm 46 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "white:power";
+			gpio = <&tlmm 56 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
 	soc {
-		pinctrl@1000000 {
-			audio_gpio_pinmux {
-				mux_1 {
-					pins = "gpio62";
-					function = "gpio";
-					drive-strength = <8>;
-					bias-pull-up;
-					output-high;
-				};
-
-				mux_2 {
-					pins = "gpio26";
-					function = "gpio";
-					drive-strength = <8>;
-					bias-pull-up;
-					output-high;
-				};
-
-				mux_3 {
-					pins = "gpio27";
-					function = "gpio";
-					drive-strength = <8>;
-					bias-pull-up;
-					output-high;
-				};
-
-				mux_4 {
-					pins = "gpio63";
-					function = "gpio";
-					drive-strength = <8>;
-					bias-pull-up;
-					output-high;
-				};
-
-				mux_5 {
-					pins = "gpio67";
-					function = "gpio";
-					drive-strength = <8>;
-					bias-pull-up;
-					output-high;
-				};
-
-				mux_6 {
-					pins = "gpio30";
-					function = "gpio";
-					drive-strength = <8>;
-					bias-pull-up;
-					output-high;
-				};
-
-				mux_7 {
-					pins = "gpio31";
-					function = "gpio";
-					drive-strength = <8>;
-					bias-pull-up;
-					output-high;
-				};
-
-				mux_8 {
-					pins = "gpio32";
-					function = "gpio";
-					drive-strength = <8>;
-					bias-pull-up;
-					output-high;
-				};
-			};
-
-			audio_pinmux {
-				mux_1 {
-					pins = "gpio26";
-					function = "audio_txbclk";
-					drive-strength = <8>;
-					bias-pull-up;
-				};
-
-				mux_2 {
-					pins = "gpio27";
-					function = "audio_txfsync";
-					drive-strength = <8>;
-					bias-pull-up;
-				};
-
-				mux_3 {
-					pins = "gpio63";
-					function = "audio_txd";
-					drive-strength = <8>;
-					bias-pull-up;
-				};
-
-				mux_4 {
-					pins = "gpio30";
-					function = "audio_rxbclk";
-					drive-strength = <8>;
-					bias-pull-up;
-				};
-
-				mux_5 {
-					pins = "gpio31";
-					function = "audio_rxfsync";
-					drive-strength = <8>;
-					bias-pull-up;
-				};
-
-				mux_6 {
-					pins = "gpio32";
-					function = "audio_rxd";
-					drive-strength = <8>;
-					bias-pull-up;
-				};
-			};
-
-			audio_pinmux_master {
-				mux_1 {
-					pins = "gpio62";
-					function = "audio_txmclk";
-					drive-strength = <8>;
-					bias-pull-up;
-				};
-
-				mux_2 {
-					pins = "gpio67";
-					function = "audio_rxmclk";
-					drive-strength = <8>;
-					bias-pull-up;
-				};
-			};
-
-			audio_pinmux_slave {
-				mux_1 {
-					pins = "gpio62";
-					function = "audio_txmclk";
-					drive-strength = <2>;
-					bias-pull-up;
-				};
-
-				mux_2 {
-					pins = "gpio67";
-					function = "audio_rxmclk";
-					drive-strength = <2>;
-					bias-pull-up;
-				};
-			};
-
-			voip_pinmux {
-				mux_1 {
-					pins = "gpio33";
-					function = "pcm_drx";
-					drive-strength = <8>;
-					bias-pull-up;
-				};
-
-				mux_2 {
-					pins = "gpio34";
-					function = "pcm_dtx";
-					drive-strength = <8>;
-					bias-pull-up;
-				};
-
-				mux_3 {
-					pins = "gpio35";
-					function = "pcm_fsync";
-					drive-strength = <8>;
-					bias-pull-up;
-				};
-
-				mux_4 {
-					pins = "gpio36";
-					function = "pcm_pclk";
-					drive-strength = <8>;
-					bias-pull-up;
-				};
-			};
-
-			zte_pm_pinmux {
-				mux {
-					pins = "gpio47", "gpio48", "gpio29";
-					function = "gpio";
-					drive-strength = <8>;
-					bias-disable;
-				};
-			};
-
-			spi_5_pins {
-				mux {
-					pins = "gpio0", "gpio2", "gpio9", "gpio16";
-					function = "blsp5_spi";
-					drive-strength = <8>;
-					bias-disable;
-				};
-			};
-
-			slic_ctl_pins {
-				mux {
-					pins = "gpio59";
-					function = "gpio";
-					bias-pull-up;
-				};
-			};
-
-			usb_mux_sel_pins: usb_mux_pins {
-				mux {
-					pins = "gpio27";
-					function = "gpio";
-					drive-strength = <8>;
-					bias-pull-down;
-				};
-			};
-
-			pcie0_pins: pcie_pins {
-				pcie0_rst {
-					pins = "gpio52";
-					function = "pcie0_rst";
-					drive-strength = <8>;
-					bias-pull-down;
-				};
-
-				pcie0_wake {
-					pins = "gpio59";
-					function = "pcie0_wake";
-					drive-strength = <8>;
-					bias-pull-down;
-				};
-			};
-
-			mdio_pins: mdio_pinmux {
-				mux_0 {
-					pins = "gpio68";
-					function = "mdc";
-					drive-strength = <8>;
-					bias-pull-up;
-				};
-				mux_1 {
-					pins = "gpio69";
-					function = "mdio";
-					drive-strength = <8>;
-					bias-pull-up;
-				};
-				mux_2 {
-					pins = "gpio25";
-					function = "gpio";
-					bias-pull-up;
-				};
-				mux_3 {
-					pins = "gpio44";
-					function = "gpio";
-					bias-pull-up;
-				};
-			};
-
-			spi_5_pins: spi-5-pins {
-				pins = "gpio0", "gpio2", "gpio9", "gpio16";
-				function = "blsp5_spi";
-				drive-strength = <8>;
-				bias-disable;
-			};
-
-			led_pins: led_pins {
-				led_pwr {
-					pins = "gpio56";
-					function = "gpio";
-					drive-strength = <8>;
-					bias-pull-down;
-				};
-			};
-		};
-
-		serial@78b3000 {
-			status = "ok";
-		};
-
-		spi@78b5000 {
-			status = "okay";
-			pinctrl-0 = <&spi_0_pins>;
-			pinctrl-names = "default";
-			cs-select = <0>;
-
-			m25p80@0 {
-				  compatible = "n25q128a11";
-				  #address-cells = <1>;
-				  #size-cells = <1>;
-				  reg = <0>;
-				  spi-max-frequency = <50000000>;
-			};
-		};
-
-		dma@7984000 {
-			 status = "ok";
-		};
-
-		qusb@79000 {
-			status = "ok";
-		};
-
-		ssphy@78000 {
-			status = "ok";
-		};
-
-		usb3@8A00000 {
-			status = "ok";
-		};
-
-		qusb@59000 {
-			status = "ok";
-		};
-
-		ssphy@58000 {
-			status = "ok";
-		};
-
-		usb3@8C00000 {
-			status = "ok";
-		};
-
-		phy@84000 {
-			status = "ok";
-		};
-
-		phy@86000 {
-			status = "ok";
-		};
-
-		pci@20000000 {
-			perst-gpio = <&tlmm 52 0>;
-			status = "disabled";
-		};
-
-		i2c@78b9000 {
-			 status = "ok";
-		};
-
-		keys {
-			compatible = "gpio-keys";
-
-			reset {
-				label = "reset";
-				linux,code = <KEY_RESTART>;
-				gpios = <&tlmm 46 GPIO_ACTIVE_LOW>;
-			};
-
-			wps {
-				label = "wps";
-				linux,code = <KEY_WPS_BUTTON>;
-				gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
-			};
-		};
-
-
-		leds {
-			compatible = "gpio-leds";
-			pinctrl-0 = <&led_pins>;
-			pinctrl-names = "default";
-
-			power: led@56 {
-				label = "power_white";
-				gpio = <&tlmm 56 GPIO_ACTIVE_HIGH>;
-			};
-		};
-
-		mdio: mdio@90000 {
-			status = "okay";
-
-			pinctrl-0 = <&mdio_pins>;
-			pinctrl-names = "default";
-			phy-reset-gpio = <&tlmm 37 0 &tlmm 25 0 &tlmm 44 0>;
-			phy0: ethernet-phy@0 {
-				reg = <0>;
-			};
-			phy1: ethernet-phy@1 {
-				reg = <1>;
-			};
-			phy2: ethernet-phy@2 {
-				reg = <2>;
-			};
-			phy3: ethernet-phy@3 {
-				reg = <3>;
-			};
-			phy4: ethernet-phy@4 {
-				reg = <24>;
-			};
-			phy5: ethernet-phy@5 {
-				reg = <28>;
-			};
-		};
-
-		ess-switch@3a000000 {
-			switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
-			switch_lan_bmp = <0x3e>; /* lan port bitmap */
-			switch_wan_bmp = <0x40>; /* wan port bitmap */
-			switch_mac_mode = <0x0>; /* mac mode for uniphy instance0*/
-			switch_mac_mode1 = <0xf>; /* mac mode for uniphy instance1*/
-			switch_mac_mode2 = <0xf>; /* mac mode for uniphy instance2*/
-			bm_tick_mode = <0>; /* bm tick mode */
-			tm_tick_mode = <0>; /* tm tick mode */
-			qcom,port_phyinfo {
-				port@0 {
-					port_id = <1>;
-					phy_address = <0>;
-				};
-				port@1 {
-					port_id = <2>;
-					phy_address = <1>;
-				};
-				port@2 {
-					port_id = <3>;
-					phy_address = <2>;
-				};
-				port@3 {
-					port_id = <4>;
-					phy_address = <3>;
-				};
-				port@4 {
-					port_id = <5>;
-					phy_address = <24>;
-					port_mac_sel = "QGMAC_PORT";
-				};
-				port@5 {
-					port_id = <6>;
-					phy_address = <28>;
-					port_mac_sel = "QGMAC_PORT";
-				};
-			};
-			port_scheduler_resource {
-				port@0 {
-					port_id = <0>;
-					ucast_queue = <0 143>;
-					mcast_queue = <256 271>;
-					l0sp = <0 35>;
-					l0cdrr = <0 47>;
-					l0edrr = <0 47>;
-					l1cdrr = <0 7>;
-					l1edrr = <0 7>;
-				};
-				port@1 {
-					port_id = <1>;
-					ucast_queue = <144 159>;
-					mcast_queue = <272 275>;
-					l0sp = <36 39>;
-					l0cdrr = <48 63>;
-					l0edrr = <48 63>;
-					l1cdrr = <8 11>;
-					l1edrr = <8 11>;
-				};
-				port@2 {
-					port_id = <2>;
-					ucast_queue = <160 175>;
-					mcast_queue = <276 279>;
-					l0sp = <40 43>;
-					l0cdrr = <64 79>;
-					l0edrr = <64 79>;
-					l1cdrr = <12 15>;
-					l1edrr = <12 15>;
-				};
-				port@3 {
-					port_id = <3>;
-					ucast_queue = <176 191>;
-					mcast_queue = <280 283>;
-					l0sp = <44 47>;
-					l0cdrr = <80 95>;
-					l0edrr = <80 95>;
-					l1cdrr = <16 19>;
-					l1edrr = <16 19>;
-				};
-				port@4 {
-					port_id = <4>;
-					ucast_queue = <192 207>;
-					mcast_queue = <284 287>;
-					l0sp = <48 51>;
-					l0cdrr = <96 111>;
-					l0edrr = <96 111>;
-					l1cdrr = <20 23>;
-					l1edrr = <20 23>;
-				};
-				port@5 {
-					port_id = <5>;
-					ucast_queue = <208 223>;
-					mcast_queue = <288 291>;
-					l0sp = <52 55>;
-					l0cdrr = <112 127>;
-					l0edrr = <112 127>;
-					l1cdrr = <24 27>;
-					l1edrr = <24 27>;
-				};
-				port@6 {
-					port_id = <6>;
-					ucast_queue = <224 239>;
-					mcast_queue = <292 295>;
-					l0sp = <56 59>;
-					l0cdrr = <128 143>;
-					l0edrr = <128 143>;
-					l1cdrr = <28 31>;
-					l1edrr = <28 31>;
-				};
-				port@7 {
-					port_id = <7>;
-					ucast_queue = <240 255>;
-					mcast_queue = <296 299>;
-					l0sp = <60 63>;
-					l0cdrr = <144 159>;
-					l0edrr = <144 159>;
-					l1cdrr = <32 35>;
-					l1edrr = <32 35>;
-				};
-			};
-			port_scheduler_config {
-				port@0 {
-					port_id = <0>;
-					l1scheduler {
-						group@0 {
-							sp = <0 1>; /*L0 SPs*/
-							/*cpri cdrr epri edrr*/
-							cfg = <0 0 0 0>;
-						};
-					};
-					l0scheduler {
-						group@0 {
-							/*unicast queues*/
-							ucast_queue = <0 4 8>;
-							/*multicast queues*/
-							mcast_queue = <256 260>;
-							/*sp cpri cdrr epri edrr*/
-							cfg = <0 0 0 0 0>;
-						};
-						group@1 {
-							ucast_queue = <1 5 9>;
-							mcast_queue = <257 261>;
-							cfg = <0 1 1 1 1>;
-						};
-						group@2 {
-							ucast_queue = <2 6 10>;
-							mcast_queue = <258 262>;
-							cfg = <0 2 2 2 2>;
-						};
-						group@3 {
-							ucast_queue = <3 7 11>;
-							mcast_queue = <259 263>;
-							cfg = <0 3 3 3 3>;
-						};
-					};
-				};
-				port@1 {
-					port_id = <1>;
-					l1scheduler {
-						group@0 {
-							sp = <36>;
-							cfg = <0 8 0 8>;
-						};
-						group@1 {
-							sp = <37>;
-							cfg = <1 9 1 9>;
-						};
-					};
-					l0scheduler {
-						group@0 {
-							ucast_queue = <144>;
-							ucast_loop_pri = <16>;
-							mcast_queue = <272>;
-							mcast_loop_pri = <4>;
-							cfg = <36 0 48 0 48>;
-						};
-					};
-				};
-				port@2 {
-					port_id = <2>;
-					l1scheduler {
-						group@0 {
-							sp = <40>;
-							cfg = <0 12 0 12>;
-						};
-						group@1 {
-							sp = <41>;
-							cfg = <1 13 1 13>;
-						};
-					};
-					l0scheduler {
-						group@0 {
-							ucast_queue = <160>;
-							ucast_loop_pri = <16>;
-							mcast_queue = <276>;
-							mcast_loop_pri = <4>;
-							cfg = <40 0 64 0 64>;
-						};
-					};
-				};
-				port@3 {
-					port_id = <3>;
-					l1scheduler {
-						group@0 {
-							sp = <44>;
-							cfg = <0 16 0 16>;
-						};
-						group@1 {
-							sp = <45>;
-							cfg = <1 17 1 17>;
-						};
-					};
-					l0scheduler {
-						group@0 {
-							ucast_queue = <176>;
-							ucast_loop_pri = <16>;
-							mcast_queue = <280>;
-							mcast_loop_pri = <4>;
-							cfg = <44 0 80 0 80>;
-						};
-					};
-				};
-				port@4 {
-					port_id = <4>;
-					l1scheduler {
-						group@0 {
-							sp = <48>;
-							cfg = <0 20 0 20>;
-						};
-						group@1 {
-							sp = <49>;
-							cfg = <1 21 1 21>;
-						};
-					};
-					l0scheduler {
-						group@0 {
-							ucast_queue = <192>;
-							ucast_loop_pri = <16>;
-							mcast_queue = <284>;
-							mcast_loop_pri = <4>;
-							cfg = <48 0 96 0 96>;
-						};
-					};
-				};
-				port@5 {
-					port_id = <5>;
-					l1scheduler {
-						group@0 {
-							sp = <52>;
-							cfg = <0 24 0 24>;
-						};
-						group@1 {
-							sp = <53>;
-							cfg = <1 25 1 25>;
-						};
-					};
-					l0scheduler {
-						group@0 {
-							ucast_queue = <208>;
-							ucast_loop_pri = <16>;
-							mcast_queue = <288>;
-							mcast_loop_pri = <4>;
-							cfg = <52 0 112 0 112>;
-						};
-					};
-				};
-				port@6 {
-					port_id = <6>;
-					l1scheduler {
-						group@0 {
-							sp = <56>;
-							cfg = <0 28 0 28>;
-						};
-						group@1 {
-							sp = <57>;
-							cfg = <1 29 1 29>;
-						};
-					};
-					l0scheduler {
-						group@0 {
-							ucast_queue = <224>;
-							ucast_loop_pri = <16>;
-							mcast_queue = <292>;
-							mcast_loop_pri = <4>;
-							cfg = <56 0 128 0 128>;
-						};
-					};
-				};
-				port@7 {
-					port_id = <7>;
-					l1scheduler {
-						group@0 {
-							sp = <60>;
-							cfg = <0 32 0 32>;
-						};
-						group@1 {
-							sp = <61>;
-							cfg = <1 33 1 33>;
-						};
-					};
-					l0scheduler {
-						group@0 {
-							ucast_queue = <240>;
-							ucast_loop_pri = <16>;
-							mcast_queue = <296>;
-							cfg = <60 0 144 0 144>;
-						};
-					};
-				};
-			};
-		};
-
 		dp5: dp5 {
 			device_type = "network";
 			compatible = "qcom,nss-dp";
 			qcom,id = <5>;
-			reg = <0x3a001800 0x200>;
-			qcom,mactype = <0>;
+			reg = <0x3a003000 0x3fff>;
+			qcom,mactype = <1>;
 			local-mac-address = [000000000000];
 			qcom,link-poll = <1>;
 			qcom,phy-mdio-addr = <24>;
@@ -748,8 +80,8 @@
 			device_type = "network";
 			compatible = "qcom,nss-dp";
 			qcom,id = <6>;
-			reg = <0x3a001a00 0x200>;
-			qcom,mactype = <0>;
+			reg = <0x3a007000 0x3fff>;
+			qcom,mactype = <1>;
 			local-mac-address = [000000000000];
 			qcom,link-poll = <1>;
 			qcom,phy-mdio-addr = <28>;
@@ -757,17 +89,400 @@
 			mdio-bus = <&mdio>;
 		};
 
-		nss-macsec0 {
-			compatible = "qcom,nss-macsec";
-			phy_addr = <0x18>;
-			mdiobus = <&mdio>;
-		};
-		nss-macsec1 {
-			compatible = "qcom,nss-macsec";
-			phy_addr = <0x1c>;
-			mdiobus = <&mdio>;
+		zte_pm {
+			compatible = "zte,zte_pm";
+			pinctrl-0 = <&zte_pm_pins>;
+			pinctrl-names = "default";
+			usb_vbus_ctrl = <&tlmm 29 1>;
+			usb_cc1 = <&tlmm 47 1>;
+			usb_cc2 = <&tlmm 48 1>;
 		};
 	};
+};
+
+&blsp1_spi1 {
+	status = "okay";
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	cs-select = <0>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor", "n25q128a11";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+	};
+};
+
+/*
+&blsp1_spi6 {
+	status = "okay";
+	pinctrl-0 = <&spi_5_pins>;
+	pinctrl-names = "default";
+	cs-select = <0>;
+
+	si3217x@0 {
+		compatible = "si3217x";
+		num_slic = <1>;
+		reg = <0>;
+		spi-cpha;
+		spi-cpol;
+		spi-max-frequency = <960000>;
+		pinctrl-0 = <&slic_ctl_pins>;
+		pinctrl-names = "default";
+		ctl-gpio = <&tlmm 57 0>;
+		rst-gpio = <&tlmm 58 0>;
+		irq-gpio = <&tlmm 59 0>;
+	};
+};
+
+&blsp1_i2c5 {
+	status = "okay";
+
+	pinctrl-0 = <&i2c_4_pins>;
+	pinctrl-names = "default";
+
+	aw9106b@5b {
+		compatible = "aw9106b";
+		reg = <0x5b>;
+		reset-gpio = <&tlmm 54 0>;
+	};
+};
+*/
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&ess_switch {
+	switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
+	switch_lan_bmp = <0x3e>; /* lan port bitmap */
+	switch_wan_bmp = <0x40>; /* wan port bitmap */
+	switch_mac_mode = <0x0>; /* mac mode for uniphy instance0*/
+	switch_mac_mode1 = <0xf>; /* mac mode for uniphy instance1*/
+	switch_mac_mode2 = <0xf>; /* mac mode for uniphy instance2*/
+	bm_tick_mode = <0>; /* bm tick mode */
+	tm_tick_mode = <0>; /* tm tick mode */
+
+	qcom,port_phyinfo {
+		port@4 {
+			port_id = <5>;
+			phy_address = <24>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+		port@5 {
+			port_id = <6>;
+			phy_address = <28>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+	port_scheduler_resource {
+		port@0 {
+			port_id = <0>;
+			ucast_queue = <0 143>;
+			mcast_queue = <256 271>;
+			l0sp = <0 35>;
+			l0cdrr = <0 47>;
+			l0edrr = <0 47>;
+			l1cdrr = <0 7>;
+			l1edrr = <0 7>;
+		};
+		port@1 {
+			port_id = <1>;
+			ucast_queue = <144 159>;
+			mcast_queue = <272 275>;
+			l0sp = <36 39>;
+			l0cdrr = <48 63>;
+			l0edrr = <48 63>;
+			l1cdrr = <8 11>;
+			l1edrr = <8 11>;
+		};
+		port@2 {
+			port_id = <2>;
+			ucast_queue = <160 175>;
+			mcast_queue = <276 279>;
+			l0sp = <40 43>;
+			l0cdrr = <64 79>;
+			l0edrr = <64 79>;
+			l1cdrr = <12 15>;
+			l1edrr = <12 15>;
+		};
+		port@3 {
+			port_id = <3>;
+			ucast_queue = <176 191>;
+			mcast_queue = <280 283>;
+			l0sp = <44 47>;
+			l0cdrr = <80 95>;
+			l0edrr = <80 95>;
+			l1cdrr = <16 19>;
+			l1edrr = <16 19>;
+		};
+		port@4 {
+			port_id = <4>;
+			ucast_queue = <192 207>;
+			mcast_queue = <284 287>;
+			l0sp = <48 51>;
+			l0cdrr = <96 111>;
+			l0edrr = <96 111>;
+			l1cdrr = <20 23>;
+			l1edrr = <20 23>;
+		};
+		port@5 {
+			port_id = <5>;
+			ucast_queue = <208 223>;
+			mcast_queue = <288 291>;
+			l0sp = <52 55>;
+			l0cdrr = <112 127>;
+			l0edrr = <112 127>;
+			l1cdrr = <24 27>;
+			l1edrr = <24 27>;
+		};
+		port@6 {
+			port_id = <6>;
+			ucast_queue = <224 239>;
+			mcast_queue = <292 295>;
+			l0sp = <56 59>;
+			l0cdrr = <128 143>;
+			l0edrr = <128 143>;
+			l1cdrr = <28 31>;
+			l1edrr = <28 31>;
+		};
+		port@7 {
+			port_id = <7>;
+			ucast_queue = <240 255>;
+			mcast_queue = <296 299>;
+			l0sp = <60 63>;
+			l0cdrr = <144 159>;
+			l0edrr = <144 159>;
+			l1cdrr = <32 35>;
+			l1edrr = <32 35>;
+		};
+	};
+	port_scheduler_config {
+		port@0 {
+			port_id = <0>;
+			l1scheduler {
+				group@0 {
+					sp = <0 1>; /*L0 SPs*/
+					/*cpri cdrr epri edrr*/
+					cfg = <0 0 0 0>;
+				};
+			};
+			l0scheduler {
+				group@0 {
+					/*unicast queues*/
+					ucast_queue = <0 4 8>;
+					/*multicast queues*/
+					mcast_queue = <256 260>;
+					/*sp cpri cdrr epri edrr*/
+					cfg = <0 0 0 0 0>;
+				};
+				group@1 {
+					ucast_queue = <1 5 9>;
+					mcast_queue = <257 261>;
+					cfg = <0 1 1 1 1>;
+				};
+				group@2 {
+					ucast_queue = <2 6 10>;
+					mcast_queue = <258 262>;
+					cfg = <0 2 2 2 2>;
+				};
+				group@3 {
+					ucast_queue = <3 7 11>;
+					mcast_queue = <259 263>;
+					cfg = <0 3 3 3 3>;
+				};
+			};
+		};
+		port@1 {
+			port_id = <1>;
+			l1scheduler {
+				group@0 {
+					sp = <36>;
+					cfg = <0 8 0 8>;
+				};
+				group@1 {
+					sp = <37>;
+					cfg = <1 9 1 9>;
+				};
+			};
+			l0scheduler {
+				group@0 {
+					ucast_queue = <144>;
+					ucast_loop_pri = <16>;
+					mcast_queue = <272>;
+					mcast_loop_pri = <4>;
+					cfg = <36 0 48 0 48>;
+				};
+			};
+		};
+		port@2 {
+			port_id = <2>;
+			l1scheduler {
+				group@0 {
+					sp = <40>;
+					cfg = <0 12 0 12>;
+				};
+				group@1 {
+					sp = <41>;
+					cfg = <1 13 1 13>;
+				};
+			};
+			l0scheduler {
+				group@0 {
+					ucast_queue = <160>;
+					ucast_loop_pri = <16>;
+					mcast_queue = <276>;
+					mcast_loop_pri = <4>;
+					cfg = <40 0 64 0 64>;
+				};
+			};
+		};
+		port@3 {
+			port_id = <3>;
+			l1scheduler {
+				group@0 {
+					sp = <44>;
+					cfg = <0 16 0 16>;
+				};
+				group@1 {
+					sp = <45>;
+					cfg = <1 17 1 17>;
+				};
+			};
+			l0scheduler {
+				group@0 {
+					ucast_queue = <176>;
+					ucast_loop_pri = <16>;
+					mcast_queue = <280>;
+					mcast_loop_pri = <4>;
+					cfg = <44 0 80 0 80>;
+				};
+			};
+		};
+		port@4 {
+			port_id = <4>;
+			l1scheduler {
+				group@0 {
+					sp = <48>;
+					cfg = <0 20 0 20>;
+				};
+				group@1 {
+					sp = <49>;
+					cfg = <1 21 1 21>;
+				};
+			};
+			l0scheduler {
+				group@0 {
+					ucast_queue = <192>;
+					ucast_loop_pri = <16>;
+					mcast_queue = <284>;
+					mcast_loop_pri = <4>;
+					cfg = <48 0 96 0 96>;
+				};
+			};
+		};
+		port@5 {
+			port_id = <5>;
+			l1scheduler {
+				group@0 {
+					sp = <52>;
+					cfg = <0 24 0 24>;
+				};
+				group@1 {
+					sp = <53>;
+					cfg = <1 25 1 25>;
+				};
+			};
+			l0scheduler {
+				group@0 {
+					ucast_queue = <208>;
+					ucast_loop_pri = <16>;
+					mcast_queue = <288>;
+					mcast_loop_pri = <4>;
+					cfg = <52 0 112 0 112>;
+				};
+			};
+		};
+		port@6 {
+			port_id = <6>;
+			l1scheduler {
+				group@0 {
+					sp = <56>;
+					cfg = <0 28 0 28>;
+				};
+				group@1 {
+					sp = <57>;
+					cfg = <1 29 1 29>;
+				};
+			};
+			l0scheduler {
+				group@0 {
+					ucast_queue = <224>;
+					ucast_loop_pri = <16>;
+					mcast_queue = <292>;
+					mcast_loop_pri = <4>;
+					cfg = <56 0 128 0 128>;
+				};
+			};
+		};
+		port@7 {
+			port_id = <7>;
+			l1scheduler {
+				group@0 {
+					sp = <60>;
+					cfg = <0 32 0 32>;
+				};
+				group@1 {
+					sp = <61>;
+					cfg = <1 33 1 33>;
+				};
+			};
+			l0scheduler {
+				group@0 {
+					ucast_queue = <240>;
+					ucast_loop_pri = <16>;
+					mcast_queue = <296>;
+					cfg = <60 0 144 0 144>;
+				};
+			};
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	//reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
+
+	ethernet-phy@4 {
+		reg = <24>;
+		//reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
+	};
+
+	ethernet-phy@5 {
+		reg = <28>;
+		//reset-gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&prng {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
 };
 
 &qpic_nand {
@@ -785,10 +500,91 @@
 	};
 };
 
+&qusb_phy_0 {
+	status = "okay";
+};
+
+&ssphy_0 {
+	status = "okay";
+};
+
+&tlmm {
+	i2c_4_pins: i2c-4-pinmux {
+		pins = "gpio21", "gpio22";
+		function = "blsp4_i2c1";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	slic_ctl_pins: slic_ctl_pins {
+		mux {
+			pins = "gpio59";
+			function = "gpio";
+			bias-pull-up;
+		};
+	};
+
+	spi_5_pins: spi-5-pins {
+		pins = "gpio0", "gpio2", "gpio9", "gpio16";
+		function = "blsp5_spi";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	mdio_pins: mdio_pinmux {
+		mux_0 {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mux_1 {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mux_2 {
+			pins = "gpio25";
+			function = "gpio";
+			bias-pull-up;
+		};
+
+		mux_3 {
+			pins = "gpio44";
+			function = "gpio";
+			bias-pull-up;
+		};
+	};
+
+	usb_mux_sel_pins: usb_mux_pins {
+		mux {
+			pins = "gpio27";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+	};
+
+	zte_pm_pins: zte_pm_pinmux {
+		mux {
+			pins = "gpio47", "gpio48", "gpio29";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+};
+
+&usb_0 {
+	status = "okay";
+};
 
 &wifi {
 	status = "okay";
-	qcom,board_id = <0x292>;
+
+	qcom,board_id = <658>;
 	qcom,ath11k-calibration-variant = "ZTE-MF269";
 };
-

--- a/target/linux/ipq807x/image/generic.mk
+++ b/target/linux/ipq807x/image/generic.mk
@@ -73,14 +73,14 @@ endef
 TARGET_DEVICES += xiaomi_ax9000
 
 define Device/zte_mf269
-        $(call Device/FitImage)
-        $(call Device/UbiFit)
-        DEVICE_VENDOR := ZTE
-        DEVICE_MODEL := MF269
-        BLOCKSIZE := 128k
-        PAGESIZE := 2048
-        DEVICE_DTS_CONFIG := config@ac04
-        SOC := ipq8071
-        DEVICE_PACKAGES := ipq-wifi-zte_mf269 uboot-envtools
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := ZTE
+	DEVICE_MODEL := MF269
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	DEVICE_DTS_CONFIG := config@ac04
+	SOC := ipq8071
+	DEVICE_PACKAGES := ipq-wifi-zte_mf269 uboot-envtools
 endef
 TARGET_DEVICES += zte_mf269


### PR DESCRIPTION
Fixed the errors on the original dts, such as the 2.5G network port and usb part. Thanks for @ksong008 's test.