### PR TITLE
ipq806x: add support for SURF G-NAT200

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -42,6 +42,11 @@ netgear,xr500)
 	ucidef_set_led_switch "wan" "WAN" "white:wan" "switch0" "0x20"
 	ucidef_set_led_ide "esata" "eSATA" "white:esata"
 	;;
+surf,g-nat200)
+	ucidef_set_led_ide "sata" "SATA" "green:sata"
+	ucidef_set_led_switch "wan" "WAN" "green:internet" "switch0" "0x20"
+	ucidef_set_led_usbport "usb" "USB" "green:usb" "usb1-port1" "usb2-port1"
+	;;
 tplink,ad7200)
 	ucidef_set_led_usbport "usb1" "USB 1" "blue:usb1" "usb1-port1" "usb2-port1"
 	ucidef_set_led_usbport "usb2" "USB 2" "blue:usb3" "usb3-port1" "usb4-port1"

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -30,6 +30,7 @@ netgear,d7800 |\
 netgear,r7500 |\
 netgear,r7500v2 |\
 qcom,ipq8064-ap148 |\
+surf,g-nat200 |\
 tplink,vr2600v)
 	ucidef_add_switch "switch0" \
 		"1:lan" "2:lan" "3:lan" "4:lan" "6@eth1" "5:wan" "0@eth0"

