### PR TITLE
luci-app-frpc: remove data type restriction of http_proxy

### DIFF
--- a/package/lean/luci-app-frpc/luasrc/model/cbi/frp/basic.lua
+++ b/package/lean/luci-app-frpc/luasrc/model/cbi/frp/basic.lua
@@ -86,7 +86,6 @@ e.rmempty = false
 e:depends("protocol","tcp")
 
 e = t:taboption("other", Value, "http_proxy", translate("HTTP PROXY"))
-e.datatype = "uinteger"
 e.placeholder = "http://user:pwd@192.168.1.128:8080"
 e:depends("enable_http_proxy",1)
 e.optional = false


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ x ] 我知道

frpc 可以通过 http/socks5 代理连接到 frps ，[见文档](https://gofrp.org/docs/features/common/client/)

luci-app-frpc 支持这项参数的设置，但它错误地给代理链接加上了无符号数的限制，导致原本格式正确的链接无法被识别。

我在 /usr/lib/lua/luci/cbi/datatypes.lua 中没有找到能识别这种链接的函数，所以建议直接去除限制。