### PR TITLE
Update 302-ARM-dts-BCM5301X-Update-Northstar-pinctrl-binding.patch

### DIFF
--- a/target/linux/bcm53xx/patches-5.4/302-ARM-dts-BCM5301X-Update-Northstar-pinctrl-binding.patch
+++ b/target/linux/bcm53xx/patches-5.4/302-ARM-dts-BCM5301X-Update-Northstar-pinctrl-binding.patch
@@ -16,14 +16,14 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 -			compatible = "simple-bus";
 +			compatible = "syscon", "simple-mfd";
  			reg = <0x100 0x1a4>;
--			ranges;
--			#address-cells = <1>;
+ 			ranges;
+ 			#address-cells = <1>;
 @@ -450,10 +450,9 @@
  						     "sata1", "sata2";
  			};
  
 -			pinctrl: pin-controller@1c0 {
-+			pinctrl: pinctrl {
++			pinctrl: pin-controller {
  				compatible = "brcm,bcm4708-pinmux";
 -				reg = <0x1c0 0x24>;
 -				reg-names = "cru_gpio_control";


### PR DESCRIPTION
修复斐讯K3打补丁失败

