### PR TITLE
ipq806x: Add Norton 518 support

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -16,6 +16,13 @@ arris,rac2v1a)
 	ucidef_add_switch "switch0" \
 		"1:lan" "2:lan" "3:lan" "4:lan" "6u@eth1" "0u@eth0"
 	;;
+norton,core-518)
+	mac_addr=$(mtd_get_mac_ascii_mmc 0:APPSBLENV ethaddr)
+	ucidef_add_switch "switch0" \
+		"2:lan" "3:lan" "4:lan" "6u@eth1" "5:wan" "0u@eth0"
+		ucidef_set_interface_macaddr "lan" "$(macaddr_add $mac_addr 1)"
+		ucidef_set_interface_macaddr "wan" "$mac_addr"
+	;;
 askey,rt4230w-rev6 |\
 askey,rt4230w-rev9.3 |\
 asrock,g10 |\

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -70,6 +70,10 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x1000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x6) 1)
 		;;
+	norton,core-518)
+		caldata_extract_mmc "0:ART" 0x1000 0x2f20
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii_mmc 0:APPSBLENV ethaddr) 2)
+		;;
 	tplink,ad7200 |\
 	tplink,c2600)
 		caldata_extract "radio" 0x1000 0x2f20
@@ -129,6 +133,10 @@ case "$FIRMWARE" in
 	netgear,xr500)
 		caldata_extract "art" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0x6) 2)
+		;;
+	norton,core-518)
+		caldata_extract_mmc "0:ART" 0x5000 0x2f20
+		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii_mmc 0:APPSBLENV ethaddr) 3)
 		;;
 	tplink,ad7200 |\
 	tplink,c2600)

--- a/target/linux/ipq806x/base-files/etc/init.d/bootcount
+++ b/target/linux/ipq806x/base-files/etc/init.d/bootcount
@@ -16,6 +16,31 @@ boot() {
 	linksys,ea8500)
 		mtd resetbc s_env || true
 		;;
+	norton,core-518)
+        . /lib/functions/caldata.sh
+        FIRMWARE='ath10k/pre-cal-pci-0000:01:00.0.bin'
+		[ -e /lib/firmware/$FIRMWARE ] || {
+            caldata_extract_mmc "0:ART" 0x1000 0x2f20
+		    ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii_mmc 0:APPSBLENV ethaddr) 2)
+        }
+
+        FIRMWARE='ath10k/pre-cal-pci-0001:01:00.0.bin'
+        [ -e /lib/firmware/$FIRMWARE ] || {
+            caldata_extract_mmc "0:ART" 0x5000 0x2f20
+		    ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii_mmc 0:APPSBLENV ethaddr) 3)
+        }
+
+		[ -e /etc/config/wireless ] || {
+			/sbin/wifi config
+			/sbin/wifi up
+		}
+
+		[ -s /etc/config/wireless ] || {
+			rm /etc/config/wireless
+			/sbin/wifi config
+			/sbin/wifi up
+		}
+		;;
 	esac
 	
 	echo 600000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq

