### PR TITLE
kmod-drm-vc4:fix drm-vc4 missing dependencies

### DIFF
--- a/target/linux/bcm27xx/modules/video.mk
+++ b/target/linux/bcm27xx/modules/video.mk
@@ -6,7 +6,7 @@ define KernelPackage/camera-bcm2835
   TITLE:=BCM2835 Camera
   KCONFIG:= \
     CONFIG_VIDEO_BCM2835 \
-    CONFIG_VIDEO_BCM2835_MMAL \
+    CONFIG_VIDEO_BCM2835_MMAL \
     CONFIG_VIDEO_BCM2835_UNICAM=n \
     CONFIG_VIDEO_ISP_BCM2835=n
   FILES:= \
@@ -21,36 +21,6 @@ define KernelPackage/camera-bcm2835/description
 endef
 
 $(eval $(call KernelPackage,camera-bcm2835))
-
-
-define KernelPackage/drm-vc4
-  SUBMENU:=$(VIDEO_MENU)
-  TITLE:=Broadcom VC4 Graphics
-  DEPENDS:= \
-    @TARGET_bcm27xx +kmod-drm \
-    +kmod-sound-core \
-    +kmod-sound-soc-core
-  KCONFIG:= \
-    CONFIG_DRM_VC4 \
-    CONFIG_DRM_VC4_HDMI_CEC=y \
-    CONFIG_DRM_GUD=n \
-    CONFIG_DRM_V3D=n \
-    CONFIG_DRM_TVE200=n
-  FILES:= \
-    $(LINUX_DIR)/drivers/gpu/drm/vc4/vc4.ko \
-    $(LINUX_DIR)/drivers/gpu/drm/drm_kms_helper.ko \
-    $(LINUX_DIR)/drivers/media/cec/cec.ko@lt5.10 \
-    $(LINUX_DIR)/drivers/media/cec/core/cec.ko@ge5.10
-  AUTOLOAD:=$(call AutoProbe,vc4)
-endef
-
-define KernelPackage/drm-vc4/description
-  Direct Rendering Manager (DRM) support for Broadcom VideoCore IV GPU
-  used in BCM2835, BCM2836 and BCM2837 SoCs (e.g. Raspberry Pi).
-endef
-
-$(eval $(call KernelPackage,drm-vc4))
-
 
 define KernelPackage/vc-sm-cma
   TITLE:=VideoCore Shared Memory (CMA) driver
@@ -85,3 +55,31 @@ define KernelPackage/vchiq-mmal-bcm2835/description
 endef
 
 $(eval $(call KernelPackage,vchiq-mmal-bcm2835))
+
+define KernelPackage/drm-vc4
+  SUBMENU:=$(VIDEO_MENU)
+  TITLE:=Broadcom VC4 Graphics
+  DEPENDS:= \
+    @TARGET_bcm27xx +kmod-drm \
+    +kmod-sound-core \
+    +kmod-sound-soc-core \
+    +kmod-drm-kms-helper 
+  KCONFIG:= \
+    CONFIG_DRM_VC4 \
+    CONFIG_DRM_VC4_HDMI_CEC=y \
+    CONFIG_DRM_GUD=n \
+    CONFIG_DRM_V3D=n \
+    CONFIG_DRM_TVE200=n
+  FILES:= \
+    $(LINUX_DIR)/drivers/gpu/drm/vc4/vc4.ko \
+    $(LINUX_DIR)/drivers/media/cec/cec.ko@lt5.10 \
+    $(LINUX_DIR)/drivers/media/cec/core/cec.ko@ge5.10
+  AUTOLOAD:=$(call AutoProbe,vc4)
+endef
+
+define KernelPackage/drm-vc4/description
+  Direct Rendering Manager (DRM) support for Broadcom VideoCore IV GPU
+  used in BCM2835, BCM2836 and BCM2837 SoCs (e.g. Raspberry Pi).
+endef
+
+$(eval $(call KernelPackage,drm-vc4))


### PR DESCRIPTION
This fix for following issue:

```
Package kmod-drm-vc4 is missing dependencies for the following libraries:
fb_sys_fops.ko
syscopyarea.ko
sysfillrect.ko
sysimgblt.ko
make[2]: *** [/openwrt/bin/targets/bcm27xx/bcm2711/packages/kmod-drm-vc4_5.4.175-1_aarch64_cortex-a72.ipk] Error 1
/openwrt/target/linux/bcm27xx/modules/video.mk:52: recipe for target '/openwrt/bin/targets/bcm27xx/bcm2711/packages/kmod-drm-vc4_5.4.175-1_aarch64_cortex-a72.ipk' failed
```

Taken from https://github.com/WYC-2020/lede/commit/f3b81b3e65fdcfc1e533ee72377aa16063908cf7

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
