### PR TITLE
more bugfix for luci-app-airplay2

### DIFF
--- a/package/lean/luci-app-airplay2/luasrc/model/cbi/shairport-sync.lua
+++ b/package/lean/luci-app-airplay2/luasrc/model/cbi/shairport-sync.lua
@@ -40,18 +40,19 @@ alsa_output_device=s:option(ListValue, "alsa_output_device", translate("Alsa Out
 alsa_output_device:value("", translate("default"))
 alsa_output_device:value("hw:0", translate("1st Soundcard (hw:0)"))
 alsa_output_device:value("hw:1", translate("2nd Soundcard (hw:1)"))
-alsa_output_device:value("hw:2", translate("3nd Soundcard (hw:2)"))
+alsa_output_device:value("hw:2", translate("3rd Soundcard (hw:2)"))
 
 alsa_mixer_control_name=s:option(ListValue, "alsa_mixer_control_name", translate("Alsa Mixer Control Name"))
-alsa_mixer_control_name:value("", translate("default"))
+alsa_mixer_control_name:value("", translate("default (software volume)"))
 alsa_mixer_control_name:value("PCM", translate("PCM"))
+alsa_mixer_control_name:value("Speaker", translate("Speaker"))
 
 alsa_output_rate=s:option(ListValue, "alsa_output_rate", translate("Alsa Output Rate"))
 alsa_output_rate:value("auto", translate("auto"))
-alsa_output_rate:value("44100", translate("44.1Khz"))
-alsa_output_rate:value("88200", translate("88.2Khz"))
-alsa_output_rate:value("176400", translate("176.4Khz"))
-alsa_output_rate:value("352800", translate("352.8Khz"))
+alsa_output_rate:value("44100", translate("44.1kHz"))
+alsa_output_rate:value("88200", translate("88.2kHz"))
+alsa_output_rate:value("176400", translate("176.4kHz"))
+alsa_output_rate:value("352800", translate("352.8kHz"))
 
 alsa_buffer_length=s:option(Value, "alsa_buffer_length", translate("Alsa Buffer Length"))
 alsa_buffer_length.default = "6615"

--- a/package/lean/luci-app-airplay2/po/zh-cn/shairport-sync.po
+++ b/package/lean/luci-app-airplay2/po/zh-cn/shairport-sync.po
@@ -46,13 +46,16 @@ msgstr "音频输出设备"
 msgid "Alsa Mixer Control Name"
 msgstr "硬件音量控制器名称"
 
+msgid "default (software volume)"
+msgstr "缺省（使用软件音量调整）
+
 msgid "1st Soundcard (hw:0)"
 msgstr "第 1 张声卡 (hw:0)"
 
 msgid "2nd Soundcard (hw:1)"
 msgstr "第 2 张声卡 (hw:1)"
 
-msgid "3nd Soundcard (hw:2)"
+msgid "3rd Soundcard (hw:2)"
 msgstr "第 3 张声卡 (hw:2)"
 
 msgid "Alsa Output Rate"

--- a/package/lean/luci-app-airplay2/root/etc/init.d/shairport-sync
+++ b/package/lean/luci-app-airplay2/root/etc/init.d/shairport-sync
@@ -61,6 +61,8 @@ start_instance() {
 		append_num "$cfg" "$conf_file" volume_range_db "volume_range_db"
 		append_str "$cfg" "$conf_file" regtype "regtype"
 		append_str "$cfg" "$conf_file" playback_mode "playback_mode"
+		append_num "$cfg" "$conf_file" alsa_buffer_length "audio_backend_buffer_desired_length"
+		append_num "$cfg" "$conf_file" alsa_latency_offset "audio_backend_latency_offset_in_seconds"
 		echo -e "};\n" >> $conf_file
 
 		# Metadata
@@ -91,9 +93,9 @@ start_instance() {
 		append_str "$cfg" "$conf_file" alsa_output_device "output_device"
 		append_str "$cfg" "$conf_file" alsa_mixer_control_name "mixer_control_name"
 		append_str "$cfg" "$conf_file" alsa_mixer_device "mixer_device"
-		append_str "$cfg" "$conf_file" alsa_output_rate "output_rate" "44100"
-		append_num "$cfg" "$conf_file" alsa_latency_offset "audio_backend_latency_offset"
-		append_num "$cfg" "$conf_file" alsa_buffer_length "audio_backend_buffer_desired_length"
+		local alsa_output_rate_val
+		config_get alsa_output_rate_val "$cfg" "alsa_output_rate"
+		[ $alsa_output_rate_val != "auto" ] && append_num "$cfg" "$conf_file" alsa_output_rate "output_rate" "44100"
 		append_str "$cfg" "$conf_file" alsa_disable_synchronization "disable_synchronization"
 		append_num "$cfg" "$conf_file" alsa_period_size "period_size"
 		append_num "$cfg" "$conf_file" alsa_buffer_size "buffer_size"
@@ -103,23 +105,8 @@ start_instance() {
 		echo -e "pipe =" >> $conf_file
 		echo -e "{" >> $conf_file
 		append_str "$cfg" "$conf_file" pipe_name "name"
-		append_num "$cfg" "$conf_file" pipe_latency_offset "audio_backend_latency_offset"
-		append_num "$cfg" "$conf_file" pipe_buffer_length "audio_backend_buffer_desired_length"
 		echo -e "};\n" >> $conf_file
 
-		# Stdout audio back end
-		echo -e "stdout =" >> $conf_file
-		echo -e "{" >> $conf_file
-		append_num "$cfg" "$conf_file" stdout_latency_offset "audio_backend_latency_offset"
-		append_num "$cfg" "$conf_file" stdout_buffer_length "audio_backend_buffer_desired_length"
-		echo -e "};\n" >> $conf_file
-
-		# AO audio back end
-		echo -e "ao =" >> $conf_file
-		echo -e "{" >> $conf_file
-		append_num "$cfg" "$conf_file" ao_latency_offset "audio_backend_latency_offset"
-		append_num "$cfg" "$conf_file" ao_buffer_length "audio_backend_buffer_desired_length"
-		echo -e "};\n" >> $conf_file
 	fi
 
 	procd_open_instance


### PR DESCRIPTION
bugfix: 修复output_rate不生效：shairport-sync配置文件的该选项，除了“auto”之外的值都应为数字形式
bugfix: 修复audio_backend_buffer_desired_length不生效：该选项已经移动到了general节中
enhance: 一些选项和文字改进
cleanup: 移除了init.d脚本配置生成中对于已经不存在的选项的生成

bugfix: in shairport-sync's conf file output_rate should be number form
    (except "auto")
bugfix: audio_backend_buffer_desired_length should in "general" section
enhance: option and text imporvement
cleanup: remove invalid options in shairport-sync's conf file generate

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
