### PR TITLE
N2N服务器端dhcp设置

### DIFF
--- a/package/lean/n2n_v2/files/n2n_v2.config
+++ b/package/lean/n2n_v2/files/n2n_v2.config
@@ -14,6 +14,7 @@ config edge
 config supernode
 	option enabled    '0'
 	option port       '1235'
+	option subnet     '10.0.0.0-10.0.0.0/24'
 
 config route
 	option enabled '0'

--- a/package/lean/n2n_v2/files/n2n_v2.init
+++ b/package/lean/n2n_v2/files/n2n_v2.init
@@ -41,7 +41,8 @@ start_instance() {
         config_get_bool enabled "$cfg" 'enabled' '0'
         [ "$enabled" = "0" ] && return 1
         config_get port "$cfg" 'port'
-        /usr/bin/supernode -p $port &
+        config_get subnet "$cfg" 'subnet'
+        /usr/bin/supernode -p $port -a $subnet &
         iptables -I INPUT -p udp --dport $port -j ACCEPT -m comment --comment 'n2n supernode port'
       ;;
       route)


### PR DESCRIPTION
supernode参数用于客户端在dhcp模式下自动分配IP，便于使用
-a IP段 | 用于自动分配IP，格式如 -a 192.168.0.0-192.168.255.0/24
luci-app-n2n_v2中也已同步更新

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
