### PR TITLE
dnsmasq: enable cache by default

### DIFF
--- a/package/network/services/dnsmasq/files/dhcp.conf
+++ b/package/network/services/dnsmasq/files/dhcp.conf
@@ -20,6 +20,9 @@ config dnsmasq
 	#list notinterface	lo
 	#list bogusnxdomain     '64.94.110.11'
 	option localservice	1  # disable to allow DNS requests from non-local subnets
+	option filter_aaaa	0
+	option cachesize	8000
+	option mini_ttl		3600
 	option ednspacket_max	1232
 
 config dhcp lan


### PR DESCRIPTION
By this we can change the default dns resolver on ssrplus to dns2tcp and finally get rid of pdnsd.