### PR TITLE
Revert "amule: update to 2.3.3 (#7935)"

### DIFF
--- a/package/lean/amule/Makefile
+++ b/package/lean/amule/Makefile
@@ -1,29 +1,36 @@
-# Copyright (C) 2021 ImmortalWrt
-# <https://immortalwrt.org>
 #
-# This is free software, licensed under the GNU General Public License v3.
+# Copyright (C) 2007-2009 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
 #
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=amule
-PKG_VERSION:=2.3.3
-PKG_RELEASE:=1
+PKG_NAME:=aMule
+PKG_VERSION:=2.3.2
+PKG_RELEASE:=3
+PKG_REV=4b87b20
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/amule-project/amule/tar.gz/$(PKG_VERSION)?
-PKG_HASH:=934f79d4dab41c2d1caea31d6c6e10337c409ba5bb8bd6fac6c63e924e82c9b8
 
-PKG_CONFIG_DEPEDS:= CONFIG_AMULE_CRYPTOPP_STATIC_LINKING
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-r$(PKG_REV).tar.bz2
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=$(PKG_REV)
+PKG_SOURCE_URL:=https://github.com/amule-project/amule.git
+PKG_MIRROR_HASH:=1575d31d68f9df881100c9e30f18fc7dec8493a8ae20787f41b6ef23604a78ff
 
-PKG_FIXUP:=autoreconf
-PKG_BUILD_DEPENDS:=libcryptopp libgd
-PKG_BUILD_PARALLEL:=1
-PKG_INSTALL:=1
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+PKG_BUILD_DEPENDS:=libgd libcryptopp
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
+
+define Package/amule/config
+config AMULE_CRYPTOPP_STATIC_LINKING
+	bool "Link libcryptopp statically"
+	default n
+endef
 
 define Package/amule
   SUBMENU:=P2P
@@ -35,17 +42,10 @@ define Package/amule
 	$(ICONV_DEPENDS) $(INTL_DEPENDS) +!AMULE_CRYPTOPP_STATIC_LINKING:libcryptopp
 endef
 
-define Package/amule/config
-config AMULE_CRYPTOPP_STATIC_LINKING
-	bool "Link libcryptopp statically"
-	default n
-endef
-
-TARGET_LDFLAGS+= -liconv
-
 CONFIGURE_ARGS+= \
 	--disable-static \
 	--disable-rpath \
+	--with-gnu-ld \
 	--disable-ccache \
 	--disable-optimize \
 	--disable-profile \
@@ -59,13 +59,11 @@ CONFIGURE_ARGS+= \
 	--disable-ed2k \
 	--disable-alc \
 	--disable-alcc \
-	--disable-debug \
 	--disable-fileview \
 	--disable-plasmamule \
 	--without-wxdebug \
 	--enable-dlp \
 	--enable-upnp \
-	--with-gnu-ld \
 	--with-zlib="$(STAGING_DIR)/usr" \
 	--with-gdlib-prefix="$(STAGING_DIR)/usr" \
 	--with-libpng-prefix="$(STAGING_DIR)/usr" \
@@ -74,27 +72,39 @@ CONFIGURE_ARGS+= \
 	--with-libiconv-prefix="$(ICONV_PREFIX)" \
 	--with-libintl-prefix="$(INTL_PREFIX)" \
 	--with-libupnp-prefix="$(STAGING_DIR)/usr" \
-	--without-x
+	--without-x \
+	--disable-debug 
 
-MAKE_FLAGS += HOSTCC="$(HOSTCC)"
+TARGET_LDFLAGS += -liconv 
+
 
 define Build/Configure
-	cd $(PKG_BUILD_DIR); $(SHELL) autogen.sh
+	cd $(PKG_BUILD_DIR) && sh ./autogen.sh
 	$(call Build/Configure/Default)
+endef
+
 ifeq ($(CONFIG_AMULE_CRYPTOPP_STATIC_LINKING),y)
-	$(SED) 's;^CRYPTOPP_LIBS.*;CRYPTOPP_LIBS \= "$(STAGING_DIR)/usr/lib/libcryptopp.a";g' \
-		$(PKG_BUILD_DIR)/src/Makefile
+	SED_CMD:=sed
+else
+	SED_CMD:=true
 endif
+
+define Build/Compile
+	$(SED_CMD) -i 's;^CRYPTOPP_LIBS.*;CRYPTOPP_LIBS \= "$(STAGING_DIR)/usr/lib/libcryptopp.a";g' \
+		$(PKG_BUILD_DIR)/src/Makefile
+	$(MAKE) -C $(PKG_BUILD_DIR) \
+		HOSTCC="$(HOSTCC)" \
+		DESTDIR="$(PKG_INSTALL_DIR)" \
+		all
 endef
 
 define Package/amule/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/amulecmd $(1)/usr/bin/amulecmd
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/amuled $(1)/usr/bin/amuled
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/amuleweb $(1)/usr/bin/amuleweb
-
-	$(INSTALL_DIR) $(1)/usr/share
-	$(CP) $(PKG_INSTALL_DIR)/usr/share/amule $(1)/usr/share/
+	$(INSTALL_DIR) $(1)/usr/share/amule/webserver
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/amule{cmd,d} $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/src/webserver/src/amuleweb $(1)/usr/bin/
+	$(CP) $(PKG_BUILD_DIR)/src/webserver/default $(1)/usr/share/amule/webserver
+	
 endef
 
 $(eval $(call BuildPackage,amule))

--- a/package/lean/amule/patches/001-amule-dlp.patch
+++ b/package/lean/amule/patches/001-amule-dlp.patch
@@ -1,6 +1,7 @@
---- a/configure.ac
-+++ b/configure.ac
-@@ -91,6 +91,14 @@ MULE_IF_ENABLED([static], [MULE_APPEND([
+diff -Naur a/configure.ac b/configure.ac
+--- a/configure.ac	2016-10-06 19:01:54.000000000 +0800
++++ b/configure.ac	2016-10-14 12:33:51.660347919 +0800
+@@ -89,6 +89,14 @@
  KDE_CONFIG_OPTIONS
  QT_CONFIG_OPTIONS
  
@@ -15,8 +16,8 @@
  # Default is yes, because they're most likely compatible.
  # However, this is only used when cross-compiling.
  AC_ARG_WITH(
-@@ -451,6 +459,8 @@ AM_CONDITIONAL(NEED_CORESERVICES, test x
- AM_CONDITIONAL(COMPILE_NLS, test x$USE_NLS = xyes)
+@@ -457,6 +465,8 @@
+ AM_CONDITIONAL(GENERATE_FLEX_HEADER, test x$HAVE_FLEX_EXTENDED = xyes)
  AM_CONDITIONAL(INSTALL_SKINS, test MULE_IS_ENABLED_ANY([monolithic, amule-gui]))
  AM_CONDITIONAL(PLASMAMULE, test MULE_IS_ENABLED([plasmamule]))
 +#Dynamic Leech Protection - Bill Lee
@@ -24,17 +25,18 @@
  
  AM_CONDITIONAL([COMPILE_LIB_COMMON],	[test MULE_IS_ENABLED_ANY([monolithic, amule-daemon, amulecmd, webserver, amule-gui, fileview])])
  AM_CONDITIONAL([COMPILE_LIB_EC],	[test MULE_IS_ENABLED_ANY([monolithic, amule-daemon, amulecmd, webserver, amule-gui])])
---- a/po/zh_CN.po
-+++ b/po/zh_CN.po
-@@ -7,6 +7,7 @@
+diff -Naur a/po/zh_CN.po b/po/zh_CN.po
+--- a/po/zh_CN.po	2016-10-06 19:01:54.000000000 +0800
++++ b/po/zh_CN.po	2016-10-14 12:33:51.662347964 +0800
+@@ -5,6 +5,7 @@
  # xiaoqiao <29551030@qq.com>, 2007, 2008.
  # JimHu <jimhuyiwei@gmail.com>, 2009.
  # Xiaoqiao <wo@xiaoqiao.me>, 2010.
 +# Bill Lee <bill.lee.y@gmail.com>, 2010, 2011.
- # Yi Qi <u4781098@anu.edu.au>, 2011.
+ # Yi Qi <u4781098@anu.edu.au>,2011.
  #
  msgid ""
-@@ -471,6 +472,12 @@ msgstr " 版权所有 (c) 2002-2011 Peta
+@@ -467,6 +468,12 @@
  msgid "http://kademlia.scs.cs.nyu.edu\n"
  msgstr "http://kademlia.scs.cs.nyu.edu\n"
  
@@ -44,22 +46,22 @@
 +msgid " Homepage: http://amule-dlp.googlecode.com \n"
 +msgstr " 主页：http://amule-dlp.googlecode.com \n"
 +
- #: src/amuleDlg.cpp:509 src/KadDlg.cpp:193 src/PartFile.cpp:919
- #: src/PartFile.cpp:927 src/PrefsUnifiedDlg.cpp:637 src/PrefsUnifiedDlg.cpp:742
- #: src/PrefsUnifiedDlg.cpp:862
-@@ -3824,6 +3831,9 @@ msgstr "按此按钮清空日志."
- msgid "Click on this button to update the servers list from URL ..."
- msgstr "按此按钮从该网址更新服务器列表 ..."
+ #: src/amuleDlg.cpp:512 src/KadDlg.cpp:193 src/PartFile.cpp:918
+ #: src/PartFile.cpp:926 src/PrefsUnifiedDlg.cpp:629
+ #: src/PrefsUnifiedDlg.cpp:734 src/PrefsUnifiedDlg.cpp:847
+@@ -3856,6 +3863,9 @@
+ msgid "Click on this button to update the nodes list from URL ..."
+ msgstr "按此更新节点列表自网址..."
  
 +msgid "DLP Info"
 +msgstr "动态反吸血信息"
 +
- #: src/muuli_wdr.cpp:2535
- msgid "Server list"
- msgstr "服务器列表"
-@@ -7448,6 +7458,48 @@ msgstr "已请求注销\n"
- msgid "Processing request [redirected]: "
- msgstr "正在处理请求 [已重定向]："
+ #: src/muuli_wdr.cpp:2649
+ msgid "Nodes (0)"
+ msgstr "节点（0）"
+@@ -7682,6 +7692,48 @@
+ #~ "\n"
+ #~ "此外，浏览器设定已经被重设为系统默认值。如有必要，请重新配置浏览器选项。\n"
  
 +msgid "Dynamic Leecher Protection Options"
 +msgstr "动态反吸血保护选项"
@@ -103,11 +105,12 @@
 +msgid "Succeed loading antiLeech! Version: %d"
 +msgstr "成功加载 antiLeech! 版本： %d"
 +
- #~ msgid ""
- #~ "Invalid URL for HTTP download or HTTP redirection (did you forget "
- #~ "'http://' ?)"
---- a/src/BaseClient.cpp
-+++ b/src/BaseClient.cpp
+ #~ msgid "Fetching status..."
+ #~ msgstr "正在获取状态..."
+ 
+diff -Naur a/src/BaseClient.cpp b/src/BaseClient.cpp
+--- a/src/BaseClient.cpp	2016-10-06 19:01:54.000000000 +0800
++++ b/src/BaseClient.cpp	2016-10-14 12:35:45.793953665 +0800
 @@ -1,4 +1,3 @@
 -//
  // This file is part of the aMule Project.
@@ -136,7 +139,7 @@
  // some client testing variables
  static wxString crash_name = wxT("[Invalid User Name]");
  static wxString empty_name = wxT("[Empty User Name]");
-@@ -290,6 +292,10 @@ void CUpDownClient::Init()
+@@ -290,6 +292,10 @@
  	m_cMessagesReceived = 0;
  	m_cMessagesSent = 0;
  
@@ -147,7 +150,7 @@
  }
  
  
-@@ -635,6 +641,15 @@ bool CUpDownClient::ProcessHelloTypePack
+@@ -635,6 +641,15 @@
  				m_fSharedDirectories = 1;
  				dwEmuleTags |= 4;
  				break;
@@ -163,7 +166,7 @@
  		}
  	}
  
-@@ -717,6 +732,11 @@ bool CUpDownClient::ProcessHelloTypePack
+@@ -717,6 +732,11 @@
  		Kademlia::CKademlia::Bootstrap(wxUINT32_SWAP_ALWAYS(GetIP()), GetKadPort());
  	}
  
@@ -175,7 +178,7 @@
  	return bIsMule;
  }
  
-@@ -966,6 +986,14 @@ bool CUpDownClient::ProcessMuleInfoPacke
+@@ -966,6 +986,14 @@
  							% GetClientFullInfo()
  					);
  
