### PR TITLE
x86: added support to generate VHDX images

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -271,17 +271,17 @@ menu "Target Images"
 		depends on GRUB_IMAGES || GRUB_EFI_IMAGES
 		select PACKAGE_kmod-e1000
 
-	config VHDX_IMAGES
-		bool "Build Hyper-V image files (VHDX)"
-		depends on TARGET_x86
-		depends on GRUB_IMAGES || GRUB_EFI_IMAGES
-		select PACKAGE_kmod-tulip
-
 	config VMDK_IMAGES
 		bool "Build VMware image files (VMDK)"
 		depends on TARGET_x86
 		depends on GRUB_IMAGES || GRUB_EFI_IMAGES
 		default y
+		select PACKAGE_kmod-e1000
+
+	config VHDX_IMAGES
+		bool "Build Hyper-V image files (VHDX)"
+		depends on TARGET_x86
+		depends on GRUB_IMAGES || GRUB_EFI_IMAGES
 		select PACKAGE_kmod-e1000
 
 	config TARGET_IMAGES_GZIP

--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -360,7 +360,7 @@ define Build/patch-cmdline
 endef
 
 # Convert a raw image into a $1 type image.
-# E.g. | qemu-image vdi
+# E.g. | qemu-image vdi <optional extra arguments to qemu-img binary>
 define Build/qemu-image
 	if command -v qemu-img; then \
 		qemu-img convert -f raw -O $1 $@ $@.new; \

--- a/target/linux/x86/Makefile
+++ b/target/linux/x86/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=i386
 BOARD:=x86
 BOARDNAME:=x86
-FEATURES:=squashfs vdi vmdk pcmcia fpu boot-part rootfs-part
+FEATURES:=squashfs vdi vmdk vhdx pcmcia fpu boot-part rootfs-part
 SUBTARGETS:=64 generic legacy geode 
 
 KERNEL_PATCHVER:=5.4

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -109,8 +109,8 @@ define Device/Default
   IMAGE/combined.img.gz := grub-config pc | combined | grub-install | gzip | append-metadata
   IMAGE/combined.qcow2 := grub-config pc | combined | grub-install | qemu-image qcow2
   IMAGE/combined.vdi := grub-config pc | combined | grub-install | qemu-image vdi
-  IMAGE/combined.vhdx := grub-config pc | combined | grub-install | qemu-image vhdx
   IMAGE/combined.vmdk := grub-config pc | combined | grub-install | qemu-image vmdk
+  IMAGE/combined.vhdx := grub-config pc | combined | grub-install | qemu-image vhdx -o subformat=dynamic
   IMAGE/rootfs.img := append-rootfs | pad-to $(ROOTFS_PARTSIZE)
   IMAGE/rootfs.img.gz := append-rootfs | pad-to $(ROOTFS_PARTSIZE) | gzip
   ARTIFACT/image-efi.iso := grub-config iso | iso efi
@@ -118,8 +118,8 @@ define Device/Default
   IMAGE/combined-efi.img.gz := grub-config efi | combined efi | grub-install efi | gzip | append-metadata
   IMAGE/combined-efi.qcow2 := grub-config efi | combined efi | grub-install efi | qemu-image qcow2
   IMAGE/combined-efi.vdi := grub-config efi | combined efi | grub-install efi | qemu-image vdi
-  IMAGE/combined-efi.vhdx := grub-config efi | combined efi | grub-install efi | qemu-image vhdx
   IMAGE/combined-efi.vmdk := grub-config efi | combined efi | grub-install efi | qemu-image vmdk
+  IMAGE/combined-efi.vhdx := grub-config efi | combined efi | grub-install efi | qemu-image vhdx -o subformat=dynamic
   ifeq ($(CONFIG_TARGET_IMAGES_GZIP),y)
     IMAGES-y := rootfs.img.gz
     IMAGES-$$(CONFIG_GRUB_IMAGES) += combined.img.gz
@@ -144,13 +144,13 @@ define Device/Default
     IMAGES-$$(CONFIG_GRUB_IMAGES) += combined.vdi
     IMAGES-$$(CONFIG_GRUB_EFI_IMAGES) += combined-efi.vdi
   endif
-  ifeq ($(CONFIG_VHDX_IMAGES),y)
-    IMAGES-$$(CONFIG_GRUB_IMAGES) += combined.vhdx
-    IMAGES-$$(CONFIG_GRUB_EFI_IMAGES) += combined-efi.vhdx
-  endif
   ifeq ($(CONFIG_VMDK_IMAGES),y)
     IMAGES-$$(CONFIG_GRUB_IMAGES) += combined.vmdk
     IMAGES-$$(CONFIG_GRUB_EFI_IMAGES) += combined-efi.vmdk
+  endif
+  ifeq ($(CONFIG_VHDX_IMAGES),y)
+    IMAGES-$$(CONFIG_GRUB_IMAGES) += combined.vhdx
+    IMAGES-$$(CONFIG_GRUB_EFI_IMAGES) += combined-efi.vhdx
   endif
   IMAGES := $$(IMAGES-y)
   ARTIFACTS := $$(ARTIFACTS-y)


### PR DESCRIPTION
######sync upstream#####

Added support to generate dynamic-sized VHDX images for Hyper-V.
Compile-tested on x86 and run-tested on Windows 10 21H2 (Hyper-V).

Signed-off-by: Oldřich Jedlička <oldium.pro@gmail.com>