### PR TITLE
build: fix ldconfig executable error in python

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -196,5 +196,4 @@ prereq: $(STAGING_DIR_HOST)/bin/mkhash
 
 # Install ldconfig stub
 $(eval $(call TestHostCommand,ldconfig-stub,Failed to install stub, \
-	touch $(STAGING_DIR_HOST)/bin/ldconfig && \
-	chmod +x $(STAGING_DIR_HOST)/bin/ldconfig))
+	$(LN) /bin/true $(STAGING_DIR_HOST)/bin/ldconfig))


### PR DESCRIPTION
See: https://github.com/openwrt/openwrt/pull/4736

在 Debian 11 上复现了 https://github.com/coolsnowwolf/lede/issues/9056 描述的错误，实测这个补丁可以在 Debian 11 中解决该错误。

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ x] 我知道