### PR TITLE
automount: 5.4 kernel returns antfs-mount

### DIFF
--- a/package/lean/automount/Makefile
+++ b/package/lean/automount/Makefile
@@ -18,7 +18,8 @@ define Package/automount
   TITLE:=Mount autoconfig hotplug script.
   MAINTAINER:=Lean
   DEPENDS:=+block-mount +kmod-fs-exfat +kmod-fs-ext4 +kmod-fs-vfat +libblkid \
-	+kmod-usb-storage +kmod-usb-storage-extras +!TARGET_ramips:kmod-usb-storage-uas +ntfs3-mount
+	+kmod-usb-storage +kmod-usb-storage-extras +!TARGET_ramips:kmod-usb-storage-uas \
+	+!LINUX_5_4:ntfs3-mount +LINUX_5_4:antfs-mount
 endef
 
 define Package/automount/description


### PR DESCRIPTION
Temporarily solve the problem that ntfs3-mount cannot mount large-capacity hard disks in the 5.4 kernel, and even if small-capacity can be mounted, it cannot be read or written.

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x ] 我知道