--- a/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-g-nat200.dts
+++ b/target/linux/ipq806x/files/arch/arm/boot/dts/qcom-ipq8064-g-nat200.dts
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "qcom-ipq8064-v2.0.dtsi"
+
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "SURF G-NAT200";
+	compatible = "surf,g-nat200", "qcom,ipq8064";
+
+	memory@0 {
+		reg = <0x42000000 0x3e000000>;
+		device_type = "memory";
+	};
+
+	aliases {
+		led-boot = &led_usb;
+		led-failsafe = &led_usb;
+		led-upgrade = &led_usb;
+
+		mdio-gpio0 = &mdio0;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+			wakeup-source;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		led_usb: usb {
+			label = "green:usb";
+			gpios = <&qcom_pinmux 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		sata {
+			label = "green:sata";
+			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_HIGH>;
+		};
+
+		internet {
+			label = "green:internet";
+			gpios = <&qcom_pinmux 67 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&qcom_pinmux {
+	led_pins: led_pins {
+		mux {
+			pins = "gpio7", "gpio26", "gpio67";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
+
+	button_pins: button_pins {
+		mux {
+			pins = "gpio54";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
+
+	spi_pins: spi_pins {
+		mux {
+			pins = "gpio18", "gpio19", "gpio21";
+			function = "gsbi5";
+			drive-strength = <10>;
+			bias-none;
+		};
+
+		cs {
+			pins = "gpio20";
+			drive-strength = <12>;
+		};
+	};
+};
+
+&gsbi5 {
+	qcom,mode = <GSBI_PROT_SPI>;
+	status = "okay";
+
+	spi@1a280000 {
+		status = "okay";
+
+		pinctrl-0 = <&spi_pins>;
+		pinctrl-names = "default";
+
+		cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
+
+		flash@0 {
+			compatible = "s25fl256s1";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			spi-max-frequency = <50000000>;
+			reg = <0>;
+
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				SBL1@0 {
+					label = "SBL1";
+					reg = <0x0 0x20000>;
+					read-only;
+				};
+
+				MIBIB@20000 {
+					label = "MIBIB";
+					reg = <0x20000 0x20000>;
+					read-only;
+				};
+
+				SBL2@40000 {
+					label = "SBL2";
+					reg = <0x40000 0x40000>;
+					read-only;
+				};
+
+				SBL3@80000 {
+					label = "SBL3";
+					reg = <0x80000 0x80000>;
+					read-only;
+				};
+
+				DDRCONFIG@100000 {
+					label = "DDRCONFIG";
+					reg = <0x100000 0x10000>;
+					read-only;
+				};
+
+				SSD@110000 {
+					label = "SSD";
+					reg = <0x110000 0x10000>;
+					read-only;
+				};
+
+				TZ@120000 {
+					label = "TZ";
+					reg = <0x120000 0x80000>;
+					read-only;
+				};
+
+				RPM@1a0000 {
+					label = "RPM";
+					reg = <0x1a0000 0x80000>;
+					read-only;
+				};
+
+				APPSBL@220000 {
+					label = "APPSBL";
+					reg = <0x220000 0x80000>;
+					read-only;
+				};
+
+				APPSBLENV@2a0000 {
+					label = "APPSBLENV";
+					reg = <0x2a0000 0x40000>;
+					read-only;
+				};
+
+				ART: ART@2e0000 {
+					label = "ART";
+					reg = <0x2e0000 0x40000>;
+					read-only;
+				};
+
+				firmware@320000 {
+					compatible = "denx,uimage";
+					label = "firmware";
+					reg = <0x320000 0x1a00000>;
+				};
+			};
+		};
+	};
+};
+
+&nand_controller {
+	status = "okay";
+
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+
+	nand@0 {
+		reg = <0>;
+		compatible = "qcom,nandcs";
+
+		nand-ecc-strength = <4>;
+		nand-bus-width = <8>;
+		nand-ecc-step-size = <512>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubifs";
+				reg = <0x0 0x1eaac000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio0_pins>;
+	pinctrl-names = "default";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		qca,ar8327-initvals = <
+			0x00004 0x7600000   /* PAD0_MODE */
+			0x00008 0x1000000   /* PAD5_MODE */
+			0x0000c 0x80        /* PAD6_MODE */
+			0x000e4 0x6a545     /* MAC_POWER_SEL */
+			0x000e0 0xc74164de  /* SGMII_CTRL */
+			0x0007c 0x4e        /* PORT0_STATUS */
+			0x00094 0x4e        /* PORT6_STATUS */
+			>;
+	};
+
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	phy-mode = "rgmii";
+	qcom,id = <1>;
+
+	pinctrl-0 = <&rgmii2_pins>;
+	pinctrl-names = "default";
+
+	mtd-mac-address = <&ART 0x6>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&gmac2 {
+	status = "okay";
+	phy-mode = "sgmii";
+	qcom,id = <2>;
+
+	mtd-mac-address = <&ART 0xc>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&adm_dma {
+	status = "okay";
+};
+
+&pcie1 {
+	status = "okay";
+};
+
+&sata_phy {
+	status = "okay";
+};
+
+&sata {
+	status = "okay";
+};
+
+&usb3_0 {
+	status = "okay";
+};
+
+&usb3_1 {
+	status = "okay";
+};

--- a/target/linux/ipq806x/image/Makefile
+++ b/target/linux/ipq806x/image/Makefile
@@ -447,6 +447,18 @@ define Device/norton_core-518
 endef
 TARGET_DEVICES += norton_core-518
 
+define Device/surf_g-nat200
+	$(call Device/LegacyImage)
+	DEVICE_VENDOR := SURF
+	DEVICE_MODEL := G-NAT200
+	SOC := qcom-ipq8064
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	IMAGE_SIZE := 26624k
+	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
+endef
+TARGET_DEVICES += surf_g-nat200
+
 define Device/tplink_ad7200
 	$(call Device/TpSafeImage)
 	DEVICE_VENDOR := TP-Link

--- a/target/linux/ipq806x/patches-5.10/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-5.10/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -907,8 +907,32 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -907,8 +907,33 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-ipq4019-ap.dk04.1-c3.dtb \
  	qcom-ipq4019-ap.dk07.1-c1.dtb \
  	qcom-ipq4019-ap.dk07.1-c2.dtb \
@@ -24,6 +24,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq8064-ea7500-v1.dtb \
 +	qcom-ipq8064-ea8500.dtb \
 +	qcom-ipq8064-g10.dtb \
++	qcom-ipq8064-g-nat200.dtb \
 +	qcom-ipq8064-r7500.dtb \
 +	qcom-ipq8064-r7500v2.dtb \
 +	qcom-ipq8064-e8350-v1.dtb \

--- a/target/linux/ipq806x/patches-5.4/0069-arm-boot-add-dts-files.patch
+++ b/target/linux/ipq806x/patches-5.4/0069-arm-boot-add-dts-files.patch
@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/arch/arm/boot/dts/Makefile
 +++ b/arch/arm/boot/dts/Makefile
-@@ -842,7 +842,31 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+@@ -842,7 +842,32 @@ dtb-$(CONFIG_ARCH_QCOM) += \
  	qcom-ipq4019-ap.dk04.1-c3.dtb \
  	qcom-ipq4019-ap.dk07.1-c1.dtb \
  	qcom-ipq4019-ap.dk07.1-c2.dtb \
@@ -24,6 +24,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	qcom-ipq8064-e8350-v1.dtb \
 +	qcom-ipq8064-ea8500.dtb \
 +	qcom-ipq8064-g10.dtb \
++	qcom-ipq8064-g-nat200.dtb \
 +	qcom-ipq8064-r7500.dtb \
 +	qcom-ipq8064-r7500v2.dtb \
 +	qcom-ipq8064-rg-mtfi-m520.dtb \


### PR DESCRIPTION
```
Hardware specs:
  SoC: Qualcomm IPQ8064
  RAM: 1GB DDR3
  SPI: 32MB S25FL256S
  NAND: 512MB S34MS04G2 (unused)
  Ethernet: 5x 10/100/1000 Mbps QCA8337
  LED: internet, usb, sata
  Button: Reset
  USB: 1 x 3.0

Installation:
  Interrupt U-Boot, tftpboot initramfs image,
  than sysupgrade to openwrt.
```
Closed: #8718