### PR TITLE
Add JCG Q10 PRO(the same as JCG Q20) with CR660x pb-boot support, cha…

### DIFF
--- a/target/linux/ramips/dts/mt7621_jcg_q10.dts
+++ b/target/linux/ramips/dts/mt7621_jcg_q10.dts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "jcg,q10", "mediatek,mt7621-soc";
+	model = "JCG Q10 PRO";
+
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_blue;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_blue: status_blue {
+			label = "blue:status";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+		};
+
+		partition@80000 {
+			label = "Nvram";
+			reg = <0x80000 0x40000>;
+			read-only;
+		};
+
+		partition@c0000 {
+			label = "Bdata";
+			reg = <0xc0000 0x40000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "Factory";
+			reg = <0x100000 0x80000>;
+			read-only;
+		};
+
+		partition@180000 {
+			label = "crash";
+			reg = <0x180000 0x40000>;
+			read-only;
+		};
+
+		partition@1c0000 {
+			label = "crash_log";
+			reg = <0x1c0000 0x40000>;
+			read-only;
+		};
+
+		partition@200000 {
+			label = "kernel";
+			reg = <0x200000 0x400000>;
+		};
+
+		partition@600000 {
+			label = "ubi";
+			reg = <0x600000 0x7980000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&ethernet {
+	compatible = "mediatek,ralink-mt7621-eth";
+	mediatek,switch = <&gsw>;
+	mtd-mac-address = <&factory 0x3fff4>;
+};
+
+&switch0 {
+	/delete-property/ compatible;
+	phy-mode = "rgmii";
+};
+
+&gsw {
+	compatible = "mediatek,ralink-mt7621-gsw";
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -826,6 +826,24 @@ define Device/jcg_jhr-ac945m
 endef
 TARGET_DEVICES += jcg_jhr-ac945m
 
+define Device/jcg_q10
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  UBINIZE_OPTS := -E 5
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 128512k
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size
+  DEVICE_VENDOR := JCG
+  DEVICE_MODEL := Q10 PRO (for cr660x pb-boot, use swconfig instead of DSA)
+  DEVICE_PACKAGES += kmod-mt7915e wpad-openssl uboot-envtools
+endef
+TARGET_DEVICES += jcg_q10
+
 define Device/jcg_q20
   $(Device/dsa-migration)
   BLOCKSIZE := 128k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -47,6 +47,10 @@ ramips_setup_interfaces()
 			"1:lan:1" "2:lan:2" "3:lan:3" "4:lan:4" "0:wan" "6@eth0"
 		ucidef_set_interface_lan "eth0.1 ra0 rai0"
 		;;
+	jcg,q10)
+		ucidef_add_switch "switch0" \
+			"1:lan:1" "4:lan:2" "0:wan" "6@eth0"
+		;;
 	d-team,newifi-d2|\
 	raisecom,msg1500-x-00)
 		ucidef_add_switch "switch0" \
@@ -134,6 +138,10 @@ ramips_setup_macs()
 		local index="$(find_mtd_index "board_data")"
 		wan_mac="$(grep -m1 mac= "/dev/mtd${index}" | cut -d= -f2)"
 		lan_mac=$wan_mac
+		;;
+	jcg,q10)
+		lan_mac=$(cat /sys/class/net/eth0/address)
+		wan_mac=$(mtd_get_mac_binary factory 0x3fffa)
 		;;
 	d-team,newifi-d2|\
 	phicomm,k2p|\


### PR DESCRIPTION
JCG Q10 PRO/Q20，使用 CR660X 的 pb-boot，分区类型同 CR660X。修改交换机为 swconfig。