### PR TITLE
libmnl: update to 1.0.5

### DIFF
--- a/package/libs/libmnl/Makefile
+++ b/package/libs/libmnl/Makefile
@@ -8,14 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmnl
-PKG_VERSION:=1.0.4
-PKG_RELEASE:=2
+PKG_VERSION:=1.0.5
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \
 	http://www.netfilter.org/projects/libmnl/files \
 	ftp://ftp.netfilter.org/pub/libmnl
-PKG_HASH:=171f89699f286a5854b72b91d06e8f8e3683064c5901fb09d954a9ab6f551f81
+PKG_HASH:=274b9b919ef3152bfb3da3a13c950dd60d6e2bcd54230ffeca298d03b40d0525
 
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 


### PR DESCRIPTION
Changes:

Duncan Roe (5):
      nlmsg: Fix a missing doxygen section trailer
      build: doc: "make" builds & installs a full set of man pages
      build: doc: get rid of the need for manual updating of Makefile
      build: If doxygen is not available, be sure to report "doxygen: no" to ./configure
      src: doc: Fix messed-up Netlink message batch diagram

Fernando Fernandez Mancera (1):
      src: fix doxygen function documentation

Florian Westphal (1):
      libmnl: zero attribute padding

Guillaume Nault (1):
      callback: mark cb_ctl_array 'const' in mnl_cb_run2()

Kylie McClain (1):
      examples: nfct-daemon: Fix test building on musl libc

Laura Garcia Liebana (4):
      examples: add arp cache dump example
      examples: fix neigh max attributes
      examples: fix print line format
      examples: reduce LOCs during neigh attributes validation

Pablo Neira Ayuso (3):
      doxygen: remove EXPORT_SYMBOL from the output
      include: add MNL_SOCKET_DUMP_SIZE definition
      build: libmnl 1.0.5 release

Petr Vorel (1):
      examples: Add rtnl-addr-add.c

Stephen Hemminger (1):
      examples: rtnl-addr-dump: fix typo

igo95862 (1):
      doxygen: Fixed link to the git source tree on the website.

Signed-off-by: Nick Hainke <vincent@systemli.org>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