--- a/target/linux/ipq806x/base-files/lib/upgrade/norton.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/norton.sh
@@ -1,0 +1,108 @@
+#
+# Copyright (C) 2016 lede-project.org
+#
+
+norton_get_rootfs() {
+	local rootfsdev
+
+	if read cmdline < /proc/cmdline; then
+		case "$cmdline" in
+			*root=*)
+				rootfsdev="${cmdline##*root=}"
+				rootfsdev="${rootfsdev%% *}"
+			;;
+		esac
+
+		echo "${rootfsdev}"
+	fi
+}
+
+norton_do_flash() {
+	local tar_file=$1
+	local kernel=$2
+	local rootfs=$3
+
+	# keep sure its unbound
+	losetup --detach-all || {
+		echo Failed to detach all loop devices. Skip this try.
+		reboot -f
+	}
+
+	# use the first found directory in the tar archive
+	local board_dir=$(tar tf $tar_file | grep -m 1 '^sysupgrade-.*/$')
+	board_dir=${board_dir%/}
+
+	echo "flashing kernel to $kernel"
+	mkdir /tmp/upgrade
+	dd if=/dev/zero bs=40 count=1 > /tmp/upgrade/pad40
+	tar xf $tar_file ${board_dir}/kernel -C /tmp/upgrade/
+	cat /tmp/upgrade/pad40 /tmp/upgrade/${board_dir}/kernel > $kernel
+
+	echo "flashing rootfs to ${rootfs}"
+	tar xf $tar_file ${board_dir}/root -O > $rootfs
+
+	# a padded rootfs is needed for overlay fs creation
+	local offset=$(tar xf $tar_file ${board_dir}/root -O | wc -c)
+	[ $offset -lt 65536 ] && {
+		echo Wrong size for rootfs: $offset
+		sleep 10
+		reboot -f
+	}
+
+	[ -e /tmp/sysupgrade.tgz ] || {
+		echo "formating rootfs_data /dev/mmcblk0p25"
+		mkfs.ext4 -F -L rootfs_data /dev/mmcblk0p25
+	}
+
+	# flashing successful
+	case "$rootfs" in
+		"/dev/mmcblk0p10")
+			;;
+		"/dev/mmcblk0p21")
+			;;
+	esac
+
+	# Cleanup
+	losetup -d $loopdev >/dev/null 2>&1
+	sync
+	umount -a
+	reboot -f
+}
+
+norton_do_upgrade() {
+	local tar_file="$1"
+	local board=$(board_name)
+	local rootfs="$(norton_get_rootfs)"
+	local kernel=
+
+	[ -b "${rootfs}" ] || return 1
+	case "$board" in
+	norton,core-518)
+
+		case "$rootfs" in
+			"/dev/mmcblk0p10")
+				# booted from the primary partition set
+				# write to the alternative set
+				kernel="/dev/mmcblk0p9"
+				rootfs="/dev/mmcblk0p10"
+			;;
+			"/dev/mmcblk0p21")
+				# booted from the alternative partition set
+				# write to the primary set
+				kernel="/dev/mmcblk0p20"
+				rootfs="/dev/mmcblk0p21"
+			;;
+			*)
+				return 1
+			;;
+		esac
+		;;
+	*)
+		return 1
+		;;
+	esac
+
+	norton_do_flash $tar_file $kernel $rootfs
+
+	return 0
+}

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -62,6 +62,9 @@ platform_do_upgrade() {
 		MTD_CONFIG_ARGS="-s 0x200000"
 		default_do_upgrade "$1"
 		;;
+	norton,core-518)
+		norton_do_upgrade "$1"
+		;;
 	ruijie,rg-mtfi-m520)
 		ruijie_do_upgrade "$1"
 		;;

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-core-518.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8065-core-518.dts
@@ -1,0 +1,462 @@
+#include "qcom-ipq8065.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Norton Core 518";
+	compatible = "norton,core-518", "qcom,ipq8065", "qcom,ipq8064";
+
+	memory@0 {
+		reg = <0x42000000 0x3e000000>;
+		device_type = "memory";
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+		rsvd@41200000 {
+			reg = <0x41200000 0x300000>;
+			no-map;
+		};
+	};
+
+	aliases {
+		serial0 = &gsbi4_serial;
+		mdio-gpio0 = &mdio0;
+		sdcc1 = &sdcc1;
+	};
+
+	chosen {
+		bootargs = "rootfstype=squashfs,ext4 rootwait noinitrd";
+		stdout-path = "serial0:115200n8";
+		append-rootblock = "root=/dev/mmcblk0p";
+	};
+
+	soc {
+		pinmux@800000 {
+			button_pins: button_pins {
+				mux {
+					pins = "gpio68";
+					function = "gpio";
+					drive-strength = <2>;
+					bias-pull-up;
+				};
+			};
+
+			hs_uart_pins: hs_uart_pins {
+				mux {
+					pins = "gpio6", "gpio7", "gpio8", "gpio9";
+					function = "gsbi7";
+					drive-strength = <0xc>;
+					bias-disable;
+				};
+			};
+
+			serial_pins: serial_pins {
+				mux {
+					pins = "gpio55", "gpio56";
+					function = "gsbi6";
+					drive-strength = <0xc>;
+					bias-disable;
+				};
+			};
+
+			i2c_pins: i2c_pins {
+				mux {
+					pins = "gpio57", "gpio58";
+					function = "gsbi6";
+					drive-strength = <0xc>;
+					bias-disable;
+				};
+			};
+
+			sdcc1_pins: sdcc1_pinmux {
+				mux {
+					pins = "gpio38", "gpio39", "gpio40",
+					"gpio41", "gpio42", "gpio43",
+					"gpio44", "gpio45", "gpio46",
+					"gpio47";
+					function = "sdc1";
+				};
+				cmd {
+					pins = "gpio45";
+					drive-strength = <10>;
+					bias-pull-up;
+				};
+				data {
+					pins = "gpio38", "gpio39", "gpio40",
+					"gpio41", "gpio43", "gpio44",
+					"gpio46", "gpio47";
+					drive-strength = <10>;
+					bias-pull-up;
+				};
+				clk {
+					pins = "gpio42";
+					drive-strength = <16>;
+					bias-disable;
+				};
+			};
+
+			mdio0_pins: mdio0_pins {
+				mux {
+					pins = "gpio0", "gpio1";
+					function = "gpio";
+					drive-strength = <8>;
+					bias-disable;
+				};
+
+				clk {
+					pins = "gpio1";
+					input-disable;
+				};
+			};
+
+			rgmii2_pins: rgmii2_pins {
+				mux {
+					pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32",
+					       "gpio51", "gpio52", "gpio59", "gpio60", "gpio61", "gpio62" ;
+					function = "rgmii2";
+					drive-strength = <8>;
+					bias-disable;
+				};
+
+				tx {
+					pins = "gpio27", "gpio28", "gpio29", "gpio30", "gpio31", "gpio32" ;
+					input-disable;
+				};
+			};
+
+			spi_pins: spi_pins {
+				mux {
+					pins = "gpio18", "gpio19", "gpio21";
+					function = "gsbi5";
+					drive-strength = <10>;
+					bias-none;
+				};
+
+				cs {
+					pins = "gpio20";
+					drive-strength = <12>;
+				};
+			};
+
+			usb0_pwr_en_pins: usb0_pwr_en_pins {
+				mux {
+					pins = "gpio22", "gpio24";
+					function = "gpio";
+					drive-strength = <12>;
+				};
+
+				pwr {
+					pins = "gpio22";
+					bias-pull-down;
+					output-high;
+				};
+
+				ovc {
+					pins = "gpio24";
+					bias-pull-up;
+				};
+			};
+
+			usb1_pwr_en_pins: usb1_pwr_en_pins {
+				mux {
+					pins = "gpio23", "gpio25";
+					function = "gpio";
+					drive-strength = <12>;
+				};
+
+				pwr {
+					pins = "gpio23";
+					bias-pull-down;
+					output-high;
+				};
+
+				ovc {
+					pins = "gpio25";
+					bias-pull-up;
+				};
+			};
+		};
+
+		gsbi@16300000 {
+			qcom,mode = <GSBI_PROT_I2C_UART>;
+			status = "okay";
+			serial@16340000 {
+				status = "okay";
+			};
+			/*
+			 * The i2c device on gsbi4 should not be enabled.
+			 * On ipq806x designs gsbi4 i2c is meant for exclusive
+			 * RPM usage. Turning this on in kernel manifests as
+			 * i2c failure for the RPM.
+			 */
+		};
+
+		gsbi5: gsbi@1a200000 {
+			qcom,mode = <GSBI_PROT_SPI>;
+			status = "okay";
+
+			spi4: spi@1a280000 {
+				status = "okay";
+
+				pinctrl-0 = <&spi_pins>;
+				pinctrl-names = "default";
+
+				cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
+
+				flash: m25p80@0 {
+					compatible = "jedec,spi-nor";
+					#address-cells = <1>;
+					#size-cells = <1>;
+					spi-max-frequency = <51200000>;
+					reg = <0>;
+
+					partitions {
+						compatible = "qcom,smem";
+					};
+				};
+			};
+		};
+
+		// gsbi@16500000 {
+		// 	status = "okay";
+		// 	qcom,mode = < 0x06 >;
+
+		// 	i2c@16580000 {
+		// 		status = "okay";
+
+		// 		ncp5623@38 {
+		// 			compatible = "ncp5623";
+		// 			reg = < 0x38 >;
+
+		// 			white {
+		// 				label = "white";
+		// 				led_group = < 0x05 >;
+		// 				linux,default-trigger = "timer";
+		// 			};
+
+		// 			amber {
+		// 				label = "amber";
+		// 				led_group = < 0x02 >;
+		// 				init_state = "full_on";
+		// 				linux,default-trigger = "none";
+		// 			};
+		// 		};
+		// 	};
+		// };
+
+		phy@100f8800 {		/* USB3 port 1 HS phy */
+			status = "okay";
+		};
+
+		phy@100f8830 {		/* USB3 port 1 SS phy */
+			status = "okay";
+		};
+
+		phy@110f8800 {		/* USB3 port 0 HS phy */
+			status = "okay";
+		};
+
+		phy@110f8830 {		/* USB3 port 0 SS phy */
+			status = "okay";
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			gpios = <&qcom_pinmux 68 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&usb3_0 {
+	status = "okay";
+
+	pinctrl-0 = <&usb0_pwr_en_pins>;
+	pinctrl-names = "default";
+};
+
+&usb3_1 {
+	status = "okay";
+
+	pinctrl-0 = <&usb1_pwr_en_pins>;
+	pinctrl-names = "default";
+};
+
+&pcie1 {
+	status = "okay";
+	reset-gpio = <&qcom_pinmux 48 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&pcie1_pins>;
+	pinctrl-names = "default";
+	max-link-speed = <1>;
+};
+
+&mdio0 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio0_pins>;
+	pinctrl-names = "default";
+
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		qca,ar8327-initvals = <
+			0x00004 0x7600000   /* PAD0_MODE */
+			0x00008 0x1000000   /* PAD5_MODE */
+			0x0000c 0x80        /* PAD6_MODE */
+			0x000e4 0xaa545     /* MAC_POWER_SEL */
+			0x000e0 0xc74164de  /* SGMII_CTRL */
+			0x0007c 0x4e        /* PORT0_STATUS */
+			0x00094 0x4e        /* PORT6_STATUS */
+			0x00970 0x1e864443  /* QM_PORT0_CTRL0 */
+			0x00974 0x000001c6  /* QM_PORT0_CTRL1 */
+			0x00978 0x19008643  /* QM_PORT1_CTRL0 */
+			0x0097c 0x000001c6  /* QM_PORT1_CTRL1 */
+			0x00980 0x19008643  /* QM_PORT2_CTRL0 */
+			0x00984 0x000001c6  /* QM_PORT2_CTRL1 */
+			0x00988 0x19008643  /* QM_PORT3_CTRL0 */
+			0x0098c 0x000001c6  /* QM_PORT3_CTRL1 */
+			0x00990 0x19008643  /* QM_PORT4_CTRL0 */
+			0x00994 0x000001c6  /* QM_PORT4_CTRL1 */
+			0x00998 0x1e864443  /* QM_PORT5_CTRL0 */
+			0x0099c 0x000001c6  /* QM_PORT5_CTRL1 */
+			0x009a0 0x1e864443  /* QM_PORT6_CTRL0 */
+			0x009a4 0x000001c6  /* QM_PORT6_CTRL1 */
+			>;
+	};
+
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+		qca,ar8327-initvals = <
+			0x000e4 0x6a545     /* MAC_POWER_SEL */
+			0x0000c 0x80        /* PAD6_MODE */
+			>;
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	compatible = "qcom,nss-gmac";
+	reg = <0x37200000 0x200000>;
+	interrupts = <GIC_SPI 223 IRQ_TYPE_LEVEL_HIGH>;
+	phy-mode = "rgmii";
+	qcom,id = <1>;
+	qcom,pcs-chanid = <0>;
+	qcom,phy-mdio-addr = <4>;
+	qcom,poll-required = <0>;
+	qcom,rgmii-delay = <1>;
+	qcom,phy_mii_type = <0>;
+	qcom,emulation = <0>;
+	qcom,forced-speed = <1000>;
+	qcom,forced-duplex = <1>;
+	qcom,socver = <0>;
+	qcom,irq = <255>;
+	mdiobus = <&mdio0>;
+
+	pinctrl-0 = <&rgmii2_pins>;
+	pinctrl-names = "default";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&gmac2 {
+	status = "okay";
+	compatible = "qcom,nss-gmac";
+	reg = <0x37400000 0x200000>;
+	interrupts = <GIC_SPI 226 IRQ_TYPE_LEVEL_HIGH>;
+	phy-mode = "sgmii";
+	qcom,id = <2>;
+	qcom,pcs-chanid = <1>;
+	qcom,phy-mdio-addr = <0>;	/* none */
+	qcom,poll-required = <0>;	/* no polling */
+	qcom,rgmii-delay = <0>;
+	qcom,phy_mii_type = <1>;
+	qcom,emulation = <0>;
+	qcom,forced-speed = <1000>;
+	qcom,forced-duplex = <1>;
+	qcom,socver = <0>;
+	qcom,irq = <258>;
+	mdiobus = <&mdio0>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+// &gmac1 {
+// 	status = "okay";
+// 	phy-mode = "rgmii";
+// 	qcom,id = <1>;
+// 	qcom,phy_mdio_addr = <4>;
+// 	qcom,poll_required = <0>;
+// 	qcom,rgmii_delay = <1>;
+// 	qcom,phy_mii_type = <0>;
+// 	qcom,emulation = <0>;
+// 	qcom,irq = <255>;
+// 	mdiobus = <&mdio0>;
+
+// 	pinctrl-0 = <&rgmii2_pins>;
+// 	pinctrl-names = "default";
+
+// 	fixed-link {
+// 		speed = <1000>;
+// 		full-duplex;
+// 	};
+// };
+
+// &gmac2 {
+// 	status = "okay";
+// 	phy-mode = "sgmii";
+// 	qcom,id = <2>;
+// 	qcom,phy_mdio_addr = <0>;	/* none */
+// 	qcom,poll_required = <0>;	/* no polling */
+// 	qcom,rgmii_delay = <0>;
+// 	qcom,phy_mii_type = <1>;
+// 	qcom,emulation = <0>;
+// 	qcom,irq = <258>;
+// 	mdiobus = <&mdio0>;
+
+// 	fixed-link {
+// 		speed = <1000>;
+// 		full-duplex;
+// 	};
+// };
+
+&pcie0 {
+	status = "okay";
+	reset-gpio = <&qcom_pinmux 3 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&pcie0_pins>;
+	pinctrl-names = "default";
+};
+
+&pcie1 {
+	status = "okay";
+	reset-gpio = <&qcom_pinmux 48 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&pcie1_pins>;
+	pinctrl-names = "default";
+	max-link-speed = <1>;
+};
+
+&amba {
+	sdcc1: sdcc@12400000 {
+		status = "okay";
+		pinctrl-0 = <&sdcc1_pins>;
+		pinctrl-names = "default";
+	};
+};
+
+&adm_dma {
+	status = "okay";
+};

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -428,6 +428,25 @@ define Device/ruijie_rg-mtfi-m520
 endef
 TARGET_DEVICES += ruijie_rg-mtfi-m520
 
+define Device/norton_core-518
+	DEVICE_TITLE := Norton Core 518
+	BOARD_NAME := core-518
+	SOC := qcom-ipq8065
+	DEVICE_DTS := qcom-ipq8065-core-518
+	BLOCKSIZE := 64k
+	KERNEL_SIZE := 4096k
+	KERNEL_SUFFIX := -uImage
+	KERNEL = kernel-bin | append-dtb | uImage none | pad-to $${KERNEL_SIZE}
+	KERNEL_NAME := zImage
+	SUPPORTED_DEVICES += core-518
+	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct e2fsprogs kmod-fs-ext4 losetup f2fs-tools
+	IMAGES := mmcblk0p10-rootfs.bin mmcblk0p9-kernel.bin sysupgrade.bin
+	IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-to $$$${BLOCKSIZE} | sysupgrade-tar rootfs=$$$$@ | append-metadata
+	IMAGE/mmcblk0p9-kernel.bin := pad-extra 40 | append-kernel | pad-to $$$${KERNEL_SIZE}
+	IMAGE/mmcblk0p10-rootfs.bin := append-rootfs | pad-rootfs
+endef
+TARGET_DEVICES += norton_core-518
+
 define Device/tplink_ad7200
 	$(call Device/TpSafeImage)
 	DEVICE_VENDOR := TP-Link

--- a/target/linux/ipq806x/patches-5.10/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-5.10/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -907,8 +907,31 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -907,8 +907,32 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-ipq4019-ap.dk04.1-c3.dtb \
  	qcom-ipq4019-ap.dk07.1-c1.dtb \
  	qcom-ipq4019-ap.dk07.1-c2.dtb \
@@ -33,6 +33,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq8064-wpq864.dtb \
 +	qcom-ipq8064-wxr-2533dhp.dtb \
 +	qcom-ipq8065-nbg6817.dtb \
++	qcom-ipq8065-core-518.dtb \
 +	qcom-ipq8065-r7800.dtb \
 +	qcom-ipq8065-xr500.dtb \
 +	qcom-ipq8065-rac2v1a.dtb \

--- a/target/linux/ipq806x/patches-5.4/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-5.4/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -842,7 +842,30 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -842,7 +842,31 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-ipq4019-ap.dk04.1-c3.dtb \
  	qcom-ipq4019-ap.dk07.1-c1.dtb \
  	qcom-ipq4019-ap.dk07.1-c2.dtb \
@@ -32,6 +32,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq8064-wpq864.dtb \
 +	qcom-ipq8064-wxr-2533dhp.dtb \
 +	qcom-ipq8065-nbg6817.dtb \
++	qcom-ipq8065-core-518.dtb \
 +	qcom-ipq8065-r7800.dtb \
 +	qcom-ipq8065-xr500.dtb \
 +	qcom-ipq8065-rac2v1a.dtb \


### PR DESCRIPTION
# Norton 518 刷机说明

这个路由器需要更换U后才能刷（因为U开启了安全启动），此固件第一次启动没有无线，开机时间3分钟后再重启无线就有了

## 刷机

1. 先判断当前系统的启动分区，留意下图的位置
![image](https://user-images.githubusercontent.com/18640537/143675900-7f792437-4123-4788-a08d-576cfd9e1797.png)

### 下面这个是需要在U-Boot刷入的

如果结尾是10，则使用下面的命令
```
tftpboot kernel.bin && mmc erase 0x00007D22 0x0000CD21 && mmc write 0x44000000 0x00007D22 0x0000CD21
tftpboot rootfs.bin && mmc erase 0x0000CD22 0x0004CD21 && mmc write 0x44000000 0x0000CD22 0x0004CD21
```

如果结尾是21，则使用下面的命令
```
tftpboot kernel.bin && mmc erase 0x00095022 0x0009A021 && mmc write 0x44000000 0x00095022 0x0009A021
tftpboot rootfs.bin && mmc erase 0x0009A022 0x000DA021 && mmc write 0x44000000 0x0009A022 0x000DA021
```

当然，你也可以直接一了百了地把这些命令都执行一遍，把这双分区都刷了

刷完后，输入bootipq即可进入系统

进去系统后，执行一次恢复出厂设置，否则配置可能无法保存。

## 编译说明

编译此机箱需要进去make kernel_menuconfig去掉下面这个选项的勾，然后再编译，否则可能无线启动巨慢
![image](https://user-images.githubusercontent.com/18640537/143676285-870ffef6-e1ce-449c-9501-a9e9de6b30fa.png)

位置在
Device Drivers -> Generic Driver Options -> Firmware loader

这个设置可能对其他机型不适用，所以编译其他机型的时候需要重新勾上，或者执行git checkout target/linux/ipq806x/config-5.4

## 致谢

十分感谢大雕、暗云、狂风邪影和Ao提供的帮助