### PR TITLE
Update n2n_v2.init

### DIFF
--- a/package/lean/n2n_v2/files/n2n_v2.init
+++ b/package/lean/n2n_v2/files/n2n_v2.init
@@ -41,7 +41,7 @@ start_instance() {
         config_get_bool enabled "$cfg" 'enabled' '0'
         [ "$enabled" = "0" ] && return 1
         config_get port "$cfg" 'port'
-        /usr/bin/supernode -l $port &
+        /usr/bin/supernode -p $port &
         iptables -I INPUT -p udp --dport $port -j ACCEPT -m comment --comment 'n2n supernode port'
       ;;
       route)


### PR DESCRIPTION
supernode V3版本启动方式已经变更为-p $port 原先的-l $port已经无法启动

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
