### PR TITLE
rockchip: fixed: Add support for off-on-delay

### DIFF
--- a/target/linux/rockchip/patches-5.10/108-Add-support-for-off-on-delay-kernel-5.10.patch
+++ b/target/linux/rockchip/patches-5.10/108-Add-support-for-off-on-delay-kernel-5.10.patch
@@ -1,0 +1,42 @@
+From e1e8004f31e353482b30e3fa0c6dd8832bb132d7 Mon Sep 17 00:00:00 2001
+From: GitHub <git@github.com>
+Date: Wed, 1 Dec 2021 15:50:40 +0800
+Subject: [PATCH] Add support for off-on-delay
+There may be unrecognized problems when the lan network is disconnected. 
+The solution is to add support for disconnection delay
+---
+ drivers/regulator/core.c  | 3 +++
+ drivers/regulator/fixed.c | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/drivers/regulator/core.c b/drivers/regulator/core.c
+index 043b5f6..f13cfb3 100644
+--- a/drivers/regulator/core.c
++++ b/drivers/regulator/core.c
+@@ -5301,6 +5301,9 @@ regulator_register(const struct regulator_desc *regulator_desc,
+ 		dangling_of_gpiod = false;
+ 	}
+ 
++	if (rdev->desc->off_on_delay)
++		rdev->last_off_jiffy = jiffies;
++
+ 	/* register with sysfs */
+ 	rdev->dev.class = &regulator_class;
+ 	rdev->dev.parent = dev;
+diff --git a/drivers/regulator/fixed.c b/drivers/regulator/fixed.c
+index 3de7709..d652e51 100644
+--- a/drivers/regulator/fixed.c
++++ b/drivers/regulator/fixed.c
+@@ -152,6 +152,9 @@ static int reg_fixed_voltage_probe(struct platform_device *pdev)
+ 						     &drvdata->desc);
+ 		if (IS_ERR(config))
+ 			return PTR_ERR(config);
++
++		of_property_read_u32(pdev->dev.of_node,
++				     "off-on-delay-us", &drvdata->desc.off_on_delay);			
+ 	} else {
+ 		config = dev_get_platdata(&pdev->dev);
+ 	}
+-- 
+2.25.1
+

--- a/target/linux/rockchip/patches-5.4/107-Add-support-for-off-on-delay-kernel-5.4.patch
+++ b/target/linux/rockchip/patches-5.4/107-Add-support-for-off-on-delay-kernel-5.4.patch
@@ -1,0 +1,43 @@
+From 1ab8e496fc24110a98d4e87d49456e210184350b Mon Sep 17 00:00:00 2001
+From: GitHub <git@github.com>
+Date: Wed, 1 Dec 2021 15:32:27 +0800
+Subject: [PATCH] Add support for off-on-delay
+There may be unrecognized problems when the lan network is disconnected. 
+The solution is to add support for disconnection delay
+
+---
+ drivers/regulator/core.c  | 3 +++
+ drivers/regulator/fixed.c | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/drivers/regulator/core.c b/drivers/regulator/core.c
+index 7fd793d..5b0edaa 100644
+--- a/drivers/regulator/core.c
++++ b/drivers/regulator/core.c
+@@ -5169,6 +5169,9 @@ regulator_register(const struct regulator_desc *regulator_desc,
+ 		dangling_of_gpiod = false;
+ 	}
+ 
++	if (rdev->desc->off_on_delay)
++		rdev->last_off_jiffy = jiffies;
++
+ 	/* register with sysfs */
+ 	rdev->dev.class = &regulator_class;
+ 	rdev->dev.parent = dev;
+diff --git a/drivers/regulator/fixed.c b/drivers/regulator/fixed.c
+index f815330..00bb4c8 100644
+--- a/drivers/regulator/fixed.c
++++ b/drivers/regulator/fixed.c
+@@ -159,6 +159,9 @@ static int reg_fixed_voltage_probe(struct platform_device *pdev)
+ 						     &drvdata->desc);
+ 		if (IS_ERR(config))
+ 			return PTR_ERR(config);
++
++		of_property_read_u32(pdev->dev.of_node,
++				     "off-on-delay-us", &drvdata->desc.off_on_delay);
+ 	} else {
+ 		config = dev_get_platdata(&pdev->dev);
+ 	}
+-- 
+2.25.1
+


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
There may be unrecognized problems when the lan network is disconnected. 
The solution is to add support for disconnection delay.