### PR TITLE
rockchip:Fix doornet2 device tree

### DIFF
--- a/package/boot/uboot-rockchip/patches/105-rockchip-rk3399-Add-support-for-EmbedFire-DoorNet2.patch
+++ b/package/boot/uboot-rockchip/patches/105-rockchip-rk3399-Add-support-for-EmbedFire-DoorNet2.patch
@@ -10,7 +10,7 @@
  	rk3399-firefly.dtb \
 --- /dev/null
 +++ b/arch/arm/dts/rk3399-doornet2-u-boot.dtsi
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,25 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Copyright (C) 2019 Jagan Teki <jagan@amarulasolutions.com>
@@ -22,8 +22,13 @@
 +#include "rk3399-sdram-ddr3-1866.dtsi"
 +
 +/{
++	aliases {
++		mmc0 = &sdmmc;
++		mmc1 = &sdhci;
++	};
++
 +	chosen {
-+		u-boot,spl-boot-order = "same-as-spl", &sdhci, &sdmmc;
++		u-boot,spl-boot-order = "same-as-spl", &sdmmc, &sdhci;
 +	};
 +};
 +

--- a/target/linux/rockchip/patches-5.10/205-rockchip-rk3399-Add-support-for-EmbedFire-DoorNet2.patch
+++ b/target/linux/rockchip/patches-5.10/205-rockchip-rk3399-Add-support-for-EmbedFire-DoorNet2.patch
@@ -128,7 +128,7 @@
 +
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
-@@ -0,0 +1,655 @@
+@@ -0,0 +1,637 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +
 +/dts-v1/;
@@ -269,30 +269,14 @@
 +	clock_in_out = "input";
 +	phy-supply = <&vcc3v3_s3>;
 +	phy-mode = "rgmii";
-+	phy-handle = <&rtl8211f>;
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&rgmii_pins>;
-+	snps,aal;
-+	tx_delay = <0x37>;
-+	rx_delay = <0x11>;
++	snps,reset-gpio = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
++	snps,reset-active-low;
++	snps,reset-delays-us = <0 100000 50000>;
++	tx_delay = <0x13>;
++	rx_delay = <0x0e>;
 +	status = "okay";
