### PR TITLE
luci-app-turboacc: fix issues #7840

### DIFF
--- a/package/lean/luci-app-turboacc/Makefile
+++ b/package/lean/luci-app-turboacc/Makefile
@@ -32,7 +32,7 @@ LUCI_DEPENDS:=+pdnsd-alt \
 define Package/$(PKG_NAME)/config
 config PACKAGE_$(PKG_NAME)_INCLUDE_OFFLOADING
 	bool "Include Flow Offload"
-	depends on PACKAGE_$(PKG_NAME)_INCLUDE_SHORTCUT_FE=n
+	depends on (PACKAGE_$(PKG_NAME)_INCLUDE_SHORTCUT_FE=n && PACKAGE_$(PKG_NAME)_INCLUDE_SHORTCUT_FE_DRV=n)
 	default y if i386||x86_64||TARGET_ramips
 
 config PACKAGE_$(PKG_NAME)_INCLUDE_SHORTCUT_FE_DRV

--- a/package/lean/luci-app-turboacc/root/etc/init.d/turboacc
+++ b/package/lean/luci-app-turboacc/root/etc/init.d/turboacc
@@ -232,7 +232,7 @@ start(){
 
 	[ "${sw_flow}" -ne "1" ] && [ "${sfe_flow}" -eq "1" ] && {
 		[ "$(have_ecm_init)" = "0" ] && {
-			/etc/init.d/shortcut-fe enabled && /etc/init.d/shortcut-fe disable
+			/etc/init.d/shortcut-fe enabled || /etc/init.d/shortcut-fe enable
 			/etc/init.d/shortcut-fe start
 		}
 	}
@@ -278,7 +278,10 @@ stop(){
 	uci commit firewall
 
 	[ "${sfe_flow}" -ne "1" ] && {
-		[ "$(have_ecm_init)" = "0" ] && /etc/init.d/shortcut-fe stop 2>"/dev/null"
+		[ -e "/etc/init.d/shortcut-fe" ] && [ "$(have_ecm_init)" = "0" ] && {
+			/etc/init.d/shortcut-fe stop 2>"/dev/null"
+			/etc/init.d/shortcut-fe enabled && /etc/init.d/shortcut-fe disable
+		}
 	}
 
 	stop_dnscache

--- a/package/lean/shortcut-fe/shortcut-fe/Makefile
+++ b/package/lean/shortcut-fe/shortcut-fe/Makefile
@@ -16,7 +16,6 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=shortcut-fe
 PKG_RELEASE:=2
-PKG_CONFIG_DEPENDS := CONFIG_IPV6
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -24,7 +23,7 @@ define KernelPackage/shortcut-fe
   SECTION:=kernel
   CATEGORY:=Kernel modules
   SUBMENU:=Network Support
-  DEPENDS:=
+  DEPENDS:=@IPV6
   TITLE:=Kernel driver for SFE
   FILES:=$(PKG_BUILD_DIR)/shortcut-fe.ko $(if $(CONFIG_IPV6),$(PKG_BUILD_DIR)/shortcut-fe-ipv6.ko,)
   KCONFIG:=CONFIG_NF_CONNTRACK_EVENTS=y \

--- a/package/lean/shortcut-fe/shortcut-fe/files/etc/init.d/shortcut-fe
+++ b/package/lean/shortcut-fe/shortcut-fe/files/etc/init.d/shortcut-fe
@@ -23,18 +23,12 @@ have_cm() {
 	echo 0
 }
 
+#load shortcut-fe and connection manager
 load_sfe() {
-        [ -d "/sys/module/shortcut_fe" ] || insmod shortcut-fe
-        [ -d "/sys/module/shortcut_fe_ipv6" ] || insmod shortcut-fe-ipv6
-}
-
-#load shortcut-fe connection manager
-load_sfe_cm() {
 	local kernel_version=$(uname -r)
 
-	#no ecm :
-	#shortcut-fe-drv.ko is not needed because other connection manager is not enabled
-	[ -d "/sys/module/shortcut_fe_drv" ] && rmmod shortcut_fe_drv
+	[ -d "/sys/module/shortcut_fe" ] || insmod /lib/modules/$kernel_version/shortcut-fe.ko
+	[ -d "/sys/module/shortcut_fe_ipv6" ] || insmod /lib/modules/$kernel_version/shortcut-fe-ipv6.ko
 
 	[ -e "/lib/modules/$kernel_version/shortcut-fe-cm.ko" ] && {
 		[ -d /sys/module/shortcut_fe_cm ] || insmod /lib/modules/$kernel_version/shortcut-fe-cm.ko
@@ -45,7 +39,7 @@ load_sfe_cm() {
 }
 
 start() {
-	[ "$(have_cm)" = "0" ] && load_sfe && load_sfe_cm
+	[ "$(have_cm)" = "0" ] && load_sfe
 }
 
 stop() {


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ x] 我知道

Fix issues #7840
Shortcut-fe-cm supports IPV6 by default. So the Shortcut-fe driver must work in an IPV6-enabled environment to prevent other problems.
**If you encounter problems, please check whether IPv6 is enabled first**