### PR TITLE
kernel: bump 5.10 to 5.10.81

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -7,10 +7,10 @@ ifdef CONFIG_TESTING_KERNEL
 endif
 
 LINUX_VERSION-5.4 = .159
-LINUX_VERSION-5.10 = .80
+LINUX_VERSION-5.10 = .81
 
 LINUX_KERNEL_HASH-5.4.159 = d718325f4eab325dce4f82b88418f68ba130864118229539541331e0a4478643
-LINUX_KERNEL_HASH-5.10.80 = 477ce8f7624263e4346c0fc25ffc334af06bcac4d6bebdd5a7fe4681557fdb39
+LINUX_KERNEL_HASH-5.10.81 = a2e1686132c4598c0adfdf52acbf1ab4bb327b2398badef346a0eff849da5adb
 
 remove_uri_prefix=$(subst git://,,$(subst http://,,$(subst https://,,$(1))))
 sanitize_uri=$(call qstrip,$(subst @,_,$(subst :,_,$(subst .,_,$(subst -,_,$(subst /,_,$(1)))))))

--- a/target/linux/generic/pending-5.10/920-mangle_bootargs.patch
+++ b/target/linux/generic/pending-5.10/920-mangle_bootargs.patch
@@ -31,7 +31,7 @@ Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
  	help
 --- a/init/main.c
 +++ b/init/main.c
-@@ -607,6 +607,29 @@ static inline void setup_nr_cpu_ids(void
+@@ -608,6 +608,29 @@ static inline void setup_nr_cpu_ids(void
  static inline void smp_prepare_cpus(unsigned int maxcpus) { }
  #endif
  
@@ -61,7 +61,7 @@ Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
  /*
   * We need to store the untouched command line for future reference.
   * We also need to store the touched command line since the parameter
-@@ -868,6 +891,7 @@ asmlinkage __visible void __init __no_sa
+@@ -869,6 +892,7 @@ asmlinkage __visible void __init __no_sa
  	pr_notice("%s", linux_banner);
  	early_security_init();
  	setup_arch(&command_line);

--- a/target/linux/ipq806x/patches-5.10/0067-generic-Mangle-bootloader-s-kernel-arguments.patch
+++ b/target/linux/ipq806x/patches-5.10/0067-generic-Mangle-bootloader-s-kernel-arguments.patch
@@ -189,7 +189,7 @@ Signed-off-by: Adrian Panella <ianchi74@outlook.com>
  static int kernel_init(void *);
  
  extern void init_IRQ(void);
-@@ -905,6 +909,18 @@ asmlinkage __visible void __init __no_sa
+@@ -906,6 +910,18 @@ asmlinkage __visible void __init __no_sa
  	pr_notice("Kernel command line: %s\n", saved_command_line);
  	/* parameters may set static keys */
  	jump_label_init();

--- a/target/linux/lantiq/patches-5.10/0001-MIPS-lantiq-add-pcie-driver.patch
+++ b/target/linux/lantiq/patches-5.10/0001-MIPS-lantiq-add-pcie-driver.patch
@@ -5481,7 +5481,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	  (transaction layer end-to-end CRC checking).
 --- a/include/linux/pci.h
 +++ b/include/linux/pci.h
-@@ -1417,6 +1417,8 @@ void pci_walk_bus(struct pci_bus *top, i
+@@ -1419,6 +1419,8 @@ void pci_walk_bus(struct pci_bus *top, i
  		  void *userdata);
  int pci_cfg_space_size(struct pci_dev *dev);
  unsigned char pci_bus_max_busnr(struct pci_bus *bus);

--- a/target/linux/mvebu/patches-5.10/300-mvebu-Mangle-bootloader-s-kernel-arguments.patch
+++ b/target/linux/mvebu/patches-5.10/300-mvebu-Mangle-bootloader-s-kernel-arguments.patch
@@ -187,7 +187,7 @@ Signed-off-by: Michael Gray <michael.gray@lantisproject.com>
  static int kernel_init(void *);
  
  extern void init_IRQ(void);
-@@ -903,6 +907,18 @@ asmlinkage __visible void __init __no_sa
+@@ -904,6 +908,18 @@ asmlinkage __visible void __init __no_sa
  	page_alloc_init();
  
  	pr_notice("Kernel command line: %s\n", saved_command_line);

--- a/target/linux/oxnas/patches-5.10/996-generic-Mangle-bootloader-s-kernel-arguments.patch
+++ b/target/linux/oxnas/patches-5.10/996-generic-Mangle-bootloader-s-kernel-arguments.patch
@@ -168,7 +168,7 @@ Signed-off-by: Adrian Panella <ianchi74@outlook.com>
  static int kernel_init(void *);
  
  extern void init_IRQ(void);
-@@ -903,6 +907,18 @@ asmlinkage __visible void __init __no_sa
+@@ -904,6 +908,18 @@ asmlinkage __visible void __init __no_sa
  	page_alloc_init();
  
  	pr_notice("Kernel command line: %s\n", saved_command_line);


### PR DESCRIPTION
Manually rebased:
    octeontx/patches-5.10/0004-PCI-add-quirk-for-Gateworks-PLX-PEX860x-switch-with-.patch

All other patches automatically rebased.

Signed-off-by: John Audia <graysky@archlinux.us>

Build system: x86_64
Build-tested: bcm2711/RPi4B, ipq806x/R7800
Run-tested: bcm2711/RPi4B, ipq806x/R7800