### PR TITLE
n2n 3.0 not support -s param

### DIFF
--- a/package/lean/n2n_v2/files/n2n_v2.init
+++ b/package/lean/n2n_v2/files/n2n_v2.init
@@ -24,15 +24,15 @@ start_instance() {
         config_get community "$cfg" 'community'
         config_get key "$cfg" 'key'
         config_get_bool route "$cfg" 'route' '0'
-        address="$ipaddr"
+        address="$ipaddr/$prefix"
         supernode_bak=""
         [ "$second_supernode" -a "$second_port" ] && supernode_bak=" -l ${second_supernode}:${second_port}"
         [ "$route" = "1" ] && args='-r'
         [ "$mode" = 'dhcp' ] && address='0.0.0.0'
         [ "-$mtu" != "-" ] && mtu="-M $mtu"
-        eval "$(ipcalc.sh "$ipaddr/$prefix")"
-        netmask="$NETMASK"
-        /usr/bin/edge -u 0 -g 0 -d $tunname -a ${mode}:${address} -s $netmask -c $community $([ -n "$key" ] && echo -k $key) -l ${supernode}:${port}$supernode_bak $args $mtu
+        # eval "$(ipcalc.sh "$ipaddr/$prefix")"
+        # netmask="$NETMASK"
+        /usr/bin/edge -u 0 -g 0 -d $tunname -a ${mode}:${address} -c $community $([ -n "$key" ] && echo -k $key) -l ${supernode}:${port}$supernode_bak $args $mtu
         iptables -I FORWARD -i "$tunname" -j ACCEPT -m comment --comment 'n2n edge eth'
         iptables -I FORWARD -o "$tunname" -j ACCEPT -m comment --comment 'n2n edge eth'
         iptables -t nat -I POSTROUTING -o "$tunname" -j MASQUERADE -m comment --comment 'n2n edge net'


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ x] 我知道

n2n 3.0 版本不再支持-s参数，掩码合并到ip中的cidr

```bash
root@OpenWrt:~# /etc/init.d/n2n_v2 start
08/Jan/2022 10:02:55 [edge.c:779] WARNING: unknown option -s

Welcome to n2n v.3.0.0 for Debian bullseye/sid
Built on Jan  7 2022 03:21:27
Copyright 2007-2021 - ntop.org and contributors

 general usage:  edge <config file> (see edge.conf)

            or   edge  -c <community name> -l <supernode host:port>
.......
```