### PR TITLE
fix luci-app-verysync luci-app-baidupcs-web 

### DIFF
--- a/package/lean/luci-app-baidupcs-web/luasrc/view/baidupcs-web/baidupcs-web_status.htm
+++ b/package/lean/luci-app-baidupcs-web/luasrc/view/baidupcs-web/baidupcs-web_status.htm
@@ -20,12 +20,9 @@ XHR.poll(3, '<%=url([[admin]], [[nas]], [[baidupcs-web]], [[status]])%>', null,
 );
 
 function openClient() {
-	var curWwwPath = window.document.location.href;
-	var pathName = window.document.location.pathname;
-	var pos = curWwwPath.indexOf(pathName);
-	var localhostPath = curWwwPath.substring(0, pos);
+	var localhostPath = window.document.location.hostname;
 	var clientPort = window.document.getElementById("cbid.baidupcs-web.config.port").value
-	var url = localhostPath + ":" + clientPort;
+	var url ="http://"  +   localhostPath + ":" + clientPort;
 	window.open(url)
 };
 //]]>

--- a/package/lean/luci-app-baidupcs-web/root/etc/init.d/baidupcs-web
+++ b/package/lean/luci-app-baidupcs-web/root/etc/init.d/baidupcs-web
@@ -12,7 +12,6 @@ max_download_load="$(uci -q get baidupcs-web.config.max_download_load || echo '1
 max_parallel="$(uci -q get baidupcs-web.config.max_parallel || echo '8')"
 
 start() {
-	stop
 	[ "$enabled" == "1" ] || exit 0
 	mkdir -p "${download_dir}"
 	baidupcs-web config set                         \

--- a/package/lean/luci-app-verysync/luasrc/view/verysync/verysync_status.htm
+++ b/package/lean/luci-app-verysync/luasrc/view/verysync/verysync_status.htm
@@ -15,12 +15,9 @@ XHR.poll(3, '<%=url([[admin]], [[nas]], [[verysync]], [[status]])%>', null,
 );
 
 function openClient() {
-	var curWwwPath = window.document.location.href;
-	var pathName = window.document.location.pathname;
-	var pos = curWwwPath.indexOf(pathName);
-	var localhostPath = curWwwPath.substring(0, pos);
+	var localhostPath = window.document.location.hostname;
 	var clientPort = window.document.getElementById("cbid.verysync.config.port").value
-	var url = localhostPath + ":" + clientPort;
+	var url = "http://"  +  localhostPath  + ":" + clientPort;
 	window.open(url)
 };
 //]]>

--- a/package/lean/luci-app-verysync/root/etc/init.d/verysync
+++ b/package/lean/luci-app-verysync/root/etc/init.d/verysync
@@ -3,16 +3,16 @@
 START=50
 STOP=10
 
+enabled="$(uci get verysync.config.enabled)"
+port="$(uci get verysync.config.port)"
+profile="$(uci get verysync.config.profile)"
+
 start() {
-	local enabled="$(uci get verysync.config.enabled)"
-	local port="$(uci get verysync.config.port)"
-	local profile="$(uci get verysync.config.profile)"
-	stop
 	[ "${enabled}" == "1" ] || exit 0
 	export HOME="/root/"
 	verysync -gui-address="0.0.0.0:${port}" -logfile="/var/log/verysync.log" -home="${profile}" -no-browser >/dev/null 2>&1 &
 }
 
 stop() {
-	kill -9 `pgrep verysync` >/dev/null 2>&1
+	killall verysync >/dev/null 2>&1
 }


### PR DESCRIPTION
修复verysync，baidupcs-web不能启动，点击按钮不能打开控制台窗口