### PR TITLE
fix mtk mt7603e and mt7615d driver build error for kernel >= 5.15

### DIFF
--- a/package/lean/mt/drivers/mt7603e/src/mt7603_wifi/os/linux/rt_linux.c
+++ b/package/lean/mt/drivers/mt7603e/src/mt7603_wifi/os/linux/rt_linux.c
@@ -914,10 +914,14 @@ static inline void __RtmpOSFSInfoChange(OS_FS_INFO * pOSFSInfo, BOOLEAN bSet)
 
 #endif
 #endif
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 		pOSFSInfo->fs = get_fs();
 		set_fs(KERNEL_DS);
+#endif
 	} else {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 		set_fs(pOSFSInfo->fs);
+#endif
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,29)
 		current->fsuid = pOSFSInfo->fsuid;
 		current->fsgid = pOSFSInfo->fsgid;
@@ -1936,8 +1940,10 @@ VOID RtmpDrvAllMacPrint(
 	if (!msg)
 		return;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 	orig_fs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 
 	/* open file */
 	file_w = filp_open(fileName, O_WRONLY | O_CREAT, 0);
@@ -1965,7 +1971,9 @@ VOID RtmpDrvAllMacPrint(
 		}
 		filp_close(file_w, NULL);
 	}
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 	set_fs(orig_fs);
+#endif
 	os_free_mem(NULL, msg);
 }
 
@@ -1987,8 +1995,10 @@ VOID RtmpDrvAllE2PPrint(
 	if (!msg)
 		return;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 	orig_fs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 
 	/* open file */
 	file_w = filp_open(fileName, O_WRONLY | O_CREAT, 0);
@@ -2017,7 +2027,9 @@ VOID RtmpDrvAllE2PPrint(
 		}
 		filp_close(file_w, NULL);
 	}
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 	set_fs(orig_fs);
+#endif
 	os_free_mem(NULL, msg);
 }
 
@@ -2031,8 +2043,10 @@ VOID RtmpDrvAllRFPrint(
 	RTMP_STRING *fileName = "RFDump.txt";
 	mm_segment_t orig_fs;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 	orig_fs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 
 	/* open file */
 	file_w = filp_open(fileName, O_WRONLY | O_CREAT, 0);
@@ -2048,7 +2062,9 @@ VOID RtmpDrvAllRFPrint(
 		}
 		filp_close(file_w, NULL);
 	}
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 	set_fs(orig_fs);
+#endif
 }
 
 

--- a/package/lean/mt/drivers/mt7603e/src/mt7603_wifi_ap/Kconfig
+++ b/package/lean/mt/drivers/mt7603e/src/mt7603_wifi_ap/Kconfig
@@ -154,8 +154,8 @@ config MT7603E_SECURITY_IMPROVEMENT_SUPPORT
 	bool "WPA2 security improvement support"
 	depends on MT7603E_RLT_AP_SUPPORT
 	default n
-	---help---
-	  WPA2 security improvement support
+#	---help---
+#	  WPA2 security improvement support
 
 
 config MT7603E_WPA3_SUPPORT
@@ -164,20 +164,20 @@ config MT7603E_WPA3_SUPPORT
 	select MT7603E_SECURITY_IMPROVEMENT_SUPPORT
 	depends on MT7603E_RLT_AP_SUPPORT
 	default n
-	---help---
-	  WPA3 support
+#	---help---
+#	  WPA3 support
 
 config MT7603E_OWE_SUPPORT
 	bool "Enhanced Open/OWE support"
 	select MT7603E_DOT11W_PMF_SUPPORT
 	depends on MT7603E_RLT_AP_SUPPORT
 	default n
-	---help---
-	  Enhanced Open/OWE support
+#	---help---
+#	  Enhanced Open/OWE support
 
 config MT7603E_NEW_BW2040_COEXIST_SUPPORT
 	bool "New BW20/40 Coexist support"
 	depends on MT7603E_RLT_AP_SUPPORT
 	default y
-	---help---
-	  Both Beacon and Radio fallback to BW20 for anti-interference
+#	---help---
+#	  Both Beacon and Radio fallback to BW20 for anti-interference

--- a/package/lean/mt/drivers/mt7615d/src/mt_wifi/os/linux/rt_linux.c
+++ b/package/lean/mt/drivers/mt7615d/src/mt_wifi/os/linux/rt_linux.c
@@ -865,10 +865,14 @@ static inline void __RtmpOSFSInfoChange(OS_FS_INFO *pOSFSInfo, BOOLEAN bSet)
 		/* pOSFSInfo->fsgid = (int)(current_fsgid()); */
 #endif
 #endif
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0))
 		pOSFSInfo->fs = get_fs();
 		set_fs(KERNEL_DS);
+#endif
 	} else {
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0))
 		set_fs(pOSFSInfo->fs);
+#endif
 #if (KERNEL_VERSION(2, 6, 29) > LINUX_VERSION_CODE)
 		current->fsuid = pOSFSInfo->fsuid;
 		current->fsgid = pOSFSInfo->fsgid;
@@ -1925,8 +1929,10 @@ VOID RtmpDrvAllMacPrint(
 	if (!msg)
 		return;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 	orig_fs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 	/* open file */
 	file_w = filp_open(fileName, O_WRONLY | O_CREAT, 0);
 
@@ -1968,7 +1974,9 @@ VOID RtmpDrvAllMacPrint(
 		filp_close(file_w, NULL);
 	}
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 	set_fs(orig_fs);
+#endif
 	os_free_mem(msg);
 }
 
@@ -1991,8 +1999,10 @@ VOID RtmpDrvAllE2PPrint(
 	if (!msg)
 		return;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 	orig_fs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 	/* open file */
 	file_w = filp_open(fileName, O_WRONLY | O_CREAT, 0);
 
@@ -2035,7 +2045,9 @@ VOID RtmpDrvAllE2PPrint(
 		filp_close(file_w, NULL);
 	}
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 	set_fs(orig_fs);
+#endif
 	os_free_mem(msg);
 }
 
@@ -2049,8 +2061,10 @@ VOID RtmpDrvAllRFPrint(
 	RTMP_STRING *fileName = "RFDump.txt";
 	mm_segment_t orig_fs;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 	orig_fs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 	/* open file */
 	file_w = filp_open(fileName, O_WRONLY | O_CREAT, 0);
 
@@ -2081,7 +2095,9 @@ VOID RtmpDrvAllRFPrint(
 		filp_close(file_w, NULL);
 	}
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 	set_fs(orig_fs);
+#endif
 }
 
 


### PR DESCRIPTION
当mt7603e和mt7615d驱动程序在内核版本>=5.15时，不再使用set_fs和get_fs。

对于新版的内核已经删除了get_fs和set_fs，所以驱动会编译失败。
在mt7603e和mt7615d驱动程序中，`kernel_read`和`kernel_write`用于较新的内核版本，这两个函数不需要get_fs和set_fs，所以可以安全地在编译高版本内核时删除这些调用。

此变更在我自己的红米ac2100上稳定运行，但仍未经过充分的测试，希望请各位大佬测试验证，确认无误后再合入。

see https://github.com/coolsnowwolf/lede/issues/9170

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
