### PR TITLE
rockchip: fix rk3399 DoorNet2 emmc clk

### DIFF
--- a/target/linux/rockchip/patches-5.10/205-rockchip-rk3399-Add-support-for-EmbedFire-DoorNet2.patch
+++ b/target/linux/rockchip/patches-5.10/205-rockchip-rk3399-Add-support-for-EmbedFire-DoorNet2.patch
@@ -128,7 +128,7 @@
 +
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
-@@ -0,0 +1,653 @@
+@@ -0,0 +1,655 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +
 +/dts-v1/;
@@ -672,6 +672,8 @@
 +
 +&sdhci {
 +	bus-width = <8>;
++	supports-emmc;
++	assigned-clock-rates = <150000000>;
 +	mmc-hs400-1_8v;
 +	mmc-hs400-enhanced-strobe;
 +	non-removable;

--- a/target/linux/rockchip/patches-5.4/205-rockchip-rk3399-Add-support-for-EmbedFire-DoorNet2.patch
+++ b/target/linux/rockchip/patches-5.4/205-rockchip-rk3399-Add-support-for-EmbedFire-DoorNet2.patch
@@ -128,7 +128,7 @@
 +
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
-@@ -0,0 +1,653 @@
+@@ -0,0 +1,655 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +
 +/dts-v1/;
@@ -672,6 +672,8 @@
 +
 +&sdhci {
 +	bus-width = <8>;
++	supports-emmc;
++	assigned-clock-rates = <150000000>;
 +	mmc-hs400-1_8v;
 +	mmc-hs400-enhanced-strobe;
 +	non-removable;


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

修复EmbedFire DoorNet2因为emmc默认频率过高造成的初始化错误