### PR TITLE
ipq806x: fix Norton 518 switch interface definition

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -73,7 +73,7 @@ tplink,c2600)
 norton,core-518)
 	hw_mac_addr=$(mtd_get_mac_ascii_mmc 0:APPSBLENV ethaddr)
 	ucidef_add_switch "switch0" \
-		"2:lan" "3:lan" "4:lan" "6@eth1" "5:wan" "0@eth0"
+		"2:lan" "3:lan" "4:lan" "6u@eth1" "5:wan" "0u@eth0"
 	ucidef_set_interface_macaddr "wan" "$hw_mac_addr"
 	ucidef_set_interface_macaddr "lan" "$(macaddr_add $hw_mac_addr 1)"
 	;;


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

Fix that the Ethernet interface function cannot work normally due to [5c40fcd](https://github.com/coolsnowwolf/lede/commit/5c40fcd80ee9774b483a1c6babd1025ab0108e61).
