### PR TITLE
rockchip:the r4s frequency is no longer used by doornet2

### DIFF
--- a/package/network/services/dnsmasq/files/dhcp.conf
+++ b/package/network/services/dnsmasq/files/dhcp.conf
@@ -24,9 +24,10 @@ config dnsmasq
 
 config dhcp lan
 	option interface	lan
-	option start 	100
-	option limit	150
-	option leasetime	12h
+	option start 	6
+	option limit	64
+	option leasetime	24h
+	option force	1
 
 config dhcp wan
 	option interface	wan

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -818,7 +818,7 @@ dnsmasq_ipset_add() {
 dnsmasq_start()
 {
 	local cfg="$1"
-	local disabled user_dhcpscript
+	local disabled user_dhcpscript logfacility
 	local resolvfile resolvdir localuse=0
 
 	config_get_bool disabled "$cfg" disabled 0
@@ -935,9 +935,7 @@ dnsmasq_start()
 	append_bool "$cfg" filter_unknown "--filter-unknown"
 
 	append_parm "$cfg" logfacility "--log-facility"
-	
-	append_parm "$cfg" mini_ttl "--min-ttl"
-
+	config_get logfacility "$cfg" "logfacility"
 	append_parm "$cfg" cachesize "--cache-size"
 	append_parm "$cfg" dnsforwardmax "--dns-forward-max"
 	append_parm "$cfg" port "--port"
@@ -976,7 +974,14 @@ dnsmasq_start()
 	config_list_foreach "$cfg" "addnhosts" append_addnhosts
 	config_list_foreach "$cfg" "bogusnxdomain" append_bogusnxdomain
 	append_parm "$cfg" "leasefile" "--dhcp-leasefile" "/tmp/dhcp.leases"
-	append_parm "$cfg" "serversfile" "--servers-file"
+
+	local serversfile
+	config_get serversfile "$cfg" "serversfile"
+	[ -n "$serversfile" ] && {
+		xappend "--servers-file=$serversfile"
+		append EXTRA_MOUNT "$serversfile"
+	}
+
 	append_parm "$cfg" "tftp_root" "--tftp-root"
 	append_parm "$cfg" "dhcp_boot" "--dhcp-boot"
 	append_parm "$cfg" "local_ttl" "--local-ttl"
@@ -1160,12 +1165,21 @@ dnsmasq_start()
 	[ -n "$user_dhcpscript" ] && procd_set_param env USER_DHCPSCRIPT="$user_dhcpscript"
 	procd_set_param respawn
 
+	local instance_ifc instance_netdev
+	config_get instance_ifc "$cfg" interface
+	[ -n "$instance_ifc" ] && network_get_device instance_netdev "$instance_ifc" &&
+		[ -n "$instance_netdev" ] && procd_set_param netdev $instance_netdev
+
 	procd_add_jail dnsmasq ubus log
 	procd_add_jail_mount $CONFIGFILE $DHCPBOGUSHOSTNAMEFILE $DHCPSCRIPT $DHCPSCRIPT_DEPENDS
 	procd_add_jail_mount $EXTRA_MOUNT $RFC6761FILE $TRUSTANCHORSFILE
 	procd_add_jail_mount $dnsmasqconffile $dnsmasqconfdir $resolvdir $user_dhcpscript
 	procd_add_jail_mount /etc/passwd /etc/group /etc/TZ /etc/hosts /etc/ethers
 	procd_add_jail_mount_rw /var/run/dnsmasq/ $leasefile
+	case "$logfacility" in */*)
+		[ ! -e "$logfacility" ] && touch "$logfacility"
+		procd_add_jail_mount_rw "$logfacility"
+	esac
 
 	procd_close_instance
 }

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -18,7 +18,7 @@ define Device/embedfire_doornet2
   SOC := rk3399
   UBOOT_DEVICE_NAME := doornet2-rk3399
   IMAGE/sysupgrade.img.gz := boot-common | boot-script nanopi-r4s | pine64-bin | gzip | append-metadata
-  DEVICE_PACKAGES := kmod-r8169 kmod-rtl8821cu -urngd
+  DEVICE_PACKAGES := kmod-r8168 -urngd
 endef
 TARGET_DEVICES += embedfire_doornet2
 

--- a/target/linux/rockchip/patches-5.10/992-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch
+++ b/target/linux/rockchip/patches-5.10/992-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch
@@ -180,14 +180,3 @@ Co-authored-by: gzelvis <gzelvis@gmail.com>
  
  / {
  	chosen {
---- a/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
-@@ -3,7 +3,7 @@
- /dts-v1/;
- #include <dt-bindings/input/linux-event-codes.h>
- #include "rk3399.dtsi"
--#include "rk3399-opp.dtsi"
-+#include "rk3399-nanopi4-opp.dtsi"
- 
- / {
- 	chosen {

--- a/target/linux/rockchip/patches-5.10/993-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-DoorNet2.patch
+++ b/target/linux/rockchip/patches-5.10/993-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-DoorNet2.patch
@@ -1,0 +1,468 @@
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-doornet2-opp.dtsi
+@@ -0,0 +1,328 @@
++#include "rk3399-sched-energy.dtsi"
++
++/ {
++	cluster0_opp: opp-table0 {
++		compatible = "operating-points-v2";
++		opp-shared;
++
++		rockchip,temp-hysteresis = <5000>;
++		rockchip,low-temp = <0>;
++		rockchip,low-temp-min-volt = <900000>;
++
++		nvmem-cells = <&cpul_leakage>;
++		nvmem-cell-names = "cpu_leakage";
++
++		rockchip,pvtm-voltage-sel = <
++			0        143500   0
++			143501   148500   1
++			148501   152000   2
++			152001   999999   3
++		>;
++		rockchip,pvtm-freq = <408000>;
++		rockchip,pvtm-volt = <1000000>;
++		rockchip,pvtm-ch = <0 0>;
++		rockchip,pvtm-sample-time = <1000>;
++		rockchip,pvtm-number = <10>;
++		rockchip,pvtm-error = <1000>;
++		rockchip,pvtm-ref-temp = <41>;
++		rockchip,pvtm-temp-prop = <115 66>;
++		rockchip,thermal-zone = "soc-thermal";
++
++		opp-408000000 {
++			opp-hz = /bits/ 64 <408000000>;
++			opp-microvolt = <800000 800000 1250000>;
++			opp-microvolt-L0 = <800000 800000 1250000>;
++			opp-microvolt-L1 = <800000 800000 1250000>;
++			opp-microvolt-L2 = <800000 800000 1250000>;
++			opp-microvolt-L3 = <800000 800000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-600000000 {
++			opp-hz = /bits/ 64 <600000000>;
++			opp-microvolt = <800000 800000 1250000>;
++			opp-microvolt-L0 = <800000 800000 1250000>;
++			opp-microvolt-L1 = <800000 800000 1250000>;
++			opp-microvolt-L2 = <800000 800000 1250000>;
++			opp-microvolt-L3 = <800000 800000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-816000000 {
++			opp-hz = /bits/ 64 <816000000>;
++			opp-microvolt = <850000 850000 1250000>;
++			opp-microvolt-L0 = <850000 850000 1250000>;
++			opp-microvolt-L1 = <825000 825000 1250000>;
++			opp-microvolt-L2 = <800000 800000 1250000>;
++			opp-microvolt-L3 = <800000 800000 1250000>;
++			clock-latency-ns = <40000>;
++			opp-suspend;
++		};
++		opp-1008000000 {
++			opp-hz = /bits/ 64 <1008000000>;
++			opp-microvolt = <925000 925000 1250000>;
++			opp-microvolt-L0 = <925000 925000 1250000>;
++			opp-microvolt-L1 = <900000 900000 1250000>;
++			opp-microvolt-L2 = <875000 875000 1250000>;
++			opp-microvolt-L3 = <850000 850000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1200000000 {
++			opp-hz = /bits/ 64 <1200000000>;
++			opp-microvolt = <1000000 1000000 1250000>;
++			opp-microvolt-L0 = <1000000 1000000 1250000>;
++			opp-microvolt-L1 = <975000 975000 1250000>;
++			opp-microvolt-L2 = <950000 950000 1250000>;
++			opp-microvolt-L3 = <925000 925000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1416000000 {
++			opp-hz = /bits/ 64 <1416000000>;
++			opp-microvolt = <1175000 1175000 1250000>;
++			opp-microvolt-L0 = <1175000 1175000 1250000>;
++			opp-microvolt-L1 = <1100000 1100000 1250000>;
++			opp-microvolt-L2 = <1050000 1050000 1250000>;
++			opp-microvolt-L3 = <975000 975000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1608000000 {
++			opp-hz = /bits/ 64 <1608000000>;
++			opp-microvolt = <1200000 1200000 1250000>;
++			opp-microvolt-L0 = <1200000 1200000 1250000>;
++			opp-microvolt-L1 = <1175000 1175000 1250000>;
++			opp-microvolt-L2 = <1125000 1125000 1250000>;
++			opp-microvolt-L3 = <1100000 1100000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1800000000 {
++			opp-hz = /bits/ 64 <1800000000>;
++			opp-microvolt = <1250000 1250000 1250000>;
++			opp-microvolt-L0 = <1250000 1250000 1250000>;
++			opp-microvolt-L1 = <1200000 1200000 1250000>;
++			opp-microvolt-L2 = <1175000 1175000 1250000>;
++			opp-microvolt-L3 = <1125000 1125000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++	};
++
++	cluster1_opp: opp-table1 {
++		compatible = "operating-points-v2";
++		opp-shared;
++
++		rockchip,temp-hysteresis = <5000>;
++		rockchip,low-temp = <0>;
++		rockchip,low-temp-min-volt = <900000>;
++
++		nvmem-cells = <&cpub_leakage>;
++		nvmem-cell-names = "cpu_leakage";
++
++		rockchip,pvtm-voltage-sel = <
++			0        149000   0
++			149001   155000   1
++			155001   160000   2
++			160001   999999   3
++		>;
++		rockchip,pvtm-freq = <408000>;
++		rockchip,pvtm-volt = <1000000>;
++		rockchip,pvtm-ch = <1 0>;
++		rockchip,pvtm-sample-time = <1000>;
++		rockchip,pvtm-number = <10>;
++		rockchip,pvtm-error = <1000>;
++		rockchip,pvtm-ref-temp = <41>;
++		rockchip,pvtm-temp-prop = <71 35>;
++		rockchip,thermal-zone = "soc-thermal";
++
++		opp-408000000 {
++			opp-hz = /bits/ 64 <408000000>;
++			opp-microvolt = <800000 800000 1275000>;
++			opp-microvolt-L0 = <800000 800000 1275000>;
++			opp-microvolt-L1 = <800000 800000 1275000>;
++			opp-microvolt-L2 = <800000 800000 1275000>;
++			opp-microvolt-L3 = <800000 800000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-600000000 {
++			opp-hz = /bits/ 64 <600000000>;
++			opp-microvolt = <800000 800000 1275000>;
++			opp-microvolt-L0 = <800000 800000 1275000>;
++			opp-microvolt-L1 = <800000 800000 1275000>;
++			opp-microvolt-L2 = <800000 800000 1275000>;
++			opp-microvolt-L3 = <800000 800000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-816000000 {
++			opp-hz = /bits/ 64 <816000000>;
++			opp-microvolt = <825000 825000 1275000>;
++			opp-microvolt-L0 = <825000 825000 1275000>;
++			opp-microvolt-L1 = <825000 825000 1275000>;
++			opp-microvolt-L2 = <800000 800000 1275000>;
++			opp-microvolt-L3 = <800000 800000 1275000>;
++			clock-latency-ns = <40000>;
++			opp-suspend;
++		};
++		opp-1008000000 {
++			opp-hz = /bits/ 64 <1008000000>;
++			opp-microvolt = <875000 875000 1275000>;
++			opp-microvolt-L0 = <875000 875000 1275000>;
++			opp-microvolt-L1 = <850000 850000 1275000>;
++			opp-microvolt-L2 = <850000 850000 1275000>;
++			opp-microvolt-L3 = <850000 850000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1200000000 {
++			opp-hz = /bits/ 64 <1200000000>;
++			opp-microvolt = <950000 950000 1275000>;
++			opp-microvolt-L0 = <950000 950000 1275000>;
++			opp-microvolt-L1 = <925000 925000 1275000>;
++			opp-microvolt-L2 = <900000 900000 1275000>;
++			opp-microvolt-L3 = <875000 875000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1416000000 {
++			opp-hz = /bits/ 64 <1416000000>;
++			opp-microvolt = <1025000 1025000 1275000>;
++			opp-microvolt-L0 = <1025000 1025000 1275000>;
++			opp-microvolt-L1 = <1000000 1000000 1275000>;
++			opp-microvolt-L2 = <1000000 1000000 1275000>;
++			opp-microvolt-L3 = <975000 975000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1608000000 {
++			opp-hz = /bits/ 64 <1608000000>;
++			opp-microvolt = <1100000 1100000 1275000>;
++			opp-microvolt-L0 = <1100000 1100000 1275000>;
++			opp-microvolt-L1 = <1075000 1075000 1275000>;
++			opp-microvolt-L2 = <1050000 1050000 1275000>;
++			opp-microvolt-L3 = <1025000 1025000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1800000000 {
++			opp-hz = /bits/ 64 <1800000000>;
++			opp-microvolt = <1200000 1200000 1275000>;
++			opp-microvolt-L0 = <1200000 1200000 1275000>;
++			opp-microvolt-L1 = <1175000 1175000 1275000>;
++			opp-microvolt-L2 = <1150000 1150000 1275000>;
++			opp-microvolt-L3 = <1125000 1125000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-2016000000 {
++			opp-hz = /bits/ 64 <2016000000>;
++			opp-microvolt = <1250000 1250000 1275000>;
++			opp-microvolt-L0 = <1250000 1250000 1275000>;
++			opp-microvolt-L1 = <1200000 1200000 1275000>;
++			opp-microvolt-L2 = <1175000 1175000 1275000>;
++			opp-microvolt-L3 = <1150000 1150000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-2208000000 {
++			opp-hz = /bits/ 64 <2208000000>;
++			opp-microvolt = <1275000 1275000 1275000>;
++			opp-microvolt-L0 = <1275000 1275000 1275000>;
++			opp-microvolt-L1 = <1250000 1250000 1275000>;
++			opp-microvolt-L2 = <1200000 1200000 1275000>;
++			opp-microvolt-L3 = <1175000 1175000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++	};
++
++	gpu_opp_table: opp-table2 {
++		compatible = "operating-points-v2";
++
++		rockchip,thermal-zone = "soc-thermal";
++		rockchip,temp-hysteresis = <5000>;
++		rockchip,low-temp = <0>;
++		rockchip,low-temp-min-volt = <900000>;
++
++		nvmem-cells = <&gpu_leakage>;
++		nvmem-cell-names = "gpu_leakage";
++
++		rockchip,pvtm-voltage-sel = <
++			0        121000   0
++			121001   125500   1
++			125501   128500   2
++			128501   999999   3
++		>;
++		rockchip,pvtm-freq = <200000>;
++		rockchip,pvtm-volt = <900000>;
++		rockchip,pvtm-ch = <3 0>;
++		rockchip,pvtm-sample-time = <1000>;
++		rockchip,pvtm-number = <10>;
++		rockchip,pvtm-error = <1000>;
++		rockchip,pvtm-ref-temp = <41>;
++		rockchip,pvtm-temp-prop = <46 12>;
++		rockchip,pvtm-thermal-zone = "gpu-thermal";
++
++		opp-200000000 {
++			opp-hz = /bits/ 64 <200000000>;
++			opp-microvolt = <800000>;
++			opp-microvolt-L0 = <800000>;
++			opp-microvolt-L1 = <800000>;
++			opp-microvolt-L2 = <800000>;
++			opp-microvolt-L3 = <800000>;
++		};
++		opp-300000000 {
++			opp-hz = /bits/ 64 <300000000>;
++			opp-microvolt = <800000>;
++			opp-microvolt-L0 = <800000>;
++			opp-microvolt-L1 = <800000>;
++			opp-microvolt-L2 = <800000>;
++			opp-microvolt-L3 = <800000>;
++		};
++		opp-400000000 {
++			opp-hz = /bits/ 64 <400000000>;
++			opp-microvolt = <825000>;
++			opp-microvolt-L0 = <825000>;
++			opp-microvolt-L1 = <825000>;
++			opp-microvolt-L2 = <800000>;
++			opp-microvolt-L3 = <800000>;
++		};
++		opp-600000000 {
++			opp-hz = /bits/ 64 <600000000>;
++			opp-microvolt = <925000>;
++			opp-microvolt-L0 = <925000>;
++			opp-microvolt-L1 = <925000>;
++			opp-microvolt-L2 = <900000>;
++			opp-microvolt-L3 = <900000>;
++		};
++		opp-800000000 {
++			opp-hz = /bits/ 64 <800000000>;
++			opp-microvolt = <1100000>;
++			opp-microvolt-L0 = <1100000>;
++			opp-microvolt-L1 = <1075000>;
++			opp-microvolt-L2 = <1050000>;
++			opp-microvolt-L3 = <1025000>;
++		};
++	};
++};
++
++&cpu_l0 {
++	operating-points-v2 = <&cluster0_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_0 &RK3399_CLUSTER_COST_0>;
++};
++
++&cpu_l1 {
++	operating-points-v2 = <&cluster0_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_0 &RK3399_CLUSTER_COST_0>;
++};
++
++&cpu_l2 {
++	operating-points-v2 = <&cluster0_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_0 &RK3399_CLUSTER_COST_0>;
++};
++
++&cpu_l3 {
++	operating-points-v2 = <&cluster0_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_0 &RK3399_CLUSTER_COST_0>;
++};
++
++&cpu_b0 {
++	operating-points-v2 = <&cluster1_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_1 &RK3399_CLUSTER_COST_1>;
++};
++
++&cpu_b1 {
++	operating-points-v2 = <&cluster1_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_1 &RK3399_CLUSTER_COST_1>;
++};
++
++&gpu {
++	operating-points-v2 = <&gpu_opp_table>;
++};
+
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-sched-energy.dtsi
+@@ -0,0 +1,121 @@
++/*
++ * Copyright (c) 2016 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This library is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This library is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++/ {
++	energy-costs {
++		RK3399_CPU_COST_0: rk3399-core-cost0 {
++			busy-cost-data = <
++				108    46	/*  408M */
++				159    67	/*  600M */
++				216    90	/*  816M */
++				267    120	/* 1008M */
++				318    153	/* 1200M */
++				375    198	/* 1416M */
++				401    222	/* 1512M */
++			>;
++			idle-cost-data = <
++				  6
++				  6
++				  0
++				  0
++			>;
++		};
++
++		RK3399_CPU_COST_1: rk3399-core-cost1 {
++			busy-cost-data = <
++				210   129	/*  408MHz */
++				308   184	/*  600MHz */
++				419   246	/*  816MHz */
++				518   335	/* 1008MHz */
++				617   428	/* 1200MHz */
++				728   573	/* 1416MHz */
++				827   724	/* 1608MHz */
++				925   900	/* 1800MHz */
++				1024  1108	/* 1992MHz */
++			>;
++			idle-cost-data = <
++				  15
++				  15
++				   0
++				   0
++			>;
++		};
++
++		RK3399_CLUSTER_COST_0: rk3399-cluster-cost0 {
++			busy-cost-data = <
++				108    46	/*  408M */
++				159    67	/*  600M */
++				216    90	/*  816M */
++				267    120	/* 1008M */
++				318    153	/* 1200M */
++				375    198	/* 1416M */
++				401    222	/* 1512M */
++			>;
++			idle-cost-data = <
++				56
++				56
++				56
++				56
++			>;
++		};
++
++		RK3399_CLUSTER_COST_1: rk3399-cluster-cost1 {
++			busy-cost-data = <
++				210   129	/*  408MHz */
++				308   184	/*  600MHz */
++				419   246	/*  816MHz */
++				518   335	/* 1008MHz */
++				617   428	/* 1200MHz */
++				728   573	/* 1416MHz */
++				827   724	/* 1608MHz */
++				925   900	/* 1800MHz */
++				1024  1108	/* 1992MHz */
++			>;
++			idle-cost-data = <
++				 65
++				 65
++				 65
++				 65
++			>;
++		};
++	};
++};
+
+--- a/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
+@@ -3,7 +3,7 @@
+ /dts-v1/;
+ #include <dt-bindings/input/linux-event-codes.h>
+ #include "rk3399.dtsi"
+-#include "rk3399-opp.dtsi"
++#include "rk3399-doornet2-opp.dtsi"
+ 
+ / {
+ 	chosen {

--- a/target/linux/rockchip/patches-5.15/992-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch
+++ b/target/linux/rockchip/patches-5.15/992-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch
@@ -180,14 +180,3 @@ Co-authored-by: gzelvis <gzelvis@gmail.com>
  
  / {
  	aliases {
---- a/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
-@@ -3,7 +3,7 @@
- /dts-v1/;
- #include <dt-bindings/input/linux-event-codes.h>
- #include "rk3399.dtsi"
--#include "rk3399-opp.dtsi"
-+#include "rk3399-nanopi4-opp.dtsi"
- 
- / {
- 	chosen {

--- a/target/linux/rockchip/patches-5.15/993-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-DoorNet2.patch
+++ b/target/linux/rockchip/patches-5.15/993-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-DoorNet2.patch
@@ -1,0 +1,468 @@
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-doornet2-opp.dtsi
+@@ -0,0 +1,328 @@
++#include "rk3399-sched-energy.dtsi"
++
++/ {
++	cluster0_opp: opp-table0 {
++		compatible = "operating-points-v2";
++		opp-shared;
++
++		rockchip,temp-hysteresis = <5000>;
++		rockchip,low-temp = <0>;
++		rockchip,low-temp-min-volt = <900000>;
++
++		nvmem-cells = <&cpul_leakage>;
++		nvmem-cell-names = "cpu_leakage";
++
++		rockchip,pvtm-voltage-sel = <
++			0        143500   0
++			143501   148500   1
++			148501   152000   2
++			152001   999999   3
++		>;
++		rockchip,pvtm-freq = <408000>;
++		rockchip,pvtm-volt = <1000000>;
++		rockchip,pvtm-ch = <0 0>;
++		rockchip,pvtm-sample-time = <1000>;
++		rockchip,pvtm-number = <10>;
++		rockchip,pvtm-error = <1000>;
++		rockchip,pvtm-ref-temp = <41>;
++		rockchip,pvtm-temp-prop = <115 66>;
++		rockchip,thermal-zone = "soc-thermal";
++
++		opp-408000000 {
++			opp-hz = /bits/ 64 <408000000>;
++			opp-microvolt = <800000 800000 1250000>;
++			opp-microvolt-L0 = <800000 800000 1250000>;
++			opp-microvolt-L1 = <800000 800000 1250000>;
++			opp-microvolt-L2 = <800000 800000 1250000>;
++			opp-microvolt-L3 = <800000 800000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-600000000 {
++			opp-hz = /bits/ 64 <600000000>;
++			opp-microvolt = <800000 800000 1250000>;
++			opp-microvolt-L0 = <800000 800000 1250000>;
++			opp-microvolt-L1 = <800000 800000 1250000>;
++			opp-microvolt-L2 = <800000 800000 1250000>;
++			opp-microvolt-L3 = <800000 800000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-816000000 {
++			opp-hz = /bits/ 64 <816000000>;
++			opp-microvolt = <850000 850000 1250000>;
++			opp-microvolt-L0 = <850000 850000 1250000>;
++			opp-microvolt-L1 = <825000 825000 1250000>;
++			opp-microvolt-L2 = <800000 800000 1250000>;
++			opp-microvolt-L3 = <800000 800000 1250000>;
++			clock-latency-ns = <40000>;
++			opp-suspend;
++		};
++		opp-1008000000 {
++			opp-hz = /bits/ 64 <1008000000>;
++			opp-microvolt = <925000 925000 1250000>;
++			opp-microvolt-L0 = <925000 925000 1250000>;
++			opp-microvolt-L1 = <900000 900000 1250000>;
++			opp-microvolt-L2 = <875000 875000 1250000>;
++			opp-microvolt-L3 = <850000 850000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1200000000 {
++			opp-hz = /bits/ 64 <1200000000>;
++			opp-microvolt = <1000000 1000000 1250000>;
++			opp-microvolt-L0 = <1000000 1000000 1250000>;
++			opp-microvolt-L1 = <975000 975000 1250000>;
++			opp-microvolt-L2 = <950000 950000 1250000>;
++			opp-microvolt-L3 = <925000 925000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1416000000 {
++			opp-hz = /bits/ 64 <1416000000>;
++			opp-microvolt = <1175000 1175000 1250000>;
++			opp-microvolt-L0 = <1175000 1175000 1250000>;
++			opp-microvolt-L1 = <1100000 1100000 1250000>;
++			opp-microvolt-L2 = <1050000 1050000 1250000>;
++			opp-microvolt-L3 = <975000 975000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1608000000 {
++			opp-hz = /bits/ 64 <1608000000>;
++			opp-microvolt = <1200000 1200000 1250000>;
++			opp-microvolt-L0 = <1200000 1200000 1250000>;
++			opp-microvolt-L1 = <1175000 1175000 1250000>;
++			opp-microvolt-L2 = <1125000 1125000 1250000>;
++			opp-microvolt-L3 = <1100000 1100000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1800000000 {
++			opp-hz = /bits/ 64 <1800000000>;
++			opp-microvolt = <1250000 1250000 1250000>;
++			opp-microvolt-L0 = <1250000 1250000 1250000>;
++			opp-microvolt-L1 = <1200000 1200000 1250000>;
++			opp-microvolt-L2 = <1175000 1175000 1250000>;
++			opp-microvolt-L3 = <1125000 1125000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++	};
++
++	cluster1_opp: opp-table1 {
++		compatible = "operating-points-v2";
++		opp-shared;
++
++		rockchip,temp-hysteresis = <5000>;
++		rockchip,low-temp = <0>;
++		rockchip,low-temp-min-volt = <900000>;
++
++		nvmem-cells = <&cpub_leakage>;
++		nvmem-cell-names = "cpu_leakage";
++
++		rockchip,pvtm-voltage-sel = <
++			0        149000   0
++			149001   155000   1
++			155001   160000   2
++			160001   999999   3
++		>;
++		rockchip,pvtm-freq = <408000>;
++		rockchip,pvtm-volt = <1000000>;
++		rockchip,pvtm-ch = <1 0>;
++		rockchip,pvtm-sample-time = <1000>;
++		rockchip,pvtm-number = <10>;
++		rockchip,pvtm-error = <1000>;
++		rockchip,pvtm-ref-temp = <41>;
++		rockchip,pvtm-temp-prop = <71 35>;
++		rockchip,thermal-zone = "soc-thermal";
++
++		opp-408000000 {
++			opp-hz = /bits/ 64 <408000000>;
++			opp-microvolt = <800000 800000 1275000>;
++			opp-microvolt-L0 = <800000 800000 1275000>;
++			opp-microvolt-L1 = <800000 800000 1275000>;
++			opp-microvolt-L2 = <800000 800000 1275000>;
++			opp-microvolt-L3 = <800000 800000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-600000000 {
++			opp-hz = /bits/ 64 <600000000>;
++			opp-microvolt = <800000 800000 1275000>;
++			opp-microvolt-L0 = <800000 800000 1275000>;
++			opp-microvolt-L1 = <800000 800000 1275000>;
++			opp-microvolt-L2 = <800000 800000 1275000>;
++			opp-microvolt-L3 = <800000 800000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-816000000 {
++			opp-hz = /bits/ 64 <816000000>;
++			opp-microvolt = <825000 825000 1275000>;
++			opp-microvolt-L0 = <825000 825000 1275000>;
++			opp-microvolt-L1 = <825000 825000 1275000>;
++			opp-microvolt-L2 = <800000 800000 1275000>;
++			opp-microvolt-L3 = <800000 800000 1275000>;
++			clock-latency-ns = <40000>;
++			opp-suspend;
++		};
++		opp-1008000000 {
++			opp-hz = /bits/ 64 <1008000000>;
++			opp-microvolt = <875000 875000 1275000>;
++			opp-microvolt-L0 = <875000 875000 1275000>;
++			opp-microvolt-L1 = <850000 850000 1275000>;
++			opp-microvolt-L2 = <850000 850000 1275000>;
++			opp-microvolt-L3 = <850000 850000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1200000000 {
++			opp-hz = /bits/ 64 <1200000000>;
++			opp-microvolt = <950000 950000 1275000>;
++			opp-microvolt-L0 = <950000 950000 1275000>;
++			opp-microvolt-L1 = <925000 925000 1275000>;
++			opp-microvolt-L2 = <900000 900000 1275000>;
++			opp-microvolt-L3 = <875000 875000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1416000000 {
++			opp-hz = /bits/ 64 <1416000000>;
++			opp-microvolt = <1025000 1025000 1275000>;
++			opp-microvolt-L0 = <1025000 1025000 1275000>;
++			opp-microvolt-L1 = <1000000 1000000 1275000>;
++			opp-microvolt-L2 = <1000000 1000000 1275000>;
++			opp-microvolt-L3 = <975000 975000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1608000000 {
++			opp-hz = /bits/ 64 <1608000000>;
++			opp-microvolt = <1100000 1100000 1275000>;
++			opp-microvolt-L0 = <1100000 1100000 1275000>;
++			opp-microvolt-L1 = <1075000 1075000 1275000>;
++			opp-microvolt-L2 = <1050000 1050000 1275000>;
++			opp-microvolt-L3 = <1025000 1025000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1800000000 {
++			opp-hz = /bits/ 64 <1800000000>;
++			opp-microvolt = <1200000 1200000 1275000>;
++			opp-microvolt-L0 = <1200000 1200000 1275000>;
++			opp-microvolt-L1 = <1175000 1175000 1275000>;
++			opp-microvolt-L2 = <1150000 1150000 1275000>;
++			opp-microvolt-L3 = <1125000 1125000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-2016000000 {
++			opp-hz = /bits/ 64 <2016000000>;
++			opp-microvolt = <1250000 1250000 1275000>;
++			opp-microvolt-L0 = <1250000 1250000 1275000>;
++			opp-microvolt-L1 = <1200000 1200000 1275000>;
++			opp-microvolt-L2 = <1175000 1175000 1275000>;
++			opp-microvolt-L3 = <1150000 1150000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-2208000000 {
++			opp-hz = /bits/ 64 <2208000000>;
++			opp-microvolt = <1275000 1275000 1275000>;
++			opp-microvolt-L0 = <1275000 1275000 1275000>;
++			opp-microvolt-L1 = <1250000 1250000 1275000>;
++			opp-microvolt-L2 = <1200000 1200000 1275000>;
++			opp-microvolt-L3 = <1175000 1175000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++	};
++
++	gpu_opp_table: opp-table2 {
++		compatible = "operating-points-v2";
++
++		rockchip,thermal-zone = "soc-thermal";
++		rockchip,temp-hysteresis = <5000>;
++		rockchip,low-temp = <0>;
++		rockchip,low-temp-min-volt = <900000>;
++
++		nvmem-cells = <&gpu_leakage>;
++		nvmem-cell-names = "gpu_leakage";
++
++		rockchip,pvtm-voltage-sel = <
++			0        121000   0
++			121001   125500   1
++			125501   128500   2
++			128501   999999   3
++		>;
++		rockchip,pvtm-freq = <200000>;
++		rockchip,pvtm-volt = <900000>;
++		rockchip,pvtm-ch = <3 0>;
++		rockchip,pvtm-sample-time = <1000>;
++		rockchip,pvtm-number = <10>;
++		rockchip,pvtm-error = <1000>;
++		rockchip,pvtm-ref-temp = <41>;
++		rockchip,pvtm-temp-prop = <46 12>;
++		rockchip,pvtm-thermal-zone = "gpu-thermal";
++
++		opp-200000000 {
++			opp-hz = /bits/ 64 <200000000>;
++			opp-microvolt = <800000>;
++			opp-microvolt-L0 = <800000>;
++			opp-microvolt-L1 = <800000>;
++			opp-microvolt-L2 = <800000>;
++			opp-microvolt-L3 = <800000>;
++		};
++		opp-300000000 {
++			opp-hz = /bits/ 64 <300000000>;
++			opp-microvolt = <800000>;
++			opp-microvolt-L0 = <800000>;
++			opp-microvolt-L1 = <800000>;
++			opp-microvolt-L2 = <800000>;
++			opp-microvolt-L3 = <800000>;
++		};
++		opp-400000000 {
++			opp-hz = /bits/ 64 <400000000>;
++			opp-microvolt = <825000>;
++			opp-microvolt-L0 = <825000>;
++			opp-microvolt-L1 = <825000>;
++			opp-microvolt-L2 = <800000>;
++			opp-microvolt-L3 = <800000>;
++		};
++		opp-600000000 {
++			opp-hz = /bits/ 64 <600000000>;
++			opp-microvolt = <925000>;
++			opp-microvolt-L0 = <925000>;
++			opp-microvolt-L1 = <925000>;
++			opp-microvolt-L2 = <900000>;
++			opp-microvolt-L3 = <900000>;
++		};
++		opp-800000000 {
++			opp-hz = /bits/ 64 <800000000>;
++			opp-microvolt = <1100000>;
++			opp-microvolt-L0 = <1100000>;
++			opp-microvolt-L1 = <1075000>;
++			opp-microvolt-L2 = <1050000>;
++			opp-microvolt-L3 = <1025000>;
++		};
++	};
++};
++
++&cpu_l0 {
++	operating-points-v2 = <&cluster0_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_0 &RK3399_CLUSTER_COST_0>;
++};
++
++&cpu_l1 {
++	operating-points-v2 = <&cluster0_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_0 &RK3399_CLUSTER_COST_0>;
++};
++
++&cpu_l2 {
++	operating-points-v2 = <&cluster0_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_0 &RK3399_CLUSTER_COST_0>;
++};
++
++&cpu_l3 {
++	operating-points-v2 = <&cluster0_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_0 &RK3399_CLUSTER_COST_0>;
++};
++
++&cpu_b0 {
++	operating-points-v2 = <&cluster1_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_1 &RK3399_CLUSTER_COST_1>;
++};
++
++&cpu_b1 {
++	operating-points-v2 = <&cluster1_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_1 &RK3399_CLUSTER_COST_1>;
++};
++
++&gpu {
++	operating-points-v2 = <&gpu_opp_table>;
++};
+
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-sched-energy.dtsi
+@@ -0,0 +1,121 @@
++/*
++ * Copyright (c) 2016 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This library is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This library is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++/ {
++	energy-costs {
++		RK3399_CPU_COST_0: rk3399-core-cost0 {
++			busy-cost-data = <
++				108    46	/*  408M */
++				159    67	/*  600M */
++				216    90	/*  816M */
++				267    120	/* 1008M */
++				318    153	/* 1200M */
++				375    198	/* 1416M */
++				401    222	/* 1512M */
++			>;
++			idle-cost-data = <
++				  6
++				  6
++				  0
++				  0
++			>;
++		};
++
++		RK3399_CPU_COST_1: rk3399-core-cost1 {
++			busy-cost-data = <
++				210   129	/*  408MHz */
++				308   184	/*  600MHz */
++				419   246	/*  816MHz */
++				518   335	/* 1008MHz */
++				617   428	/* 1200MHz */
++				728   573	/* 1416MHz */
++				827   724	/* 1608MHz */
++				925   900	/* 1800MHz */
++				1024  1108	/* 1992MHz */
++			>;
++			idle-cost-data = <
++				  15
++				  15
++				   0
++				   0
++			>;
++		};
++
++		RK3399_CLUSTER_COST_0: rk3399-cluster-cost0 {
++			busy-cost-data = <
++				108    46	/*  408M */
++				159    67	/*  600M */
++				216    90	/*  816M */
++				267    120	/* 1008M */
++				318    153	/* 1200M */
++				375    198	/* 1416M */
++				401    222	/* 1512M */
++			>;
++			idle-cost-data = <
++				56
++				56
++				56
++				56
++			>;
++		};
++
++		RK3399_CLUSTER_COST_1: rk3399-cluster-cost1 {
++			busy-cost-data = <
++				210   129	/*  408MHz */
++				308   184	/*  600MHz */
++				419   246	/*  816MHz */
++				518   335	/* 1008MHz */
++				617   428	/* 1200MHz */
++				728   573	/* 1416MHz */
++				827   724	/* 1608MHz */
++				925   900	/* 1800MHz */
++				1024  1108	/* 1992MHz */
++			>;
++			idle-cost-data = <
++				 65
++				 65
++				 65
++				 65
++			>;
++		};
++	};
++};
+
+--- a/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
+@@ -3,7 +3,7 @@
+ /dts-v1/;
+ #include <dt-bindings/input/linux-event-codes.h>
+ #include "rk3399.dtsi"
+-#include "rk3399-opp.dtsi"
++#include "rk3399-doornet2-opp.dtsi"
+ 
+ / {
+ 	chosen {

--- a/target/linux/rockchip/patches-5.4/992-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch
+++ b/target/linux/rockchip/patches-5.4/992-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-NanoPi4.patch
@@ -180,15 +180,3 @@ Co-authored-by: gzelvis <gzelvis@gmail.com>
  
  / {
  	chosen {
---- a/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
-+++ b/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
-@@ -3,7 +3,7 @@
- /dts-v1/;
- #include <dt-bindings/input/linux-event-codes.h>
- #include "rk3399.dtsi"
--#include "rk3399-opp.dtsi"
-+#include "rk3399-nanopi4-opp.dtsi"
- 
- / {
- 	chosen {
-  

--- a/target/linux/rockchip/patches-5.4/993-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-DoorNet2.patch
+++ b/target/linux/rockchip/patches-5.4/993-rockchip-rk3399-overclock-to-2.2-1.8-GHz-for-DoorNet2.patch
@@ -1,0 +1,468 @@
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-doornet2-opp.dtsi
+@@ -0,0 +1,328 @@
++#include "rk3399-sched-energy.dtsi"
++
++/ {
++	cluster0_opp: opp-table0 {
++		compatible = "operating-points-v2";
++		opp-shared;
++
++		rockchip,temp-hysteresis = <5000>;
++		rockchip,low-temp = <0>;
++		rockchip,low-temp-min-volt = <900000>;
++
++		nvmem-cells = <&cpul_leakage>;
++		nvmem-cell-names = "cpu_leakage";
++
++		rockchip,pvtm-voltage-sel = <
++			0        143500   0
++			143501   148500   1
++			148501   152000   2
++			152001   999999   3
++		>;
++		rockchip,pvtm-freq = <408000>;
++		rockchip,pvtm-volt = <1000000>;
++		rockchip,pvtm-ch = <0 0>;
++		rockchip,pvtm-sample-time = <1000>;
++		rockchip,pvtm-number = <10>;
++		rockchip,pvtm-error = <1000>;
++		rockchip,pvtm-ref-temp = <41>;
++		rockchip,pvtm-temp-prop = <115 66>;
++		rockchip,thermal-zone = "soc-thermal";
++
++		opp-408000000 {
++			opp-hz = /bits/ 64 <408000000>;
++			opp-microvolt = <800000 800000 1250000>;
++			opp-microvolt-L0 = <800000 800000 1250000>;
++			opp-microvolt-L1 = <800000 800000 1250000>;
++			opp-microvolt-L2 = <800000 800000 1250000>;
++			opp-microvolt-L3 = <800000 800000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-600000000 {
++			opp-hz = /bits/ 64 <600000000>;
++			opp-microvolt = <800000 800000 1250000>;
++			opp-microvolt-L0 = <800000 800000 1250000>;
++			opp-microvolt-L1 = <800000 800000 1250000>;
++			opp-microvolt-L2 = <800000 800000 1250000>;
++			opp-microvolt-L3 = <800000 800000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-816000000 {
++			opp-hz = /bits/ 64 <816000000>;
++			opp-microvolt = <850000 850000 1250000>;
++			opp-microvolt-L0 = <850000 850000 1250000>;
++			opp-microvolt-L1 = <825000 825000 1250000>;
++			opp-microvolt-L2 = <800000 800000 1250000>;
++			opp-microvolt-L3 = <800000 800000 1250000>;
++			clock-latency-ns = <40000>;
++			opp-suspend;
++		};
++		opp-1008000000 {
++			opp-hz = /bits/ 64 <1008000000>;
++			opp-microvolt = <925000 925000 1250000>;
++			opp-microvolt-L0 = <925000 925000 1250000>;
++			opp-microvolt-L1 = <900000 900000 1250000>;
++			opp-microvolt-L2 = <875000 875000 1250000>;
++			opp-microvolt-L3 = <850000 850000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1200000000 {
++			opp-hz = /bits/ 64 <1200000000>;
++			opp-microvolt = <1000000 1000000 1250000>;
++			opp-microvolt-L0 = <1000000 1000000 1250000>;
++			opp-microvolt-L1 = <975000 975000 1250000>;
++			opp-microvolt-L2 = <950000 950000 1250000>;
++			opp-microvolt-L3 = <925000 925000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1416000000 {
++			opp-hz = /bits/ 64 <1416000000>;
++			opp-microvolt = <1175000 1175000 1250000>;
++			opp-microvolt-L0 = <1175000 1175000 1250000>;
++			opp-microvolt-L1 = <1100000 1100000 1250000>;
++			opp-microvolt-L2 = <1050000 1050000 1250000>;
++			opp-microvolt-L3 = <975000 975000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1608000000 {
++			opp-hz = /bits/ 64 <1608000000>;
++			opp-microvolt = <1200000 1200000 1250000>;
++			opp-microvolt-L0 = <1200000 1200000 1250000>;
++			opp-microvolt-L1 = <1175000 1175000 1250000>;
++			opp-microvolt-L2 = <1125000 1125000 1250000>;
++			opp-microvolt-L3 = <1100000 1100000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1800000000 {
++			opp-hz = /bits/ 64 <1800000000>;
++			opp-microvolt = <1250000 1250000 1250000>;
++			opp-microvolt-L0 = <1250000 1250000 1250000>;
++			opp-microvolt-L1 = <1200000 1200000 1250000>;
++			opp-microvolt-L2 = <1175000 1175000 1250000>;
++			opp-microvolt-L3 = <1125000 1125000 1250000>;
++			clock-latency-ns = <40000>;
++		};
++	};
++
++	cluster1_opp: opp-table1 {
++		compatible = "operating-points-v2";
++		opp-shared;
++
++		rockchip,temp-hysteresis = <5000>;
++		rockchip,low-temp = <0>;
++		rockchip,low-temp-min-volt = <900000>;
++
++		nvmem-cells = <&cpub_leakage>;
++		nvmem-cell-names = "cpu_leakage";
++
++		rockchip,pvtm-voltage-sel = <
++			0        149000   0
++			149001   155000   1
++			155001   160000   2
++			160001   999999   3
++		>;
++		rockchip,pvtm-freq = <408000>;
++		rockchip,pvtm-volt = <1000000>;
++		rockchip,pvtm-ch = <1 0>;
++		rockchip,pvtm-sample-time = <1000>;
++		rockchip,pvtm-number = <10>;
++		rockchip,pvtm-error = <1000>;
++		rockchip,pvtm-ref-temp = <41>;
++		rockchip,pvtm-temp-prop = <71 35>;
++		rockchip,thermal-zone = "soc-thermal";
++
++		opp-408000000 {
++			opp-hz = /bits/ 64 <408000000>;
++			opp-microvolt = <800000 800000 1275000>;
++			opp-microvolt-L0 = <800000 800000 1275000>;
++			opp-microvolt-L1 = <800000 800000 1275000>;
++			opp-microvolt-L2 = <800000 800000 1275000>;
++			opp-microvolt-L3 = <800000 800000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-600000000 {
++			opp-hz = /bits/ 64 <600000000>;
++			opp-microvolt = <800000 800000 1275000>;
++			opp-microvolt-L0 = <800000 800000 1275000>;
++			opp-microvolt-L1 = <800000 800000 1275000>;
++			opp-microvolt-L2 = <800000 800000 1275000>;
++			opp-microvolt-L3 = <800000 800000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-816000000 {
++			opp-hz = /bits/ 64 <816000000>;
++			opp-microvolt = <825000 825000 1275000>;
++			opp-microvolt-L0 = <825000 825000 1275000>;
++			opp-microvolt-L1 = <825000 825000 1275000>;
++			opp-microvolt-L2 = <800000 800000 1275000>;
++			opp-microvolt-L3 = <800000 800000 1275000>;
++			clock-latency-ns = <40000>;
++			opp-suspend;
++		};
++		opp-1008000000 {
++			opp-hz = /bits/ 64 <1008000000>;
++			opp-microvolt = <875000 875000 1275000>;
++			opp-microvolt-L0 = <875000 875000 1275000>;
++			opp-microvolt-L1 = <850000 850000 1275000>;
++			opp-microvolt-L2 = <850000 850000 1275000>;
++			opp-microvolt-L3 = <850000 850000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1200000000 {
++			opp-hz = /bits/ 64 <1200000000>;
++			opp-microvolt = <950000 950000 1275000>;
++			opp-microvolt-L0 = <950000 950000 1275000>;
++			opp-microvolt-L1 = <925000 925000 1275000>;
++			opp-microvolt-L2 = <900000 900000 1275000>;
++			opp-microvolt-L3 = <875000 875000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1416000000 {
++			opp-hz = /bits/ 64 <1416000000>;
++			opp-microvolt = <1025000 1025000 1275000>;
++			opp-microvolt-L0 = <1025000 1025000 1275000>;
++			opp-microvolt-L1 = <1000000 1000000 1275000>;
++			opp-microvolt-L2 = <1000000 1000000 1275000>;
++			opp-microvolt-L3 = <975000 975000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1608000000 {
++			opp-hz = /bits/ 64 <1608000000>;
++			opp-microvolt = <1100000 1100000 1275000>;
++			opp-microvolt-L0 = <1100000 1100000 1275000>;
++			opp-microvolt-L1 = <1075000 1075000 1275000>;
++			opp-microvolt-L2 = <1050000 1050000 1275000>;
++			opp-microvolt-L3 = <1025000 1025000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-1800000000 {
++			opp-hz = /bits/ 64 <1800000000>;
++			opp-microvolt = <1200000 1200000 1275000>;
++			opp-microvolt-L0 = <1200000 1200000 1275000>;
++			opp-microvolt-L1 = <1175000 1175000 1275000>;
++			opp-microvolt-L2 = <1150000 1150000 1275000>;
++			opp-microvolt-L3 = <1125000 1125000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-2016000000 {
++			opp-hz = /bits/ 64 <2016000000>;
++			opp-microvolt = <1250000 1250000 1275000>;
++			opp-microvolt-L0 = <1250000 1250000 1275000>;
++			opp-microvolt-L1 = <1200000 1200000 1275000>;
++			opp-microvolt-L2 = <1175000 1175000 1275000>;
++			opp-microvolt-L3 = <1150000 1150000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++		opp-2208000000 {
++			opp-hz = /bits/ 64 <2208000000>;
++			opp-microvolt = <1275000 1275000 1275000>;
++			opp-microvolt-L0 = <1275000 1275000 1275000>;
++			opp-microvolt-L1 = <1250000 1250000 1275000>;
++			opp-microvolt-L2 = <1200000 1200000 1275000>;
++			opp-microvolt-L3 = <1175000 1175000 1275000>;
++			clock-latency-ns = <40000>;
++		};
++	};
++
++	gpu_opp_table: opp-table2 {
++		compatible = "operating-points-v2";
++
++		rockchip,thermal-zone = "soc-thermal";
++		rockchip,temp-hysteresis = <5000>;
++		rockchip,low-temp = <0>;
++		rockchip,low-temp-min-volt = <900000>;
++
++		nvmem-cells = <&gpu_leakage>;
++		nvmem-cell-names = "gpu_leakage";
++
++		rockchip,pvtm-voltage-sel = <
++			0        121000   0
++			121001   125500   1
++			125501   128500   2
++			128501   999999   3
++		>;
++		rockchip,pvtm-freq = <200000>;
++		rockchip,pvtm-volt = <900000>;
++		rockchip,pvtm-ch = <3 0>;
++		rockchip,pvtm-sample-time = <1000>;
++		rockchip,pvtm-number = <10>;
++		rockchip,pvtm-error = <1000>;
++		rockchip,pvtm-ref-temp = <41>;
++		rockchip,pvtm-temp-prop = <46 12>;
++		rockchip,pvtm-thermal-zone = "gpu-thermal";
++
++		opp-200000000 {
++			opp-hz = /bits/ 64 <200000000>;
++			opp-microvolt = <800000>;
++			opp-microvolt-L0 = <800000>;
++			opp-microvolt-L1 = <800000>;
++			opp-microvolt-L2 = <800000>;
++			opp-microvolt-L3 = <800000>;
++		};
++		opp-300000000 {
++			opp-hz = /bits/ 64 <300000000>;
++			opp-microvolt = <800000>;
++			opp-microvolt-L0 = <800000>;
++			opp-microvolt-L1 = <800000>;
++			opp-microvolt-L2 = <800000>;
++			opp-microvolt-L3 = <800000>;
++		};
++		opp-400000000 {
++			opp-hz = /bits/ 64 <400000000>;
++			opp-microvolt = <825000>;
++			opp-microvolt-L0 = <825000>;
++			opp-microvolt-L1 = <825000>;
++			opp-microvolt-L2 = <800000>;
++			opp-microvolt-L3 = <800000>;
++		};
++		opp-600000000 {
++			opp-hz = /bits/ 64 <600000000>;
++			opp-microvolt = <925000>;
++			opp-microvolt-L0 = <925000>;
++			opp-microvolt-L1 = <925000>;
++			opp-microvolt-L2 = <900000>;
++			opp-microvolt-L3 = <900000>;
++		};
++		opp-800000000 {
++			opp-hz = /bits/ 64 <800000000>;
++			opp-microvolt = <1100000>;
++			opp-microvolt-L0 = <1100000>;
++			opp-microvolt-L1 = <1075000>;
++			opp-microvolt-L2 = <1050000>;
++			opp-microvolt-L3 = <1025000>;
++		};
++	};
++};
++
++&cpu_l0 {
++	operating-points-v2 = <&cluster0_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_0 &RK3399_CLUSTER_COST_0>;
++};
++
++&cpu_l1 {
++	operating-points-v2 = <&cluster0_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_0 &RK3399_CLUSTER_COST_0>;
++};
++
++&cpu_l2 {
++	operating-points-v2 = <&cluster0_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_0 &RK3399_CLUSTER_COST_0>;
++};
++
++&cpu_l3 {
++	operating-points-v2 = <&cluster0_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_0 &RK3399_CLUSTER_COST_0>;
++};
++
++&cpu_b0 {
++	operating-points-v2 = <&cluster1_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_1 &RK3399_CLUSTER_COST_1>;
++};
++
++&cpu_b1 {
++	operating-points-v2 = <&cluster1_opp>;
++	sched-energy-costs = <&RK3399_CPU_COST_1 &RK3399_CLUSTER_COST_1>;
++};
++
++&gpu {
++	operating-points-v2 = <&gpu_opp_table>;
++};
+
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-sched-energy.dtsi
+@@ -0,0 +1,121 @@
++/*
++ * Copyright (c) 2016 Fuzhou Rockchip Electronics Co., Ltd
++ *
++ * This file is dual-licensed: you can use it either under the terms
++ * of the GPL or the X11 license, at your option. Note that this dual
++ * licensing only applies to this file, and not this project as a
++ * whole.
++ *
++ *  a) This library is free software; you can redistribute it and/or
++ *     modify it under the terms of the GNU General Public License as
++ *     published by the Free Software Foundation; either version 2 of the
++ *     License, or (at your option) any later version.
++ *
++ *     This library is distributed in the hope that it will be useful,
++ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
++ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ *     GNU General Public License for more details.
++ *
++ * Or, alternatively,
++ *
++ *  b) Permission is hereby granted, free of charge, to any person
++ *     obtaining a copy of this software and associated documentation
++ *     files (the "Software"), to deal in the Software without
++ *     restriction, including without limitation the rights to use,
++ *     copy, modify, merge, publish, distribute, sublicense, and/or
++ *     sell copies of the Software, and to permit persons to whom the
++ *     Software is furnished to do so, subject to the following
++ *     conditions:
++ *
++ *     The above copyright notice and this permission notice shall be
++ *     included in all copies or substantial portions of the Software.
++ *
++ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++ *     OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++/ {
++	energy-costs {
++		RK3399_CPU_COST_0: rk3399-core-cost0 {
++			busy-cost-data = <
++				108    46	/*  408M */
++				159    67	/*  600M */
++				216    90	/*  816M */
++				267    120	/* 1008M */
++				318    153	/* 1200M */
++				375    198	/* 1416M */
++				401    222	/* 1512M */
++			>;
++			idle-cost-data = <
++				  6
++				  6
++				  0
++				  0
++			>;
++		};
++
++		RK3399_CPU_COST_1: rk3399-core-cost1 {
++			busy-cost-data = <
++				210   129	/*  408MHz */
++				308   184	/*  600MHz */
++				419   246	/*  816MHz */
++				518   335	/* 1008MHz */
++				617   428	/* 1200MHz */
++				728   573	/* 1416MHz */
++				827   724	/* 1608MHz */
++				925   900	/* 1800MHz */
++				1024  1108	/* 1992MHz */
++			>;
++			idle-cost-data = <
++				  15
++				  15
++				   0
++				   0
++			>;
++		};
++
++		RK3399_CLUSTER_COST_0: rk3399-cluster-cost0 {
++			busy-cost-data = <
++				108    46	/*  408M */
++				159    67	/*  600M */
++				216    90	/*  816M */
++				267    120	/* 1008M */
++				318    153	/* 1200M */
++				375    198	/* 1416M */
++				401    222	/* 1512M */
++			>;
++			idle-cost-data = <
++				56
++				56
++				56
++				56
++			>;
++		};
++
++		RK3399_CLUSTER_COST_1: rk3399-cluster-cost1 {
++			busy-cost-data = <
++				210   129	/*  408MHz */
++				308   184	/*  600MHz */
++				419   246	/*  816MHz */
++				518   335	/* 1008MHz */
++				617   428	/* 1200MHz */
++				728   573	/* 1416MHz */
++				827   724	/* 1608MHz */
++				925   900	/* 1800MHz */
++				1024  1108	/* 1992MHz */
++			>;
++			idle-cost-data = <
++				 65
++				 65
++				 65
++				 65
++			>;
++		};
++	};
++};
+
+--- a/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-doornet2.dtsi
+@@ -3,7 +3,7 @@
+ /dts-v1/;
+ #include <dt-bindings/input/linux-event-codes.h>
+ #include "rk3399.dtsi"
+-#include "rk3399-opp.dtsi"
++#include "rk3399-doornet2-opp.dtsi"
+ 
+ / {
+ 	chosen {


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [×] 我知道

Because the manufacturer gave the doornet2 schematic diagram and optimized the frequency core power supply, it turned out that the r4s overclocking patch had been used to cause the doornet2 temperature to be too high. However, according to the schematic analysis, there are certain differences between the r4s wiki schematic and doornet2, although the core is the same, the power supply is different. The use frequency of doornet2 has been changed to 1.27v for the large core and 1.25v for the small core. After three days of observation, the final decision has stabilized. The CPU temperature has good heat dissipation, and the core overclocking power supply does not cause performance degradation or difference.

This optimization has been done for r4s, but it is still not recommended to use the frequency optimized by doornet2, because after testing, the system directly crashes and turns off the lights at gigabit speed, pulls high frequency, or high performance, plus voltage, no matter how doornet2 overclocking patch is used. easy to crash. I will optimize it for r4s next time

if you have any questions, please ask, thank you

