### PR TITLE
wolfssl: bump to 5.2.0

### DIFF
--- a/package/libs/wolfssl/Makefile
+++ b/package/libs/wolfssl/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wolfssl
-PKG_VERSION:=5.1.1-stable
+PKG_VERSION:=5.2.0-stable
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/wolfSSL/wolfssl/archive/v$(PKG_VERSION)
-PKG_HASH:=d3e0544dbe7e9587c0f6538cdc671b6492663bb7a4281819538abe6c99cdbd92
+PKG_HASH:=409b4646c5f54f642de0e9f3544c3b83de7238134f5b1ff93fb44527bf119d05
 
 PKG_FIXUP:=libtool libtool-abiver
 PKG_INSTALL:=1

--- a/package/libs/wolfssl/patches/100-disable-hardening-check.patch
+++ b/package/libs/wolfssl/patches/100-disable-hardening-check.patch
@@ -1,6 +1,6 @@
 --- a/wolfssl/wolfcrypt/settings.h
 +++ b/wolfssl/wolfcrypt/settings.h
-@@ -2346,7 +2346,7 @@ extern void uITRON4_free(void *p) ;
+@@ -2338,7 +2338,7 @@ extern void uITRON4_free(void *p) ;
  #endif
  
  /* warning for not using harden build options (default with ./configure) */

--- a/package/libs/wolfssl/patches/200-ecc-rng.patch
+++ b/package/libs/wolfssl/patches/200-ecc-rng.patch
@@ -11,7 +11,7 @@ RNG regardless of the built settings for wolfssl.
 
 --- a/wolfcrypt/src/ecc.c
 +++ b/wolfcrypt/src/ecc.c
-@@ -11647,21 +11647,21 @@ void wc_ecc_fp_free(void)
+@@ -11655,21 +11655,21 @@ void wc_ecc_fp_free(void)
  
  #endif /* FP_ECC */
  
@@ -37,7 +37,7 @@ RNG regardless of the built settings for wolfssl.
  
 --- a/wolfssl/wolfcrypt/ecc.h
 +++ b/wolfssl/wolfcrypt/ecc.h
-@@ -647,10 +647,8 @@ WOLFSSL_API
+@@ -650,10 +650,8 @@ WOLFSSL_API
  void wc_ecc_fp_free(void);
  WOLFSSL_LOCAL
  void wc_ecc_fp_init(void);

--- a/package/libs/wolfssl/patches/300-fix-SSL_get_verify_result-regression.patch
+++ b/package/libs/wolfssl/patches/300-fix-SSL_get_verify_result-regression.patch
@@ -1,4 +1,4 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 87e43dd63ba429297e439f2dfd1ee8b45981e18b Mon Sep 17 00:00:00 2001
 From: Juliusz Sosinowicz <juliusz@wolfssl.com>
 Date: Sat, 12 Feb 2022 00:34:24 +0100
 Subject: [PATCH] Reported in ZD13631
@@ -10,11 +10,9 @@ References: https://github.com/wolfSSL/wolfssl/issues/4879
  src/internal.c | 3 +++
  1 file changed, 3 insertions(+)
 
-diff --git a/src/internal.c b/src/internal.c
-index 0dded42a76c4..f5814d30607c 100644
 --- a/src/internal.c
 +++ b/src/internal.c
-@@ -12372,6 +12372,9 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
+@@ -12342,6 +12342,9 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte*
                              }
  
                              ret = 0; /* clear errors and continue */


### PR DESCRIPTION
Fixes two high-severity vulnerabilities:

- CVE-2022-25640: A TLS v1.3 server who requires mutual authentication
  can be bypassed.  If a malicious client does not send the
  certificate_verify message a client can connect without presenting a
  certificate even if the server requires one.

- CVE-2022-25638: A TLS v1.3 client attempting to authenticate a TLS
  v1.3 server can have its certificate heck bypassed. If the sig_algo in
  the certificate_verify message is different than the certificate
  message checking may be bypassed.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