@@ -190,7 +193,7 @@
  					break;
  			}
  		}
-@@ -1003,6 +1031,11 @@ bool CUpDownClient::ProcessMuleInfoPacke
+@@ -1003,6 +1031,11 @@
  		m_byInfopacketsReceived |= IP_EMULEPROTPACK;
  	}
  
@@ -202,7 +205,7 @@
  	return (protocol_version == 0xFF); // This was a OS_Info?
  }
  
-@@ -2303,7 +2336,7 @@ bool CUpDownClient::CheckHandshakeFinish
+@@ -2302,7 +2335,7 @@
  }
  
  
@@ -211,8 +214,9 @@
  wxString CUpDownClient::GetClientFullInfo()
  {
  	if (m_clientVerString.IsEmpty()) {
---- /dev/null
-+++ b/src/CString_wx.h
+diff -Naur a/src/CString_wx.h b/src/CString_wx.h
+--- a/src/CString_wx.h	1970-01-01 08:00:00.000000000 +0800
++++ b/src/CString_wx.h	2016-10-14 12:33:51.664348010 +0800
 @@ -0,0 +1,59 @@
 +/**
 + * Author:	Bill Lee<bill.lee.y@gmail.com>
@@ -273,8 +277,9 @@
 +		}
 +};
 +#endif
---- /dev/null
-+++ b/src/DLP.cpp
+diff -Naur a/src/DLP.cpp b/src/DLP.cpp
+--- a/src/DLP.cpp	1970-01-01 08:00:00.000000000 +0800
++++ b/src/DLP.cpp	2016-10-14 12:33:51.664348010 +0800
 @@ -0,0 +1,190 @@
 +// Copyright (C) 2011 Bill Lee <bill.lee.y@gmail.com>
 +//
@@ -466,8 +471,9 @@
 +	antiLeechLib.Load(file);
 +	return antiLeechLib.IsLoaded();
 +}
---- /dev/null
-+++ b/src/DLP.h
+diff -Naur a/src/DLP.h b/src/DLP.h
+--- a/src/DLP.h	1970-01-01 08:00:00.000000000 +0800
++++ b/src/DLP.h	2016-10-14 12:33:51.665348032 +0800
 @@ -0,0 +1,45 @@
 +// Copyright (C) 2011 Bill Lee <bill.lee.y@gmail.com>
 +//
@@ -514,8 +520,9 @@
 +
 +	bool LoadFrom(wxString& file);
 +};
---- /dev/null
-+++ b/src/DLPPref.h
+diff -Naur a/src/DLPPref.h b/src/DLPPref.h
+--- a/src/DLPPref.h	1970-01-01 08:00:00.000000000 +0800
++++ b/src/DLPPref.h	2016-10-14 12:33:51.665348032 +0800
 @@ -0,0 +1,15 @@
 +#ifndef ANTILEECH_AMULE_H
 +#define ANTILEECH_AMULE_H
@@ -532,9 +539,10 @@
 +#define PF_GHOSTMOD	0x100
 +
 +#endif
---- a/src/DownloadQueue.cpp
-+++ b/src/DownloadQueue.cpp
-@@ -623,6 +623,15 @@ void CDownloadQueue::CheckAndAddSource(C
+diff -Naur a/src/DownloadQueue.cpp b/src/DownloadQueue.cpp
+--- a/src/DownloadQueue.cpp	2016-10-06 19:01:54.000000000 +0800
++++ b/src/DownloadQueue.cpp	2016-10-14 12:33:51.665348032 +0800
+@@ -623,6 +623,15 @@
  		return;
  	}
  
@@ -550,9 +558,10 @@
  	// Filter sources which are known to be dead/useless
  	if ( theApp->clientlist->IsDeadSource( source ) || sender->IsDeadSource(source) ) {
  		source->Safe_Delete();
---- a/src/ExternalConn.cpp
-+++ b/src/ExternalConn.cpp
-@@ -55,6 +55,9 @@
+diff -Naur a/src/ExternalConn.cpp b/src/ExternalConn.cpp
+--- a/src/ExternalConn.cpp	2016-10-06 19:01:54.000000000 +0800
++++ b/src/ExternalConn.cpp	2016-10-14 12:33:51.666348055 +0800
+@@ -57,6 +57,9 @@
  #include "kademlia/kademlia/UDPFirewallTester.h"
  #include "Statistics.h"
  
@@ -562,7 +571,7 @@
  
  //-------------------- File_Encoder --------------------
  
-@@ -1388,6 +1391,15 @@ CECPacket *CECServerSocket::ProcessReque
+@@ -1384,6 +1387,15 @@
  				}
  			}
  			break;
@@ -578,9 +587,10 @@
  		//
  		// Status requests
  		//
---- a/src/Logger.cpp
-+++ b/src/Logger.cpp
-@@ -297,6 +297,8 @@ void CLogger::FlushApplog()
+diff -Naur a/src/Logger.cpp b/src/Logger.cpp
+--- a/src/Logger.cpp	2016-10-06 19:01:54.000000000 +0800
++++ b/src/Logger.cpp	2016-10-14 12:40:22.827322335 +0800
+@@ -297,6 +297,8 @@
  }
  
  CLogger theLogger;
@@ -589,9 +599,10 @@
  
  BEGIN_EVENT_TABLE(CLogger, wxEvtHandler)
  	EVT_MULE_LOGGING(CLogger::OnLoggingEvent)
---- a/src/Logger.h
-+++ b/src/Logger.h
-@@ -310,6 +310,8 @@ private:
+diff -Naur a/src/Logger.h b/src/Logger.h
+--- a/src/Logger.h	2016-10-06 19:01:54.000000000 +0800
++++ b/src/Logger.h	2016-10-14 12:41:14.694519856 +0800
+@@ -310,6 +310,8 @@
  };
  
  extern CLogger theLogger;
@@ -600,7 +611,7 @@
  
  /**
   * This class forwards log-lines from wxWidgets to CLogger.
-@@ -456,5 +458,8 @@ public:
+@@ -456,5 +458,8 @@
  	#define AddLogLineF(string) theLogger.AddLogLine(__TFILE__, __LINE__, false, logStandard, string, false, false)
  #endif
  
@@ -609,9 +620,10 @@
 +
  #endif
  // File_checked_for_headers
---- a/src/LoggerConsole.cpp
-+++ b/src/LoggerConsole.cpp
-@@ -94,6 +94,8 @@ void CLogger::AddLogLine(
+diff -Naur a/src/LoggerConsole.cpp b/src/LoggerConsole.cpp
+--- a/src/LoggerConsole.cpp	2016-10-06 19:01:54.000000000 +0800
++++ b/src/LoggerConsole.cpp	2016-10-14 12:41:54.805446813 +0800
+@@ -85,6 +85,8 @@
  }
  
  CLogger theLogger;
@@ -620,9 +632,10 @@
  
  BEGIN_EVENT_TABLE(CLogger, wxEvtHandler)
  END_EVENT_TABLE()
---- a/src/Makefile.am
-+++ b/src/Makefile.am
-@@ -178,6 +178,13 @@ core_sources = \
+diff -Naur a/src/Makefile.am b/src/Makefile.am
+--- a/src/Makefile.am	2016-10-06 19:01:54.000000000 +0800
++++ b/src/Makefile.am	2016-10-14 12:33:51.666348055 +0800
+@@ -179,6 +179,13 @@
  	kademlia/routing/RoutingZone.cpp
  
  
@@ -636,9 +649,10 @@
  gui_sources = \
  	amule-gui.cpp \
  	amuleDlg.cpp \
---- a/src/Preferences.cpp
-+++ b/src/Preferences.cpp
-@@ -49,6 +49,11 @@
+diff -Naur a/src/Preferences.cpp b/src/Preferences.cpp
+--- a/src/Preferences.cpp	2016-10-06 19:01:54.000000000 +0800
++++ b/src/Preferences.cpp	2016-10-14 12:33:51.667348078 +0800
+@@ -51,6 +51,11 @@
  
  #include "UserEvents.h"
  
@@ -650,7 +664,7 @@
  #ifndef AMULE_DAEMON
  #include <wx/valgen.h>
  #include "muuli_wdr.h"
-@@ -343,6 +348,19 @@ protected:
+@@ -344,6 +349,19 @@
  	wxWindow*	m_widget;
  };
  
@@ -670,7 +684,7 @@
  
  /** Cfg class for wxStrings. */
  class Cfg_Str : public Cfg_Tmpl<wxString>
-@@ -952,6 +970,11 @@ CPreferences::CPreferences()
+@@ -953,6 +971,11 @@
  	s_userhash[5] = 14;
  	s_userhash[14] = 111;
  
@@ -682,7 +696,7 @@
  #ifndef CLIENT_GUI
  	LoadPreferences();
  	ReloadSharedFolders();
-@@ -1061,6 +1084,20 @@ void CPreferences::BuildItemList( const
+@@ -1062,6 +1085,20 @@
  	NewCfgItem( IDC_NETWORKKAD, (new Cfg_Bool( wxT("/eMule/ConnectToKad"),	s_ConnectToKad, true )) );
  	NewCfgItem( IDC_NETWORKED2K, ( new Cfg_Bool( wxT("/eMule/ConnectToED2K"),	s_ConnectToED2K, true ) ));
  
@@ -703,7 +717,7 @@
  
  	/**
  	 * Files
-@@ -1471,6 +1508,11 @@ void CPreferences::Save()
+@@ -1471,6 +1508,11 @@
  	}
  
  	SavePreferences();
@@ -715,7 +729,7 @@
  
  	#ifndef CLIENT_GUI
  	CTextFile sdirfile;
-@@ -1483,6 +1525,21 @@ void CPreferences::Save()
+@@ -1483,6 +1525,21 @@
  	#endif
  }
  
@@ -737,9 +751,10 @@
  
  CPreferences::~CPreferences()
  {
---- a/src/Preferences.h
-+++ b/src/Preferences.h
-@@ -580,6 +580,11 @@ public:
+diff -Naur a/src/Preferences.h b/src/Preferences.h
+--- a/src/Preferences.h	2016-10-06 19:01:54.000000000 +0800
++++ b/src/Preferences.h	2016-10-14 12:33:51.667348078 +0800
+@@ -579,6 +579,11 @@
  	// Sleep
  	static bool		GetPreventSleepWhileDownloading() { return s_preventSleepWhileDownloading; }
  	static void		SetPreventSleepWhileDownloading(bool status) { s_preventSleepWhileDownloading = status; }
@@ -751,7 +766,7 @@
  protected:
  	static	int32 GetRecommendedMaxConnections();
  
-@@ -600,6 +605,11 @@ protected:
+@@ -599,6 +604,11 @@
  private:
  	void LoadPreferences();
  	void SavePreferences();
@@ -763,7 +778,7 @@
  
  protected:
  	static wxString	s_configDir;
-@@ -815,6 +825,20 @@ protected:
+@@ -813,6 +823,20 @@
  	// Stats server
  	static wxString s_StatsServerName;
  	static wxString s_StatsServerURL;
@@ -784,8 +799,9 @@
  };
  
  
---- a/src/PrefsUnifiedDlg.cpp
-+++ b/src/PrefsUnifiedDlg.cpp
+diff -Naur a/src/PrefsUnifiedDlg.cpp b/src/PrefsUnifiedDlg.cpp
+--- a/src/PrefsUnifiedDlg.cpp	2016-10-06 19:01:54.000000000 +0800
++++ b/src/PrefsUnifiedDlg.cpp	2016-10-14 12:33:51.668348101 +0800
 @@ -53,6 +53,11 @@
  #include "UserEvents.h"
  #include "PlatformSpecific.h"		// Needed for PLATFORMSPECIFIC_CAN_PREVENT_SLEEP_MODE
@@ -798,7 +814,7 @@
  BEGIN_EVENT_TABLE(PrefsUnifiedDlg,wxDialog)
  	// Events
  #define USEREVENTS_EVENT(ID, NAME, VARS) \
-@@ -114,6 +119,11 @@ BEGIN_EVENT_TABLE(PrefsUnifiedDlg,wxDial
+@@ -114,6 +119,11 @@
  	EVT_CHOICE(IDC_COLORSELECTOR,		PrefsUnifiedDlg::OnColorCategorySelected)
  	EVT_LIST_ITEM_SELECTED(ID_PREFSLISTCTRL,PrefsUnifiedDlg::OnPrefsPageChange)
  
@@ -810,7 +826,7 @@
  	EVT_INIT_DIALOG(PrefsUnifiedDlg::OnInitDialog)
  
  	EVT_COMMAND_SCROLL(IDC_SLIDER,		PrefsUnifiedDlg::OnScrollBarChange)
-@@ -187,6 +197,9 @@ PrefsPage pages[] =
+@@ -187,6 +197,9 @@
  	{ wxTRANSLATE("Online Signature"),	PreferencesOnlineSigTab,	21 },
  	{ wxTRANSLATE("Advanced"),			PreferencesaMuleTweaksTab,	12 },
  	{ wxTRANSLATE("Events"),			PreferencesEventsTab,		5 }
@@ -820,7 +836,7 @@
  #ifdef __DEBUG__
  	,{ wxTRANSLATE("Debugging"),		PreferencesDebug,			25 }
  #endif
-@@ -1096,6 +1109,21 @@ void PrefsUnifiedDlg::OnButtonIPFilterUp
+@@ -1076,6 +1089,21 @@
  	theApp->ipfilter->Update( CastChild( IDC_IPFILTERURL, wxTextCtrl )->GetValue() );
  }
  
@@ -842,9 +858,10 @@
  
  void PrefsUnifiedDlg::OnPrefsPageChange(wxListEvent& event)
  {
---- a/src/PrefsUnifiedDlg.h
-+++ b/src/PrefsUnifiedDlg.h
-@@ -124,6 +124,9 @@ protected:
+diff -Naur a/src/PrefsUnifiedDlg.h b/src/PrefsUnifiedDlg.h
+--- a/src/PrefsUnifiedDlg.h	2016-10-06 19:01:54.000000000 +0800
++++ b/src/PrefsUnifiedDlg.h	2016-10-14 12:33:51.668348101 +0800
+@@ -124,6 +124,9 @@
  	void OnUserEventSelected(wxListEvent& event);
  	void OnLanguageChoice(wxCommandEvent &event);
  	void CreateEventPanels(const int idx, const wxString& vars, wxWindow* parent);
@@ -854,9 +871,10 @@
  
  	void OnInitDialog( wxInitDialogEvent& evt );
  
---- a/src/ServerWnd.cpp
-+++ b/src/ServerWnd.cpp
-@@ -46,6 +46,7 @@ BEGIN_EVENT_TABLE(CServerWnd,wxPanel)
+diff -Naur a/src/ServerWnd.cpp b/src/ServerWnd.cpp
+--- a/src/ServerWnd.cpp	2016-10-06 19:01:54.000000000 +0800
++++ b/src/ServerWnd.cpp	2016-10-14 12:33:51.668348101 +0800
+@@ -46,6 +46,7 @@
  	EVT_BUTTON(ID_BTN_RESET, CServerWnd::OnBnClickedResetLog)
  	EVT_BUTTON(ID_BTN_RESET_SERVER, CServerWnd::OnBnClickedResetServerLog)
  	EVT_SPLITTER_SASH_POS_CHANGED(ID_SRV_SPLITTER,CServerWnd::OnSashPositionChanged)
@@ -864,7 +882,7 @@
  END_EVENT_TABLE()
  
  
-@@ -152,6 +153,11 @@ void CServerWnd::OnBnClickedResetServerL
+@@ -152,6 +153,11 @@
  	theApp->GetServerLog(true); // Reset it
  }
  
@@ -876,9 +894,10 @@
  
  void CServerWnd::UpdateED2KInfo()
  {
---- a/src/ServerWnd.h
-+++ b/src/ServerWnd.h
-@@ -50,6 +50,7 @@ private:
+diff -Naur a/src/ServerWnd.h b/src/ServerWnd.h
+--- a/src/ServerWnd.h	2016-10-06 19:01:54.000000000 +0800
++++ b/src/ServerWnd.h	2016-10-14 12:33:51.668348101 +0800
+@@ -50,6 +50,7 @@
  	void OnBnClickedUpdateservermetfromurl(wxCommandEvent& evt);
  	void OnBnClickedResetLog(wxCommandEvent& evt);
  	void OnBnClickedResetServerLog(wxCommandEvent& evt);
@@ -886,9 +905,10 @@
  
  	DECLARE_EVENT_TABLE()
  };
---- a/src/TextClient.cpp
-+++ b/src/TextClient.cpp
-@@ -67,6 +67,7 @@ enum {
+diff -Naur a/src/TextClient.cpp b/src/TextClient.cpp
+--- a/src/TextClient.cpp	2016-10-06 19:01:54.000000000 +0800
++++ b/src/TextClient.cpp	2016-10-14 12:33:51.669348124 +0800
+@@ -73,6 +73,7 @@
  	CMD_ID_RELOAD_SHARED,
  	CMD_ID_RELOAD_IPFILTER_LOCAL,
  	CMD_ID_RELOAD_IPFILTER_NET,
@@ -896,7 +916,7 @@
  	CMD_ID_SET_IPFILTER_ON,
  	CMD_ID_SET_IPFILTER_OFF,
  	CMD_ID_SET_IPFILTER_CLIENTS_ON,
-@@ -100,7 +101,6 @@ enum {
+@@ -106,7 +107,6 @@
  	CMD_ID_DOWNLOAD,
  	// IDs for deprecated commands
  	CMD_ID_SET_IPFILTER
@@ -904,7 +924,7 @@
  };
  
  // method to create a SearchFile
-@@ -234,6 +234,12 @@ int CamulecmdApp::ProcessCommand(int Cmd
+@@ -240,6 +240,12 @@
  		case CMD_ID_DISCONNECT_KAD:
  			request_list.push_back(new CECPacket(EC_OP_KAD_STOP));
  			break;
@@ -917,7 +937,7 @@
  
  		case CMD_ID_RELOAD_SHARED:
  			request_list.push_back(new CECPacket(EC_OP_SHAREDFILES_RELOAD));
-@@ -904,6 +910,9 @@ void CamulecmdApp::OnInitCommandSet()
+@@ -903,6 +909,9 @@
  	tmp2->AddCommand(wxT("Net"), CMD_ID_RELOAD_IPFILTER_NET, wxTRANSLATE("Update IP filtering table from URL."),
  					wxTRANSLATE("If URL is omitted the URL from the preferences is used."), CMD_PARAM_OPTIONAL);
  
@@ -927,9 +947,10 @@
  	tmp = m_commands.AddCommand(wxT("Connect"), CMD_ID_CONNECT, wxTRANSLATE("Connect to the network."),
  				    wxTRANSLATE("This will connect to all networks that are enabled in Preferences.\nYou may also optionally specify a server address in IP:Port form, to connect to\nthat server only. The IP must be a dotted decimal IPv4 address,\nor a resolvable DNS name."), CMD_PARAM_OPTIONAL);
  	tmp->AddCommand(wxT("ED2K"), CMD_ID_CONNECT_ED2K, wxTRANSLATE("Connect to eD2k only."), wxEmptyString, CMD_PARAM_NEVER);
---- a/src/UploadQueue.cpp
-+++ b/src/UploadQueue.cpp
-@@ -390,6 +390,11 @@ void CUploadQueue::AddClientToQueue(CUpD
+diff -Naur a/src/UploadQueue.cpp b/src/UploadQueue.cpp
+--- a/src/UploadQueue.cpp	2016-10-06 19:01:54.000000000 +0800
++++ b/src/UploadQueue.cpp	2016-10-14 12:33:51.669348124 +0800
+@@ -390,6 +390,11 @@
  		return;
  	}
  
@@ -941,9 +962,10 @@
  	client->AddAskedCount();
  	client->SetLastUpRequest();
  
---- a/src/amule-gui.cpp
-+++ b/src/amule-gui.cpp
-@@ -333,6 +333,21 @@ wxString CamuleGuiApp::GetLog(bool reset
+diff -Naur a/src/amule-gui.cpp b/src/amule-gui.cpp
+--- a/src/amule-gui.cpp	2016-10-06 19:01:54.000000000 +0800
++++ b/src/amule-gui.cpp	2016-10-14 12:33:51.669348124 +0800
+@@ -333,6 +333,21 @@
  	return CamuleApp::GetLog(reset);
  }
  
@@ -965,8 +987,9 @@
  
  wxString CamuleGuiApp::GetServerLog(bool reset)
  {
---- a/src/amule.cpp
-+++ b/src/amule.cpp
+diff -Naur a/src/amule.cpp b/src/amule.cpp
+--- a/src/amule.cpp	2016-10-06 19:01:54.000000000 +0800
++++ b/src/amule.cpp	2016-10-14 12:33:51.670348146 +0800
 @@ -23,7 +23,6 @@
  // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301, USA
  //
@@ -975,7 +998,7 @@
  #include "amule.h"			// Interface declarations.
  
  #include <csignal>
-@@ -87,6 +86,11 @@
+@@ -90,6 +89,11 @@
  #include <wx/sysopt.h>			// Do_not_auto_remove
  #endif
  
@@ -987,7 +1010,7 @@
  #ifndef AMULE_DAEMON
  	#ifdef __WXMAC__
  		#include <CoreFoundation/CFBundle.h>  // Do_not_auto_remove
-@@ -517,6 +521,11 @@ bool CamuleApp::OnInit()
+@@ -520,6 +524,11 @@
  	uploadqueue	= new CUploadQueue();
  	ipfilter	= new CIPFilter();
  
@@ -999,7 +1022,7 @@
  	// Creates all needed listening sockets
  	wxString msg;
  	if (!ReinitializeNetwork(&msg)) {
-@@ -2063,3 +2072,8 @@ DEFINE_LOCAL_EVENT_TYPE(wxEVT_CORE_SOURC
+@@ -2062,3 +2071,8 @@
  DEFINE_LOCAL_EVENT_TYPE(wxEVT_CORE_UDP_DNS_DONE)
  DEFINE_LOCAL_EVENT_TYPE(wxEVT_CORE_SERVER_DNS_DONE)
  // File_checked_for_headers
@@ -1008,9 +1031,10 @@
 +#ifdef AMULE_DLP
 +DLP* theDLP;
 +#endif
---- a/src/amule.h
-+++ b/src/amule.h
-@@ -134,6 +134,8 @@ protected:
+diff -Naur a/src/amule.h b/src/amule.h
+--- a/src/amule.h	2016-10-06 19:01:54.000000000 +0800
++++ b/src/amule.h	2016-10-14 12:42:22.776093625 +0800
+@@ -135,6 +135,8 @@
  	bool		m_geometryEnabled;
  	wxString	m_geometryString;
  	wxString	m_logFile;
@@ -1019,7 +1043,7 @@
  	wxString	m_appName;
  	wxString	m_PidFile;
  
-@@ -409,6 +411,7 @@ public:
+@@ -410,6 +412,7 @@
  	wxString GetLog(bool reset = false);
  	wxString GetServerLog(bool reset = false);
  	void AddServerMessageLine(wxString &msg);
@@ -1027,7 +1051,7 @@
  	DECLARE_EVENT_TABLE()
  };
  
-@@ -573,6 +576,8 @@ public:
+@@ -573,6 +576,8 @@
  
  	virtual int ShowAlert(wxString msg, wxString title, int flags);
  
@@ -1036,7 +1060,7 @@
  	DECLARE_EVENT_TABLE()
  };
  
-@@ -583,3 +588,8 @@ extern CamuleDaemonApp *theApp;
+@@ -583,3 +588,8 @@
  
  #endif // AMULE_H
  // File_checked_for_headers
@@ -1045,9 +1069,10 @@
 +class DLP;	//forward declaretion
 +extern DLP* theDLP;
 +#endif
---- a/src/amuleAppCommon.cpp
-+++ b/src/amuleAppCommon.cpp
-@@ -65,6 +65,9 @@ CamuleAppCommon::CamuleAppCommon()
+diff -Naur a/src/amuleAppCommon.cpp b/src/amuleAppCommon.cpp
+--- a/src/amuleAppCommon.cpp	2016-10-06 19:01:54.000000000 +0800
++++ b/src/amuleAppCommon.cpp	2016-10-14 12:44:08.981552362 +0800
+@@ -65,6 +65,9 @@
  		m_configFile	= wxT("amule.conf");
  		m_logFile		= wxT("logfile");
  
@@ -1057,7 +1082,7 @@
  		if (IsDaemon()) {
  			m_appName	= wxT("aMuleD");
  		} else {
-@@ -443,6 +446,21 @@ bool CamuleAppCommon::InitCommon(int arg
+@@ -443,6 +446,21 @@
  		return false;
  	}
  
@@ -1079,9 +1104,10 @@
  	// Load Preferences
  	CPreferences::BuildItemList(thePrefs::GetConfigDir());
  	CPreferences::LoadAllItems( wxConfigBase::Get() );
---- a/src/amuleDlg.cpp
-+++ b/src/amuleDlg.cpp
-@@ -311,7 +311,7 @@ m_clientSkinNames(CLIENT_SKIN_SIZE)
+diff -Naur a/src/amuleDlg.cpp b/src/amuleDlg.cpp
+--- a/src/amuleDlg.cpp	2016-10-06 19:01:54.000000000 +0800
++++ b/src/amuleDlg.cpp	2016-10-14 12:44:47.637582726 +0800
+@@ -315,7 +315,7 @@
  	wxNotebook* logs_notebook = CastChild( ID_SRVLOG_NOTEBOOK, wxNotebook);
  	wxNotebook* networks_notebook = CastChild( ID_NETNOTEBOOK, wxNotebook);
  
@@ -1090,7 +1116,7 @@
  	wxASSERT(networks_notebook->GetPageCount() == 2);
  
  	for (uint32 i = 0; i < logs_notebook->GetPageCount(); ++i) {
-@@ -503,7 +503,12 @@ void CamuleDlg::OnAboutButton(wxCommandE
+@@ -507,7 +507,12 @@
  		_("Part of aMule is based on \n") <<
  		_("Kademlia: Peer-to-peer routing based on the XOR metric.\n") <<
                  _(" Copyright (c) 2002-2011 Petar Maymounkov ( petar@post.harvard.edu )\n") <<
@@ -1104,7 +1130,7 @@
  
  	if (m_is_safe_state) {
  		wxMessageBox(msg, _("Message"), wxOK | wxICON_INFORMATION, this);
-@@ -655,8 +660,24 @@ void CamuleDlg::AddServerMessageLine(wxS
+@@ -659,8 +664,24 @@
  		}
  		cv->ShowPosition(cv->GetLastPosition()-1);
  	}
@@ -1129,7 +1155,7 @@
  
  void CamuleDlg::ShowConnectionState(bool skinChanged)
  {
-@@ -1435,7 +1456,9 @@ void CamuleDlg::DoNetworkRearrange()
+@@ -1456,7 +1477,9 @@
  	if (thePrefs::GetNetworkKademlia()) {
  		logs_notebook->AddPage(m_logpages[3].page, m_logpages[3].name);
  	}
@@ -1140,9 +1166,10 @@
  	// Set the main window.
  	// If we have both networks active, activate a notebook to select between them.
  	// If only one is active, show the window directly without a surrounding one tab notebook.
---- a/src/amuleDlg.h
-+++ b/src/amuleDlg.h
-@@ -114,6 +114,9 @@ public:
+diff -Naur a/src/amuleDlg.h b/src/amuleDlg.h
+--- a/src/amuleDlg.h	2016-10-06 19:01:54.000000000 +0800
++++ b/src/amuleDlg.h	2016-10-14 12:33:51.671348169 +0800
+@@ -114,6 +114,9 @@
  
  	void AddLogLine(const wxString& line);
  	void AddServerMessageLine(wxString& message);
@@ -1152,7 +1179,7 @@
  	void ResetLog(int id);
  
  	void ShowUserCount(const wxString& info = wxEmptyString);
-@@ -222,7 +225,7 @@ private:
+@@ -231,7 +234,7 @@
  	WX_DECLARE_STRING_HASH_MAP(wxZipEntry*, ZipCatalog);
  	ZipCatalog cat;
  
@@ -1161,9 +1188,10 @@
  	PageType m_networkpages[2];
  
  	bool LoadGUIPrefs(bool override_pos, bool override_size);
---- a/src/amuled.cpp
-+++ b/src/amuled.cpp
-@@ -783,4 +783,10 @@ int CamuleDaemonApp::ShowAlert(wxString
+diff -Naur a/src/amuled.cpp b/src/amuled.cpp
+--- a/src/amuled.cpp	2016-10-06 19:01:54.000000000 +0800
++++ b/src/amuled.cpp	2016-10-14 12:45:23.506600119 +0800
+@@ -749,4 +749,10 @@
  	return 0;	// That's neither yes nor no, ok, cancel
  }
  
@@ -1174,8 +1202,9 @@
 +}
 +
  // File_checked_for_headers
---- /dev/null
-+++ b/src/antiLeech.h
+diff -Naur a/src/antiLeech.h b/src/antiLeech.h
+--- a/src/antiLeech.h	1970-01-01 08:00:00.000000000 +0800
++++ b/src/antiLeech.h	2016-10-14 12:33:51.672348192 +0800
 @@ -0,0 +1,48 @@
 +#ifndef ANTILEECH_H
 +#define ANTILEECH_H
@@ -1225,8 +1254,9 @@
 +extern "C" int destoryAntiLeechInstant(IantiLeech*);
 +
 +#endif
---- /dev/null
-+++ b/src/antiLeech_wx.h
+diff -Naur a/src/antiLeech_wx.h b/src/antiLeech_wx.h
+--- a/src/antiLeech_wx.h	1970-01-01 08:00:00.000000000 +0800
++++ b/src/antiLeech_wx.h	2016-10-14 12:33:51.672348192 +0800
 @@ -0,0 +1,49 @@
 +#ifndef ANTILEECH_WX_H
 +#define ANTILEECH_WX_H
@@ -1277,9 +1307,10 @@
 +#define _tcsicmp(a, b)		wcscasecmp(a, b)
 +
 +#endif
---- a/src/libs/ec/abstracts/ECCodes.abstract
-+++ b/src/libs/ec/abstracts/ECCodes.abstract
-@@ -148,6 +148,8 @@ EC_OP_SERVER_SET_STATIC_PRIO        0x56
+diff -Naur a/src/libs/ec/abstracts/ECCodes.abstract b/src/libs/ec/abstracts/ECCodes.abstract
+--- a/src/libs/ec/abstracts/ECCodes.abstract	2016-10-06 19:01:54.000000000 +0800
++++ b/src/libs/ec/abstracts/ECCodes.abstract	2016-10-14 12:33:51.672348192 +0800
+@@ -148,6 +148,8 @@
  
  EC_OP_FRIEND                        0x57
  
@@ -1288,9 +1319,10 @@
  [/Section]
  
  [Section Content]
---- a/src/libs/ec/cpp/ECCodes.h
-+++ b/src/libs/ec/cpp/ECCodes.h
-@@ -121,7 +121,8 @@ enum ECOpCodes {
+diff -Naur a/src/libs/ec/cpp/ECCodes.h b/src/libs/ec/cpp/ECCodes.h
+--- a/src/libs/ec/cpp/ECCodes.h	2016-10-06 19:01:54.000000000 +0800
++++ b/src/libs/ec/cpp/ECCodes.h	2016-10-14 12:33:51.673348215 +0800
+@@ -121,7 +121,8 @@
  	EC_OP_CLIENT_SWAP_TO_ANOTHER_FILE   = 0x54,
  	EC_OP_SHARED_FILE_SET_COMMENT       = 0x55,
  	EC_OP_SERVER_SET_STATIC_PRIO        = 0x56,
@@ -1300,7 +1332,7 @@
  };
  
  enum ECTagNames {
-@@ -556,6 +557,7 @@ wxString GetDebugNameECOpCodes(uint8 arg
+@@ -556,6 +557,7 @@
  		case 0x55: return wxT("EC_OP_SHARED_FILE_SET_COMMENT");
  		case 0x56: return wxT("EC_OP_SERVER_SET_STATIC_PRIO");
  		case 0x57: return wxT("EC_OP_FRIEND");
@@ -1308,9 +1340,10 @@
  		default: return CFormat(wxT("unknown %d 0x%x")) % arg % arg;
  	}
  }
---- a/src/libs/ec/java/ECCodes.java
-+++ b/src/libs/ec/java/ECCodes.java
-@@ -112,6 +112,7 @@ public final static byte EC_OP_CLIENT_SW
+diff -Naur a/src/libs/ec/java/ECCodes.java b/src/libs/ec/java/ECCodes.java
+--- a/src/libs/ec/java/ECCodes.java	2016-10-06 19:01:54.000000000 +0800
++++ b/src/libs/ec/java/ECCodes.java	2016-10-14 12:33:51.673348215 +0800
+@@ -112,6 +112,7 @@
  public final static byte EC_OP_SHARED_FILE_SET_COMMENT       = 0x55;
  public final static byte EC_OP_SERVER_SET_STATIC_PRIO        = 0x56;
  public final static byte EC_OP_FRIEND                        = 0x57;
@@ -1318,9 +1351,10 @@
  
  public final static short EC_TAG_STRING                             = 0x0000;
  public final static short EC_TAG_PASSWD_HASH                        = 0x0001;
---- a/src/muuli_wdr.cpp
-+++ b/src/muuli_wdr.cpp
-@@ -1772,6 +1772,51 @@ wxSizer *PreferencesServerTab( wxWindow
+diff -Naur a/src/muuli_wdr.cpp b/src/muuli_wdr.cpp
+--- a/src/muuli_wdr.cpp	2016-10-06 19:01:54.000000000 +0800
++++ b/src/muuli_wdr.cpp	2016-10-14 12:33:51.676348283 +0800
+@@ -1769,6 +1769,51 @@
      return item0;
  }
  
@@ -1372,7 +1406,7 @@
  wxSizer *PreferencesFilesTab( wxWindow *parent, bool call_fit, bool set_sizer )
  {
      wxBoxSizer *item0 = new wxBoxSizer( wxVERTICAL );
-@@ -2590,6 +2635,42 @@ wxSizer *serverListDlgUp( wxWindow *pare
+@@ -2587,6 +2632,42 @@
      return item0;
  }
  
@@ -1415,7 +1449,7 @@
  wxSizer *serverListDlgDown( wxWindow *parent, bool call_fit, bool set_sizer )
  {
      wxStaticBox *item1 = new wxStaticBox( parent, -1, wxT("") );
-@@ -2605,7 +2686,7 @@ wxSizer *serverListDlgDown( wxWindow *pa
+@@ -2602,7 +2683,7 @@
      wxPanel *item4 = new wxPanel( item3, -1 );
      aMuleLog( item4, FALSE );
      item3->AddPage( item4, _("aMule Log") );
@@ -1424,7 +1458,7 @@
      wxPanel *item5 = new wxPanel( item3, -1 );
      ServerInfoLog( item5, FALSE );
      item3->AddPage( item5, _("Server Info") );
-@@ -2617,6 +2698,10 @@ wxSizer *serverListDlgDown( wxWindow *pa
+@@ -2614,6 +2695,10 @@
      wxPanel *item7 = new wxPanel( item3, -1 );
      Kad_Info( item7, FALSE );
      item3->AddPage( item7, _("Kad Info") );
@@ -1435,21 +1469,22 @@
  
      item0->Add( item2, 1, wxGROW|wxALIGN_CENTER_VERTICAL, 5 );
  
---- a/src/muuli_wdr.h
-+++ b/src/muuli_wdr.h
-@@ -336,6 +336,10 @@ wxSizer *transferDlg( wxWindow *parent,
- #define ID_BTN_RESET_SERVER 10241
+diff -Naur a/src/muuli_wdr.h b/src/muuli_wdr.h
+--- a/src/muuli_wdr.h	2016-10-06 19:01:54.000000000 +0800
++++ b/src/muuli_wdr.h	2016-10-14 12:33:51.676348283 +0800
+@@ -335,6 +335,10 @@
+ #define ID_BTN_RESET_SERVER 10240
  wxSizer *ServerInfoLog( wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE );
  
 +#define ID_DLPINFO 22001
 +#define ID_BTN_RESET_DLP 22002
 +wxSizer *DLPInfoLog( wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE );
 +
- #define ID_LOGVIEW 10242
- #define ID_BTN_RESET 10243
+ #define ID_LOGVIEW 10241
+ #define ID_BTN_RESET 10242
  wxSizer *aMuleLog( wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE );
-@@ -425,6 +429,21 @@ wxSizer *CoreConnect( wxWindow *parent,
- #define ID_DEBUGCATS 10308
+@@ -424,6 +428,21 @@
+ #define ID_DEBUGCATS 10307
  wxSizer *PreferencesDebug( wxWindow *parent, bool call_fit = TRUE, bool set_sizer = TRUE );
  
 +/* Dynamic Leecher Protection */
@@ -1468,11 +1503,12 @@
 +#endif
 +
  extern wxSizer *IDC_CURJOB;
- #define IDC_CONV_PB_LABEL 10309
- #define IDC_CONV_PROZENT 10310
---- a/src/updownclient.h
-+++ b/src/updownclient.h
-@@ -408,7 +408,13 @@ public:
+ #define IDC_CONV_PB_LABEL 10308
+ #define IDC_CONV_PROZENT 10309
+diff -Naur a/src/updownclient.h b/src/updownclient.h
+--- a/src/updownclient.h	2016-10-06 19:01:54.000000000 +0800
++++ b/src/updownclient.h	2016-10-14 12:37:03.224728226 +0800
+@@ -408,7 +408,13 @@
  	bool		GetSentCancelTransfer() const	{ return m_fSentCancelTransfer; }
  	void		SetSentCancelTransfer(bool bVal)	{ m_fSentCancelTransfer = bVal; }
  
@@ -1487,7 +1523,7 @@
  	wxString	GetClientShortInfo();
  
  	const wxString& GetClientOSInfo() const		{ return m_sClientOSInfo; }
-@@ -581,7 +587,10 @@ public:
+@@ -581,7 +587,10 @@
  	bool		ShouldReceiveCryptUDPPackets() const;
  
  	bool		HasDisabledSharedFiles() const { return m_fNoViewSharedFiles; }
@@ -1499,7 +1535,7 @@
  private:
  
  	CClientCredits	*credits;
-@@ -842,6 +851,10 @@ private:
+@@ -842,6 +851,10 @@
  #ifdef __DEBUG__
  	wxString	connection_reason;
  #endif

--- a/package/lean/amule/patches/003_enable_upnp_cross_compile.patch
+++ b/package/lean/amule/patches/003_enable_upnp_cross_compile.patch
@@ -1,14 +1,15 @@
---- a/m4/libupnp.m4
-+++ b/m4/libupnp.m4
-@@ -57,7 +57,6 @@ dnl	Test for --with-libupnp-prefix
- 	])
+diff -Naur a/m4/libupnp.m4 b/m4/libupnp.m4
+--- a/m4/libupnp.m4	2016-10-06 19:01:54.000000000 +0800
++++ b/m4/libupnp.m4	2016-10-11 07:36:39.198318574 +0800
+@@ -52,7 +52,6 @@
+ 		[export PKG_CONFIG_PATH=$withval/lib/pkgconfig])
  
  dnl	Check for libupnp >= MIN_LIBUPNP_VERSION
 -	AS_IF([test $cross_compiling = no], [
  		AC_MSG_CHECKING([for libupnp version >= MIN_LIBUPNP_VERSION])
  		AS_IF([test -n "$PKG_CONFIG"], [
  			AS_IF([$PKG_CONFIG libupnp --exists], [
-@@ -84,11 +83,6 @@ dnl	Check for libupnp >= MIN_LIBUPNP_VER
+@@ -79,11 +78,6 @@
  		])
  		AC_MSG_RESULT([$result$resultstr])
  		libupnp_error="libupnp >= MIN_LIBUPNP_VERSION not found$resultstr"

--- a/package/lean/amule/patches/004_file_name_conversion.patch
+++ b/package/lean/amule/patches/004_file_name_conversion.patch
@@ -1,0 +1,78 @@
+diff --git a/src/amule.h b/src/amule.h
+index f25702f..240c02d 100644
+--- a/src/amule.h
++++ b/src/amule.h
+@@ -553,6 +553,13 @@ class CamuleDaemonApp : public CamuleApp
+ 	int OnExit();
+ 
+ 	virtual int InitGui(bool geometry_enable, wxString &geometry_string);
++	// The GTK wxApps sets its file name conversion properly
++	// in wxApp::Initialize(), while wxAppConsole::Initialize()
++	// does not, leaving wxConvFile being set to wxConvLibc. File
++	// name conversion should be set otherwise amuled will abort to
++	// handle non-ASCII file names which monolithic amule can handle.
++	// This function are overrided to perform this.
++	virtual bool Initialize(int& argc_, wxChar **argv_);
+ 
+ #ifdef AMULED_APPTRAITS
+ 	struct sigaction m_oldSignalChildAction;
+diff --git a/src/amuled.cpp b/src/amuled.cpp
+index 486da59..86e1ff8 100644
+--- a/src/amuled.cpp
++++ b/src/amuled.cpp
+@@ -704,6 +704,41 @@ int CamuleDaemonApp::InitGui(bool ,wxString &)
+ 	return 0;
+ }
+ 
++bool CamuleDaemonApp::Initialize(int& argc_, wxChar **argv_)
++{
++	if ( !wxAppConsole::Initialize(argc_, argv_) ) {
++		return false;
++	}
++
++#ifdef __UNIX__
++	wxString encName;
++#if wxUSE_INTL
++	// if a non default locale is set,
++	// assume that the user wants his
++        // filenames in this locale too
++        encName = wxLocale::GetSystemEncodingName().Upper();
++
++        // But don't consider ASCII in this case.
++	if ( !encName.empty() ) {
++		if ( encName == wxT("US-ASCII") ) {
++			// This means US-ASCII when returned
++			// from GetEncodingFromName().
++			encName.clear();
++		}
++        }
++#endif // wxUSE_INTL
++
++	// in this case, UTF-8 is used by default.
++        if ( encName.empty() ) {
++		encName = wxT("UTF-8");
++	}
++
++	static wxConvBrokenFileNames fileconv(encName);
++	wxConvFileName = &fileconv;
++#endif // __UNIX__
++
++	return true;
++}
+ 
+ int CamuleDaemonApp::OnExit()
+ {
+diff --git a/src/libs/common/Path.cpp b/src/libs/common/Path.cpp
+index 28152a2..5efefd0 100644
+--- a/src/libs/common/Path.cpp
++++ b/src/libs/common/Path.cpp
+@@ -229,7 +229,8 @@ CPath::CPath(const wxString& filename)
+ 	}
+ 
+ 	wxCharBuffer fn = filename2char(filename);
+-	if (fn.data()) {
++	// add fn.length() for wx 3.x
++	if (fn.data()) {
+ 		// Filename is valid in the current locale. This means that
+ 		// it either originated from a (wx)system-call, or from a
+ 		// user with a properly setup system.

--- a/package/lean/amule/patches/005_best_keyword_kad_search.patch
+++ b/package/lean/amule/patches/005_best_keyword_kad_search.patch
@@ -1,0 +1,174 @@
+diff --git a/src/SearchList.cpp b/src/SearchList.cpp
+index 32b28e9..342a18f 100644
+--- a/src/SearchList.cpp
++++ b/src/SearchList.cpp
+@@ -75,7 +75,7 @@ void ParsedSearchExpression(const CSearchExpr* pexpr)
+ 	int iOpNot = 0;
+ 
+ 	for (unsigned int i = 0; i < pexpr->m_aExpr.GetCount(); i++) {
+-		wxString str(pexpr->m_aExpr[i]);
++		const wxString& str = pexpr->m_aExpr[i];
+ 		if (str == SEARCHOPTOK_AND) {
+ 			iOpAnd++;
+ 		} else if (str == SEARCHOPTOK_OR) {
+@@ -108,6 +108,25 @@ void ParsedSearchExpression(const CSearchExpr* pexpr)
+ 
+ 	// optimize search expression, if no OR nor NOT specified
+ 	if (iOpAnd > 0 && iOpOr == 0 && iOpNot == 0) {
++		// figure out if we can use a better keyword than the one the user selected
++		// for example most user will search like this "The oxymoronaccelerator 2", which would ask the node which indexes "the"
++		// This causes higher traffic for such nodes and makes them a viable target to attackers, while the kad result should be
++		// the same or even better if we ask the node which indexes the rare keyword "oxymoronaccelerator", so we try to rearrange
++		// keywords and generally assume that the longer keywords are rarer
++		if (/*thePrefs::GetRearrangeKadSearchKeywords() &&*/ !s_strCurKadKeyword.IsEmpty()) {
++			for (unsigned int i = 0; i < pexpr->m_aExpr.GetCount(); i++) {
++				if (pexpr->m_aExpr[i] != SEARCHOPTOK_AND) {
++					if (pexpr->m_aExpr[i] != s_strCurKadKeyword
++						&& pexpr->m_aExpr[i].find_first_of(Kademlia::CSearchManager::GetInvalidKeywordChars()) == wxString::npos
++						&& pexpr->m_aExpr[i].Find('"') != 0 // no quoted expressions as keyword
++						&& pexpr->m_aExpr[i].length() >= 3
++						&& s_strCurKadKeyword.length() < pexpr->m_aExpr[i].length())
++					{
++						s_strCurKadKeyword = pexpr->m_aExpr[i];
++					}
++				}
++			}
++		}
+ 		wxString strAndTerms;
+ 		for (unsigned int i = 0; i < pexpr->m_aExpr.GetCount(); i++) {
+ 			if (pexpr->m_aExpr[i] != SEARCHOPTOK_AND) {
+@@ -285,7 +304,7 @@ void CSearchList::RemoveResults(long searchID)
+ }
+ 
+ 
+-wxString CSearchList::StartNewSearch(uint32* searchID, SearchType type, const CSearchParams& params)
++wxString CSearchList::StartNewSearch(uint32* searchID, SearchType type, CSearchParams& params)
+ {
+ 	// Check that we can actually perform the specified desired search.
+ 	if ((type == KadSearch) && !Kademlia::CKademlia::IsRunning()) {
+@@ -306,6 +325,16 @@ wxString CSearchList::StartNewSearch(uint32* searchID, SearchType type, const CS
+ 		m_resultType.Clear();
+ 	}
+ 
++	if (type == KadSearch) {
++		Kademlia::WordList words;
++		Kademlia::CSearchManager::GetWords(params.searchString, &words);
++		if (!words.empty()) {
++			params.strKeyword = words.front();
++		} else {
++			return _("No keyword for Kad search - aborting");
++		}
++	}
++
+ 	bool supports64bit = type == KadSearch ? true : theApp->serverconnect->GetCurrentServer() != NULL && (theApp->serverconnect->GetCurrentServer()->GetTCPFlags() & SRV_TCPFLG_LARGEFILES);
+ 	bool packetUsing64bit;
+ 
+@@ -332,8 +361,7 @@ wxString CSearchList::StartNewSearch(uint32* searchID, SearchType type, const CS
+ 
+ 			// searchstring will get tokenized there
+ 			// The tab must be created with the Kad search ID, so searchID is updated.
+-			Kademlia::CSearch* search = Kademlia::CSearchManager::PrepareFindKeywords(
+-										 params.searchString, data->GetLength(), data->GetRawBuffer(), *searchID);
++			Kademlia::CSearch* search = Kademlia::CSearchManager::PrepareFindKeywords(params.strKeyword, data->GetLength(), data->GetRawBuffer(), *searchID);
+ 
+ 			*searchID = search->GetSearchID();
+ 			m_currentSearch = *searchID;
+@@ -632,7 +660,7 @@ void CSearchList::StopSearch(bool globalOnly)
+ }
+ 
+ 
+-CSearchList::CMemFilePtr CSearchList::CreateSearchData(const CSearchParams& params, SearchType WXUNUSED(type), bool supports64bit, bool& packetUsing64bit)
++CSearchList::CMemFilePtr CSearchList::CreateSearchData(CSearchParams& params, SearchType type, bool supports64bit, bool& packetUsing64bit)
+ {
+ 	// Count the number of used parameters
+ 	unsigned int parametercount = 0;
+@@ -659,14 +687,16 @@ CSearchList::CMemFilePtr CSearchList::CreateSearchData(const CSearchParams& para
+ 	_astrParserErrors.Empty();
+ 	_SearchExpr.m_aExpr.Empty();
+ 
++	s_strCurKadKeyword.Clear();
++	if (type == KadSearch) {
++		wxASSERT( !params.strKeyword.IsEmpty() );
++		s_strCurKadKeyword = params.strKeyword;
++	}
++
+ 	LexInit(params.searchString);
+ 	int iParseResult = yyparse();
+ 	LexFree();
+ 
+-#ifdef __DEBUG__
+-	AddLogLineNS(CFormat(wxT("Search parsing result for \"%s\": %i"))
+-		% params.searchString % iParseResult);
+-#endif
+ 	if (_astrParserErrors.GetCount() > 0) {
+ 		for (unsigned int i=0; i < _astrParserErrors.GetCount(); ++i) {
+ 			AddLogLineNS(CFormat(wxT("Error %u: %s\n")) % i % _astrParserErrors[i]);
+@@ -681,21 +711,13 @@ CSearchList::CMemFilePtr CSearchList::CreateSearchData(const CSearchParams& para
+ 		return CMemFilePtr(NULL);
+ 	}
+ 
+-	#ifdef __DEBUG__
+-	wxString mes(wxT("Search expression:"));
+-	for (unsigned int i = 0; i < _SearchExpr.m_aExpr.GetCount(); i++) {
+-		mes << wxT(" ") << _SearchExpr.m_aExpr[i];
++	if (type == KadSearch && s_strCurKadKeyword != params.strKeyword) {
++		AddDebugLogLineN(logSearch, CFormat(wxT("Keyword was rearranged, using '%s' instead of '%s'")) % s_strCurKadKeyword % params.strKeyword);
++		params.strKeyword = s_strCurKadKeyword;
+ 	}
+-	AddLogLineNS(mes);
+-	AddLogLineNS(CFormat(wxT("Expression count: %i")) % _SearchExpr.m_aExpr.GetCount());
+-	#endif
+ 
+ 	parametercount += _SearchExpr.m_aExpr.GetCount();
+ 
+-	#ifdef __DEBUG__
+-	AddLogLineNS(CFormat(wxT("Parameters: %i")) % parametercount);
+-	#endif
+-
+ 	/* Leave the unicode comment there, please... */
+ 	CSearchExprTarget target(data.get(), true /*I assume everyone is unicoded */ ? utf8strRaw : utf8strNone, supports64bit, packetUsing64bit);
+ 
+diff --git a/src/SearchList.h b/src/SearchList.h
+index 35b0fc6..6db7508 100644
+--- a/src/SearchList.h
++++ b/src/SearchList.h
+@@ -64,6 +64,8 @@ class CSearchList : public wxEvtHandler
+ 
+ 		//! The actual string to search for.
+ 		wxString searchString;
++		//! The keyword selected for Kad search
++		wxString strKeyword;
+ 		//! The type of files to search for (may be empty), one of ED2KFTSTR_*
+ 		wxString typeText;
+ 		//! The filename extension. May be empty.
+@@ -90,7 +92,7 @@ class CSearchList : public wxEvtHandler
+ 	 * @param params The search parameters, see CSearchParams.
+ 	 * @return An empty string on success, otherwise an error-message.
+ 	 */
+-	wxString StartNewSearch(uint32* searchID, SearchType type, const CSearchParams& params);
++	wxString StartNewSearch(uint32* searchID, SearchType type, CSearchParams& params);
+ 
+ 	/** Stops the current search (global or Kad), if any is in progress. */
+ 	void StopSearch(bool globalOnly = false);
+@@ -189,7 +191,7 @@ class CSearchList : public wxEvtHandler
+ 	typedef std::auto_ptr<CMemFile> CMemFilePtr;
+ 
+ 	/** Create a basic search-packet for the given search-type. */
+-	CMemFilePtr CreateSearchData(const CSearchParams& params, SearchType type, bool supports64bit, bool& packetUsing64bit);
++	CMemFilePtr CreateSearchData(CSearchParams& params, SearchType type, bool supports64bit, bool& packetUsing64bit);
+ 
+ 
+ 	//! Timer used for global search intervals.
+diff --git a/src/kademlia/kademlia/SearchManager.cpp b/src/kademlia/kademlia/SearchManager.cpp
+index e7f25d4..f9ee924 100644
+--- a/src/kademlia/kademlia/SearchManager.cpp
++++ b/src/kademlia/kademlia/SearchManager.cpp
+@@ -127,7 +127,7 @@ CSearch* CSearchManager::PrepareFindKeywords(const wxString& keyword, uint32_t s
+ 
+ 		wxString wstrKeyword = s->m_words.front();
+ 
+-		AddLogLineNS(CFormat(_("Keyword for search: %s")) % wstrKeyword);
++		AddDebugLogLineN(logSearch, CFormat(wxT("Keyword for search: %s")) % wstrKeyword);
+ 
+ 		// Kry - I just decided to assume everyone is unicoded
+ 		// GonoszTopi - seconded

--- a/package/lean/amule/patches/006_update-libupnp.patch
+++ b/package/lean/amule/patches/006_update-libupnp.patch
@@ -1,0 +1,365 @@
+diff -Naur a/m4/libupnp.m4 b/m4/libupnp.m4
+--- a/m4/libupnp.m4	2016-10-06 18:49:44.000000000 +0800
++++ b/m4/libupnp.m4	2019-12-11 22:13:19.008225399 +0800
+@@ -45,11 +45,16 @@
+ 
+ dnl	Test for --with-libupnp-prefix
+ 	AC_ARG_WITH(
+-		[libupnp-prefix],
+-		[AS_HELP_STRING(
++		[libupnp-prefix],[
++		AS_HELP_STRING(
+ 			[--with-libupnp-prefix=PREFIX],
+-			[UPnP library location])],
+-		[export PKG_CONFIG_PATH=$withval/lib/pkgconfig])
++			[UPnP library location])],[
++		AS_IF([test -d "$withval/lib64/pkgconfig"],[
++			export PKG_CONFIG_PATH=$withval/lib64/pkgconfig
++		],[
++			export PKG_CONFIG_PATH=$withval/lib/pkgconfig
++		])
++	])
+ 
+ dnl	Check for libupnp >= MIN_LIBUPNP_VERSION
+ 	AS_IF([test $cross_compiling = no], [
+diff -Naur a/src/UPnPBase.cpp b/src/UPnPBase.cpp
+--- a/src/UPnPBase.cpp	2016-10-06 18:49:44.000000000 +0800
++++ b/src/UPnPBase.cpp	2019-12-11 22:15:04.536768532 +0800
+@@ -1127,7 +1127,11 @@
+ 
+ 
+ // This function is static
++#if UPNP_VERSION >= 10800
++int CUPnPControlPoint::Callback(Upnp_EventType_e EventType, const void *Event, void * /*Cookie*/)
++#else
+ int CUPnPControlPoint::Callback(Upnp_EventType EventType, void *Event, void * /*Cookie*/)
++#endif
+ {
+ 	std::ostringstream msg;
+ 	std::ostringstream msg2;
+@@ -1149,24 +1153,47 @@
+ 		msg2<< "UPNP_DISCOVERY_SEARCH_RESULT: ";
+ 		// UPnP Discovery
+ upnpDiscovery:
++#if UPNP_VERSION >= 10800
++		UpnpDiscovery *d_event = (UpnpDiscovery *)Event;
++#else
+ 		struct Upnp_Discovery *d_event = (struct Upnp_Discovery *)Event;
++#endif
+ 		IXML_Document *doc = NULL;
++#if UPNP_VERSION >= 10800
++		int errCode = UpnpDiscovery_get_ErrCode(d_event);
++		if (errCode != UPNP_E_SUCCESS) {
++			msg << UpnpGetErrorMessage(errCode) << ".";
++#else
+ 		int ret;
+ 		if (d_event->ErrCode != UPNP_E_SUCCESS) {
+ 			msg << UpnpGetErrorMessage(d_event->ErrCode) << ".";
++#endif
+ 			AddDebugLogLineC(logUPnP, msg);
+ 		}
+ 		// Get the XML tree device description in doc
++#if UPNP_VERSION >= 10800
++		const char *location = UpnpDiscovery_get_Location_cstr(d_event);
++		int ret = UpnpDownloadXmlDoc(location, &doc);
++#else
+ 		ret = UpnpDownloadXmlDoc(d_event->Location, &doc);
++#endif
+ 		if (ret != UPNP_E_SUCCESS) {
+ 			msg << "Error retrieving device description from " <<
++#if UPNP_VERSION >= 10800
++				location << ": " <<
++#else
+ 				d_event->Location << ": " <<
++#endif
+ 				UpnpGetErrorMessage(ret) <<
+ 				"(" << ret << ").";
+ 			AddDebugLogLineC(logUPnP, msg);
+ 		} else {
+ 			msg2 << "Retrieving device description from " <<
++#if UPNP_VERSION >= 10800
++				location << ".";
++#else
+ 				d_event->Location << ".";
++#endif
+ 			AddDebugLogLineN(logUPnP, msg2);
+ 		}
+ 		if (doc) {
+@@ -1194,8 +1221,14 @@
+ 					AddDebugLogLineC(logUPnP, msg);
+ 				}
+ 				// Add the root device to our list
++#if UPNP_VERSION >= 10800
++				int expires = UpnpDiscovery_get_Expires(d_event);
++				upnpCP->AddRootDevice(rootDevice, urlBase,
++					location, expires);
++#else
+ 				upnpCP->AddRootDevice(rootDevice, urlBase,
+ 					d_event->Location, d_event->Expires);
++#endif
+ 			}
+ 			// Free the XML doc tree
+ 			IXML::Document::Free(doc);
+@@ -1216,28 +1249,62 @@
+ 	case UPNP_DISCOVERY_ADVERTISEMENT_BYEBYE: {
+ 		//fprintf(stderr, "Callback: UPNP_DISCOVERY_ADVERTISEMENT_BYEBYE\n");
+ 		// UPnP Device Removed
++#if UPNP_VERSION >= 10800
++		UpnpDiscovery *dab_event = (UpnpDiscovery *)Event;
++		int errCode = UpnpDiscovery_get_ErrCode(dab_event);
++		if (errCode != UPNP_E_SUCCESS) {
++#else
+ 		struct Upnp_Discovery *dab_event = (struct Upnp_Discovery *)Event;
+ 		if (dab_event->ErrCode != UPNP_E_SUCCESS) {
++#endif
+ 			msg << "error(UPNP_DISCOVERY_ADVERTISEMENT_BYEBYE): " <<
++#if UPNP_VERSION >= 10800
++				UpnpGetErrorMessage(errCode) <<
++#else
+ 				UpnpGetErrorMessage(dab_event->ErrCode) <<
++#endif
+ 				".";
+ 			AddDebugLogLineC(logUPnP, msg);
+ 		}
++#if UPNP_VERSION >= 10800
++		std::string devType = UpnpDiscovery_get_DeviceType_cstr(dab_event);
++#else
+ 		std::string devType = dab_event->DeviceType;
++#endif
+ 		// Check for an InternetGatewayDevice and removes it from the list
++
+ 		std::transform(devType.begin(), devType.end(), devType.begin(), tolower);
++
+ 		if (stdStringIsEqualCI(devType, UPnP::Device::IGW)) {
++#if UPNP_VERSION >= 10800
++			const char *deviceID =
++				UpnpDiscovery_get_DeviceID_cstr(dab_event);
++			upnpCP->RemoveRootDevice(deviceID);
++#else
+ 			upnpCP->RemoveRootDevice(dab_event->DeviceId);
++#endif
+ 		}
+ 		break;
+ 	}
+ 	case UPNP_EVENT_RECEIVED: {
+ 		//fprintf(stderr, "Callback: UPNP_EVENT_RECEIVED\n");
+ 		// Event reveived
++#if UPNP_VERSION >= 10800
++		UpnpEvent *e_event = (UpnpEvent *)Event;
++		int eventKey = UpnpEvent_get_EventKey(e_event);
++		IXML_Document *changedVariables =
++			UpnpEvent_get_ChangedVariables(e_event);
++		const std::string sid = UpnpEvent_get_SID_cstr(e_event);
++#else
+ 		struct Upnp_Event *e_event = (struct Upnp_Event *)Event;
+ 		const std::string Sid = e_event->Sid;
++#endif
+ 		// Parses the event
++#if UPNP_VERSION >= 10800
++		upnpCP->OnEventReceived(sid, eventKey, changedVariables);
++#else
+ 		upnpCP->OnEventReceived(Sid, e_event->EventKey, e_event->ChangedVariables);
++#endif
+ 		break;
+ 	}
+ 	case UPNP_EVENT_SUBSCRIBE_COMPLETE:
+@@ -1252,24 +1319,42 @@
+ 		//fprintf(stderr, "Callback: UPNP_EVENT_RENEWAL_COMPLETE\n");
+ 		msg << "error(UPNP_EVENT_RENEWAL_COMPLETE): ";
+ upnpEventRenewalComplete:
++#if UPNP_VERSION >= 10800
++		UpnpEventSubscribe *es_event = (UpnpEventSubscribe *)Event;
++		int errCode = UpnpEventSubscribe_get_ErrCode(es_event);
++		if (errCode != UPNP_E_SUCCESS) {
++#else
+ 		struct Upnp_Event_Subscribe *es_event =
+ 			(struct Upnp_Event_Subscribe *)Event;
+ 		if (es_event->ErrCode != UPNP_E_SUCCESS) {
++#endif
+ 			msg << "Error in Event Subscribe Callback";
++#if UPNP_VERSION >= 10800
++			UPnP::ProcessErrorMessage(msg.str(), errCode, NULL, NULL);
++#else
+ 			UPnP::ProcessErrorMessage(
+ 				msg.str(), es_event->ErrCode, NULL, NULL);
++#endif
+ 		} else {
+ #if 0
++#if UPNP_VERSION >= 10800
++
++			const UpnpString *publisherUrl =
++				UpnpEventSubscribe_get_PublisherUrl(es_event);
++			const char *sid = UpnpEvent_get_SID_cstr(es_event);
++			int timeOut = UpnpEvent_get_TimeOut(es_event);
++			TvCtrlPointHandleSubscribeUpdate(
++				publisherUrl, sid, timeOut);
++#else
+ 			TvCtrlPointHandleSubscribeUpdate(
+ 				GET_UPNP_STRING(es_event->PublisherUrl),
+ 				es_event->Sid,
+ 				es_event->TimeOut );
+ #endif
++#endif
+ 		}
+-
+ 		break;
+ 	}
+-
+ 	case UPNP_EVENT_AUTORENEWAL_FAILED:
+ 		//fprintf(stderr, "Callback: UPNP_EVENT_AUTORENEWAL_FAILED\n");
+ 		msg << "error(UPNP_EVENT_AUTORENEWAL_FAILED): ";
+@@ -1280,29 +1365,56 @@
+ 		msg << "error(UPNP_EVENT_SUBSCRIPTION_EXPIRED): ";
+ 		msg2 << "UPNP_EVENT_SUBSCRIPTION_EXPIRED: ";
+ upnpEventSubscriptionExpired:
++#if UPNP_VERSION >= 10800
++		UpnpEventSubscribe *es_event = (UpnpEventSubscribe *)Event;
++#else
+ 		struct Upnp_Event_Subscribe *es_event =
+ 			(struct Upnp_Event_Subscribe *)Event;
++#endif
+ 		Upnp_SID newSID;
+ 		memset(newSID, 0, sizeof(Upnp_SID));
+ 		int TimeOut = 1801;
++#if UPNP_VERSION >= 10800
++		const char *publisherUrl =
++			UpnpEventSubscribe_get_PublisherUrl_cstr(es_event);
++#endif
+ 		int ret = UpnpSubscribe(
+ 			upnpCP->m_UPnPClientHandle,
++#if UPNP_VERSION >= 10800
++			publisherUrl,
++#else
+ 			GET_UPNP_STRING(es_event->PublisherUrl),
++#endif
+ 			&TimeOut,
+ 			newSID);
+ 		if (ret != UPNP_E_SUCCESS) {
+ 			msg << "Error Subscribing to EventURL";
++#if UPNP_VERSION >= 10800
++			int errCode = UpnpEventSubscribe_get_ErrCode(es_event);
++#endif
+ 			UPnP::ProcessErrorMessage(
++#if UPNP_VERSION >= 10800
++				msg.str(), errCode, NULL, NULL);
++#else
+ 				msg.str(), es_event->ErrCode, NULL, NULL);
++#endif
+ 		} else {
+ 			ServiceMap::iterator it =
++#if UPNP_VERSION >= 10800
++				upnpCP->m_ServiceMap.find(publisherUrl);
++#else
+ 				upnpCP->m_ServiceMap.find(GET_UPNP_STRING(es_event->PublisherUrl));
++#endif
+ 			if (it != upnpCP->m_ServiceMap.end()) {
+ 				CUPnPService &service = *(it->second);
+ 				service.SetTimeout(TimeOut);
+ 				service.SetSID(newSID);
+ 				msg2 << "Re-subscribed to EventURL '" <<
++#if UPNP_VERSION >= 10800
++					publisherUrl <<
++#else
+ 					GET_UPNP_STRING(es_event->PublisherUrl) <<
++#endif
+ 					"' with SID == '" <<
+ 					newSID << "'.";
+ 				AddDebugLogLineC(logUPnP, msg2);
+@@ -1321,17 +1433,34 @@
+ 	case UPNP_CONTROL_ACTION_COMPLETE: {
+ 		//fprintf(stderr, "Callback: UPNP_CONTROL_ACTION_COMPLETE\n");
+ 		// This is here if we choose to do this asynchronously
++#if UPNP_VERSION >= 10800
++		UpnpActionComplete *a_event = (UpnpActionComplete *)Event;
++		int errCode = UpnpActionComplete_get_ErrCode(a_event);
++		IXML_Document *actionResult =
++			UpnpActionComplete_get_ActionResult(a_event);
++		if (errCode != UPNP_E_SUCCESS) {
++#else
+ 		struct Upnp_Action_Complete *a_event =
+ 			(struct Upnp_Action_Complete *)Event;
+ 		if (a_event->ErrCode != UPNP_E_SUCCESS) {
++#endif
+ 			UPnP::ProcessErrorMessage(
+ 				"UpnpSendActionAsync",
++#if UPNP_VERSION >= 10800
++				errCode, NULL,
++				actionResult);
++#else
+ 				a_event->ErrCode, NULL,
+ 				a_event->ActionResult);
++#endif
+ 		} else {
+ 			// Check the response document
+ 			UPnP::ProcessActionResponse(
++#if UPNP_VERSION >= 10800
++				actionResult,
++#else
+ 				a_event->ActionResult,
++#endif
+ 				"<UpnpSendActionAsync>");
+ 		}
+ 		/* No need for any processing here, just print out results.
+@@ -1342,22 +1471,43 @@
+ 	case UPNP_CONTROL_GET_VAR_COMPLETE: {
+ 		//fprintf(stderr, "Callback: UPNP_CONTROL_GET_VAR_COMPLETE\n");
+ 		msg << "error(UPNP_CONTROL_GET_VAR_COMPLETE): ";
++#if UPNP_VERSION >= 10800
++		UpnpStateVarComplete *sv_event = (UpnpStateVarComplete *)Event;
++		int errCode = UpnpStateVarComplete_get_ErrCode(sv_event);
++		if (errCode != UPNP_E_SUCCESS) {
++#else
+ 		struct Upnp_State_Var_Complete *sv_event =
+ 			(struct Upnp_State_Var_Complete *)Event;
+ 		if (sv_event->ErrCode != UPNP_E_SUCCESS) {
++#endif
+ 			msg << "m_UpnpGetServiceVarStatusAsync";
+ 			UPnP::ProcessErrorMessage(
++#if UPNP_VERSION >= 10800
++				msg.str(), errCode, NULL, NULL);
++#else
+ 				msg.str(), sv_event->ErrCode, NULL, NULL);
++#endif
+ 		} else {
+ #if 0
+ 			// Warning: The use of UpnpGetServiceVarStatus and
+ 			// UpnpGetServiceVarStatusAsync is deprecated by the
+ 			// UPnP forum.
++#if UPNP_VERSION >= 10800
++			const char *ctrlUrl =
++				UpnpStateVarComplete_get_CtrlUrl(sv_event);
++			const char *stateVarName =
++				UpnpStateVarComplete_get_StateVarName(sv_event);
++			const DOMString currentVal =
++				UpnpStateVarComplete_get_CurrentVal(sv_event);
++			TvCtrlPointHandleGetVar(
++				ctrlUrl, stateVarName, currentVal);
++#else
+ 			TvCtrlPointHandleGetVar(
+ 				sv_event->CtrlUrl,
+ 				sv_event->StateVarName,
+ 				sv_event->CurrentVal );
+ #endif
++#endif
+ 		}
+ 		break;
+ 	}
+diff -Naur a/src/UPnPBase.h b/src/UPnPBase.h
+--- a/src/UPnPBase.h	2016-10-06 18:49:44.000000000 +0800
++++ b/src/UPnPBase.h	2019-12-11 22:16:28.165063153 +0800
+@@ -489,9 +489,15 @@
+ 
+ 	// Callback function
+ 	static int Callback(
++	#if UPNP_VERSION >= 10800
++		Upnp_EventType_e EventType,
++		const void *Event,
++		void *Cookie);
++	#else
+ 		Upnp_EventType EventType,
+ 		void* Event,
+ 		void* Cookie);
++	#endif
+ 
+ private:
+ 	void OnEventReceived(

--- a/package/lean/amule/patches/007-binutils.patch
+++ b/package/lean/amule/patches/007-binutils.patch
@@ -1,0 +1,19 @@
+--- a/src/libs/common/MuleDebug.cpp	2016-10-06 18:49:44.000000000 +0800
++++ b/src/libs/common/MuleDebug.cpp	2021-06-17 02:16:40.000000000 +0800
+@@ -268,14 +268,14 @@
+ 		return;
+ 	}
+ 
+-	bfd_vma vma = bfd_get_section_vma(abfd, section);
++	bfd_vma vma = bfd_section_vma(section);
+ 
+ 	unsigned long address = (unsigned long)_address;
+ 	if (address < vma) {
+ 		return;
+ 	}
+ 
+-	bfd_size_type size = bfd_section_size(abfd, section);
++	bfd_size_type size = bfd_section_size(section);
+ 	if (address > (vma + size)) {
+ 		return;
+ 	}

--- a/package/lean/amule/patches/008-upnp2.patch
+++ b/package/lean/amule/patches/008-upnp2.patch
@@ -1,0 +1,16 @@
+diff --git a/src/UPnPBase.cpp b/src/UPnPBase.cpp
+index 46ac7451e..dd244e5b0 100644
+--- a/src/UPnPBase.cpp
++++ b/src/UPnPBase.cpp
+@@ -828,9 +828,9 @@
+ 	int ret;
+ 	char *ipAddress = NULL;
+ 	unsigned short port = 0;
+-	ret = UpnpInit(ipAddress, udpPort);
++	ret = UpnpInit2(0, udpPort);
+ 	if (ret != UPNP_E_SUCCESS) {
+-		msg << "error(UpnpInit): Error code ";
++		msg << "error(UpnpInit2): Error code ";
+ 		goto error;
+ 	}
+ 	port = UpnpGetServerPort();


### PR DESCRIPTION
The dependencies in the repo doesn't meet the minimum requirements for
upgrading to the latest aMule version.

This reverts commit dc43ea2936dafe5a85cf9154a1c7af5dadec942f.

Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>

don't be a smart-ass.
