### PR TITLE
ucode: update to latest Git HEAD

### DIFF
--- a/package/utils/ucode/Makefile
+++ b/package/utils/ucode/Makefile
@@ -12,13 +12,13 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://github.com/jow-/ucode.git
-PKG_SOURCE_DATE:=2022-02-11
-PKG_SOURCE_VERSION:=a29bad9454edcc285f7f37410b6822affede44d1
-PKG_MIRROR_HASH:=eaba0f12c469ef82b772a64f8763e8855dbba81551a78d05f547c0922a7dacad
+PKG_SOURCE_DATE:=2022-04-07
+PKG_SOURCE_VERSION:=33f1e0b0926e973fb5ae445e9a995848762143bb
+PKG_MIRROR_HASH:=e419678244c5402c739e3a200d6d1d7cd6989a711c73744bc68b2d5b76bae33a
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_LICENSE:=ISC
 
-PKG_ABI_VERSION:=20220206
+PKG_ABI_VERSION:=20220322
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
@@ -152,7 +152,7 @@ endef
 
 define Package/ucode/install
 	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ucode $(1)/usr/bin/ucode
+	$(CP) $(PKG_INSTALL_DIR)/usr/bin/u* $(1)/usr/bin/
 endef
 
 define Package/libucode/install


### PR DESCRIPTION
33f1e0b treewide: move json-c compat shims into internal header file
e0e9431 vm: move unhandled exception reporting out of `uc_vm_execute_chunk()`
2b59140 vm: fix callframe double free on unhanded exceptions
7d7e950 main: abort when failing to load a preload library
1032a67 lib: let `json()` accept input objects implementing `read()` method
5ee68d5 fs: implement `fs.readfile()` and `fs.writefile()`
df6b861 ci: debian: change path before attempting to invoke Git operations
dfaf05a ci: debian: automatically update changelog from Git tag
34f3c45 ci: fix YAML syntax of Debian workflow
e956bcf fs: fix off-by-one in fs.dirname() function
6fc4b6c .gitignore: fix overmatching patterns, blacklist cram .venv
7c2e082 build: remove legacy json-c check
77942af build: add polyfills for older libjson-c versions
0b4aaa3 CI: build Debian package
f404285 debian: Add package definition
a37f654 types: fix escape sequence encoding of high byte values in JSON strings
aae5312 Update README.md
8134e25 build: fix symlink install target
87c7296 treewide: replace some leftover "utpl" occurrences, update .gitignore
7d27ad5 build: only stage ucc symlink if compile support is enabled
171402f lib: add date and time related functions
8b5dc60 lib: provide API function to obtain stdlib function implementations
eb0d2f1 main: turn ucode into multicall executable
28ee7e1 uloop: add support for tasks
753dea9 CI: build on macOS
668c5c0 lib: add argument position support (`%m$`) to `sprintf()` and `printf()`
ab46fdf treewide: remove legacy json-c include directives
b8f49b1 tests: 21_regex_literals: generalize syntax error test case
fd2e5e7 tests: 16_sort: fix logic flaw exposed on OS X
2c71bf2 tests: run_tests.sh: pass dummy value to `-T` flag
55c4a90 lib: disallow zero padding for %s formats
0d05cb5 tests: run_tests.sh: use greadlink if available
271e520 resolv: make OS X compatible
d13c320 fs: avoid Linux specific sys/sysmacros.h include on OS X
33397a3 uloop: use execvp() on OS X
bafdc8f lib: add naive sigtimedwait() stub for OS X
ada1585 build: consolidate CMakeLists.txt and cover OS X deviations
befbb69 include: add OS X compatible endian.h header
49838a8 include: rename include guards to avoid clashes with system headers
91f65de nl80211: add missing attributes and correct some attribute flags
b4a1fd5 lib: adjust require(), render() and include() raw mode semantics
4618807 main: rework CLI frontend
73dcd78 lib: fix potential integer underflow on empty render output
c402551 vm: fix crash on object literals with non-string computed properties
efe8a02 syntax: support add new operators
078d686 ubus: add event support
6c66c83 ubus: refactor error and argument handling
1cb04f9 ubus: add object publishing, notify and subscribe support
0e85974 uloop: clear errno before integer conversion attempts
05bd7ed types: treat resource type prototypes as GC roots
a2a26ca lib: introduce uloop binding
6b6d01f vm: release this context on exception in managed method call
1af23a9 tests: fix proto() testcase
4ce69a8 fs: implement access(), mkstemp(), file.flush() and proc.flush()

Signed-off-by: Jo-Philipp Wich <jo@mein.io>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
