### PR TITLE
rockchip:fix nanopi-r4s mac address

### DIFF
--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -48,7 +48,11 @@ rockchip_setup_macs()
 		lan_mac=$(macaddr_add "$wan_mac" +1)
 		;;
 	friendlyarm,nanopi-r4s)
-		wan_mac=$(get_mac_binary "/sys/bus/i2c/devices/2-0051/eeprom" 0xfa)
+		if [ -f /sys/bus/i2c/devices/2-0051/eeprom ]; then
+			wan_mac=$(get_mac_binary "/sys/bus/i2c/devices/2-0051/eeprom" 0xfa)
+		else
+			wan_mac=$(nanopi_r2s_generate_mac)
+		fi
 		lan_mac=$(macaddr_setbit_la "$wan_mac")
 		;;
 	xunlong,orangepi-r1-plus|\

--- a/target/linux/rockchip/patches-5.10/007-arm64-dts-rockchip-add-EEPROM-node-for-NanoPi-R4S.patch
+++ b/target/linux/rockchip/patches-5.10/007-arm64-dts-rockchip-add-EEPROM-node-for-NanoPi-R4S.patch
@@ -8,20 +8,15 @@ stores the MAC address.
 
 Signed-off-by: Tianling Shen <cnsztl@gmail.com>
 ---
- .../boot/dts/rockchip/rk3399-nanopi-r4s.dts    | 18 ++++++++++++++++++
- 1 file changed, 18 insertions(+)
+ .../boot/dts/rockchip/rk3399-nanopi-r4s.dts    | 13 +++++++++++++
+1 file changed, 13 insertions(+)
 
 --- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
-@@ -68,6 +68,24 @@
+@@ -75,6 +75,19 @@ &emmc_phy {
  	status = "disabled";
  };
  
-+&gmac {
-+	nvmem-cells = <&mac_address>;
-+	nvmem-cell-names = "mac-address";
-+};
-+
 +&i2c2 {
 +	eeprom@51 {
 +		compatible = "microchip,24c02", "atmel,24c02";

--- a/target/linux/rockchip/patches-5.15/007-arm64-dts-rockchip-add-EEPROM-node-for-NanoPi-R4S.patch
+++ b/target/linux/rockchip/patches-5.15/007-arm64-dts-rockchip-add-EEPROM-node-for-NanoPi-R4S.patch
@@ -8,20 +8,15 @@ stores the MAC address.
 
 Signed-off-by: Tianling Shen <cnsztl@gmail.com>
 ---
- .../boot/dts/rockchip/rk3399-nanopi-r4s.dts    | 18 ++++++++++++++++++
- 1 file changed, 18 insertions(+)
+ .../boot/dts/rockchip/rk3399-nanopi-r4s.dts    | 13 +++++++++++++
+1 file changed, 13 insertions(+)
 
 --- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
-@@ -68,6 +68,24 @@
+@@ -75,6 +75,19 @@ &emmc_phy {
  	status = "disabled";
  };
  
-+&gmac {
-+	nvmem-cells = <&mac_address>;
-+	nvmem-cell-names = "mac-address";
-+};
-+
 +&i2c2 {
 +	eeprom@51 {
 +		compatible = "microchip,24c02", "atmel,24c02";

--- a/target/linux/rockchip/patches-5.4/010-arm64-dts-rockchip-add-EEPROM-node-for-NanoPi-R4S.patch
+++ b/target/linux/rockchip/patches-5.4/010-arm64-dts-rockchip-add-EEPROM-node-for-NanoPi-R4S.patch
@@ -8,20 +8,15 @@ stores the MAC address.
 
 Signed-off-by: Tianling Shen <cnsztl@gmail.com>
 ---
- .../boot/dts/rockchip/rk3399-nanopi-r4s.dts    | 18 ++++++++++++++++++
- 1 file changed, 18 insertions(+)
+ .../boot/dts/rockchip/rk3399-nanopi-r4s.dts    | 13 +++++++++++++
+1 file changed, 13 insertions(+)
 
 --- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
-@@ -68,6 +68,24 @@
+@@ -75,6 +75,19 @@ &emmc_phy {
  	status = "disabled";
  };
  
-+&gmac {
-+	nvmem-cells = <&mac_address>;
-+	nvmem-cell-names = "mac-address";
-+};
-+
 +&i2c2 {
 +	eeprom@51 {
 +		compatible = "microchip,24c02", "atmel,24c02";


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
there will be a change in the next batch of r4s. The specifications are with or 
without eeprom chip. In order to consider the cost of the chip, they decided to 
remove the eeprom chip and reduce the price.
Today is update theme is optimized for with or without eeprom chips.
**if the r4s does not have an eeprom chip, the previous firmware 
cannot be used! have a greater impact on this**

remove the mandatory binding of the mac address in the patch. If it is 
not removed, the initialization will fail for the chip without EEPROM. 
It is recommended to remove the mandatory binding.

```
+&gmac {
+	nvmem-cells = <&mac_address>;
+	nvmem-cell-names = "mac-address";
+};
```

[02_network](https://github.com/coolsnowwolf/lede/commit/966d926746467e6c56b24a782779d10caf1a7207)
modify the script to store the correct method for obtaining 
the mac address: if there is no eeprom chip, the sd id will be 
used to randomly form the mac address. The basic test is 
as follows. . .

with eeprom chip:
![y (2)](https://user-images.githubusercontent.com/84753324/158024766-7470d24a-bf54-4f7e-9bf8-9cbf427e5352.png)

without eeprom chip:
![n (2)](https://user-images.githubusercontent.com/84753324/158024779-28853516-2000-4bab-8ca0-a4c5067742d3.png)

the above test, the previous chip is not affected. This update is only for those without chip optimization
please comment if you have any questions, thank you