-+	
-+	mdio {
-+		compatible = "snps,dwmac-mdio";
-+		#address-cells = <1>;
-+		#size-cells = <0>;
-+
-+		rtl8211f: ethernet-phy@1 {
-+			compatible = "ethernet-phy-id001c.c916",
-+				     "ethernet-phy-ieee802.3-c22";			
-+			reg = <0>;
-+			pinctrl-0 = <&eth_phy_reset_pin>;
-+			pinctrl-names = "default";
-+			reset-assert-us = <10000>;
-+			reset-deassert-us = <50000>;
-+			reset-gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
-+		};
-+	};
 +};
 +
 +&gpu {
@@ -672,10 +656,8 @@
 +
 +&sdhci {
 +	bus-width = <8>;
-+	supports-emmc;
-+	assigned-clock-rates = <150000000>;
-+	mmc-hs400-1_8v;
-+	mmc-hs400-enhanced-strobe;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
 +	non-removable;
 +	status = "okay";
 +};

--- a/target/linux/rockchip/patches-5.10/992-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch
+++ b/target/linux/rockchip/patches-5.10/992-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch
@@ -180,3 +180,14 @@ Co-authored-by: gzelvis <gzelvis@gmail.com>
  
  / {
  	chosen {
+--- a/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
+@@ -3,7 +3,7 @@
+ /dts-v1/;
+ #include <dt-bindings/input/linux-event-codes.h>
+ #include "rk3399.dtsi"
+-#include "rk3399-opp.dtsi"
++#include "rk3399-nanopi4-opp.dtsi"
+ 
+ / {
+ 	chosen {

--- a/target/linux/rockchip/patches-5.4/205-rockchip-rk3399-Add-support-for-EmbedFire-DoorNet2.patch
+++ b/target/linux/rockchip/patches-5.4/205-rockchip-rk3399-Add-support-for-EmbedFire-DoorNet2.patch
@@ -128,7 +128,7 @@
 +
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
-@@ -0,0 +1,655 @@
+@@ -0,0 +1,637 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +
 +/dts-v1/;
@@ -269,30 +269,14 @@
 +	clock_in_out = "input";
 +	phy-supply = <&vcc3v3_s3>;
 +	phy-mode = "rgmii";
-+	phy-handle = <&rtl8211f>;
 +	pinctrl-names = "default";
 +	pinctrl-0 = <&rgmii_pins>;
-+	snps,aal;
-+	tx_delay = <0x37>;
-+	rx_delay = <0x11>;
++	snps,reset-gpio = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
++	snps,reset-active-low;
++	snps,reset-delays-us = <0 100000 50000>;
++	tx_delay = <0x13>;
++	rx_delay = <0x0e>;
 +	status = "okay";
-+	
-+	mdio {
-+		compatible = "snps,dwmac-mdio";
-+		#address-cells = <1>;
-+		#size-cells = <0>;
-+
-+		rtl8211f: ethernet-phy@1 {
-+			compatible = "ethernet-phy-id001c.c916",
-+				     "ethernet-phy-ieee802.3-c22";			
-+			reg = <0>;
-+			pinctrl-0 = <&eth_phy_reset_pin>;
-+			pinctrl-names = "default";
-+			reset-assert-us = <10000>;
-+			reset-deassert-us = <50000>;
-+			reset-gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
-+		};
-+	};
 +};
 +
 +&gpu {
@@ -672,10 +656,8 @@
 +
 +&sdhci {
 +	bus-width = <8>;
-+	supports-emmc;
-+	assigned-clock-rates = <150000000>;
-+	mmc-hs400-1_8v;
-+	mmc-hs400-enhanced-strobe;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
 +	non-removable;
 +	status = "okay";
 +};
@@ -784,3 +766,29 @@
 +	status = "okay";
 +};
 +
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_mdio.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_mdio.c
+@@ -363,6 +363,11 @@ int stmmac_mdio_register(struct net_device *ndev)
+ 		goto bus_register_fail;
+ 	}
+
++		stmmac_mdio_write(new_bus,0,31,2627);
++		stmmac_mdio_write(new_bus,0,25,0x1801);
++		stmmac_mdio_write(new_bus,0,31,0);
++		stmmac_mdio_write(new_bus,0,0,0x8000);
++
+ 	if (priv->plat->phy_node || mdio_node)
+ 		goto bus_register_done;
+
+
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+@@ -2191,6 +2191,8 @@ static int stmmac_init_dma_engine(struct stmmac_priv *priv)
+ 	if (priv->extend_desc && (priv->mode == STMMAC_RING_MODE))
+ 		atds = 1;
+ 
++	msleep(1500);
++
+ 	ret = stmmac_reset(priv, priv->ioaddr);
+ 	if (ret) {
+ 		dev_err(priv->device, "Failed to reset the dma\n");

--- a/target/linux/rockchip/patches-5.4/992-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch
+++ b/target/linux/rockchip/patches-5.4/992-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch
@@ -180,3 +180,15 @@ Co-authored-by: gzelvis <gzelvis@gmail.com>
  
  / {
  	chosen {
+--- a/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
+@@ -3,7 +3,7 @@
+ /dts-v1/;
+ #include <dt-bindings/input/linux-event-codes.h>
+ #include "rk3399.dtsi"
+-#include "rk3399-opp.dtsi"
++#include "rk3399-nanopi4-opp.dtsi"
+ 
+ / {
+ 	chosen {
+  


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
u-boot:
Modify the startup method of doornet2: change sd to priority startup, which is convenient for repairing emmc; I think that changing sd to start first is to facilitate the repair of emmc booting to sd in the event of a crash, re-destructing emmc partitions and creating new partitions, and burning the dd command into it.
phy:
According to the manufacturer's board Ethernet, it is recommended to use two timing modes: one is provided by Rockchip by default, and the other is to add 25M timing to solve the self-adaptation problem:The actual test is not affected by other r4s devices,The stmmac_main.c power-on reset time for doornet2 phy is 1.5 seconds.
emmc:
According to the actual test emmc read and write performance, hs400 and hs200 are the same, but rk3399 supports hs400 and 200 modes, I think it is safer to reduce hs200.
The above information has been expressed in detail, if there is any problem, it can be corrected, thank you!