### PR TITLE
ramips: mt7621: fix typo "-wpad-openssl" in image target mt7621.mk

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -146,7 +146,7 @@ define Device/alfa-network_quad-e4g
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := Quad-E4G
   DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 uboot-envtools \
-	-wpad-openssl
+	wpad-openssl
   SUPPORTED_DEVICES += quad-e4g
 endef
 TARGET_DEVICES += alfa-network_quad-e4g
@@ -183,7 +183,7 @@ define Device/asiarf_ap7621-001
   IMAGE_SIZE := 16000k
   DEVICE_VENDOR := AsiaRF
   DEVICE_MODEL := AP7621-001
-  DEVICE_PACKAGES := kmod-sdhci-mt7620 kmod-mt76x2 kmod-usb3 -wpad-openssl
+  DEVICE_PACKAGES := kmod-sdhci-mt7620 kmod-mt76x2 kmod-usb3 wpad-openssl
 endef
 TARGET_DEVICES += asiarf_ap7621-001
 
@@ -192,7 +192,7 @@ define Device/asiarf_ap7621-nv1
   IMAGE_SIZE := 16000k
   DEVICE_VENDOR := AsiaRF
   DEVICE_MODEL := AP7621-NV1
-  DEVICE_PACKAGES := kmod-sdhci-mt7620 kmod-mt76x2 kmod-usb3 -wpad-openssl
+  DEVICE_PACKAGES := kmod-sdhci-mt7620 kmod-mt76x2 kmod-usb3 wpad-openssl
 endef
 TARGET_DEVICES += asiarf_ap7621-nv1
 
@@ -276,7 +276,7 @@ define Device/beeline_smartbox-turbo-plus
   DEVICE_VENDOR := Beeline
   DEVICE_MODEL := SmartBox TURBO+
   DEVICE_PACKAGES := kmod-mt7603e kmod-mt7615d luci-app-mtwifi \
-	-wpad-openssl kmod-usb3 uboot-envtools
+	wpad-openssl kmod-usb3 uboot-envtools
 endef
 TARGET_DEVICES += beeline_smartbox-turbo-plus
 
@@ -463,7 +463,7 @@ define Device/d-team_newifi-d2
   DEVICE_MODEL := D2
   DEVICE_COMPAT_VERSION := 1.1
   DEVICE_PACKAGES := kmod-mt7603e kmod-mt76x2e kmod-usb3 \
-	kmod-usb-ledtrig-usbport luci-app-mtwifi -wpad-openssl
+	kmod-usb-ledtrig-usbport luci-app-mtwifi wpad-openssl
 endef
 TARGET_DEVICES += d-team_newifi-d2
 
@@ -641,7 +641,7 @@ define Device/gehua_ghl-r-001
   DEVICE_VENDOR := GeHua
   DEVICE_MODEL := GHL-R-001
   DEVICE_PACKAGES := kmod-mt7603e kmod-mt76x2e kmod-usb3 \
-	kmod-usb-ledtrig-usbport luci-app-mtwifi -wpad-openssl
+	kmod-usb-ledtrig-usbport luci-app-mtwifi wpad-openssl
 endef
 TARGET_DEVICES += gehua_ghl-r-001
 
@@ -650,7 +650,7 @@ define Device/glinet_gl-mt1300
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-MT1300
-  DEVICE_PACKAGES := kmod-mt7615d_dbdc kmod-usb3 -luci-newapi -wpad-openssl
+  DEVICE_PACKAGES := kmod-mt7615d_dbdc kmod-usb3 -luci-newapi wpad-openssl
 endef
 TARGET_DEVICES += glinet_gl-mt1300
 
@@ -658,7 +658,7 @@ define Device/gnubee_gb-pc1
   $(Device/dsa-migration)
   DEVICE_VENDOR := GnuBee
   DEVICE_MODEL := Personal Cloud One
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 kmod-sdhci-mt7620 -wpad-openssl
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 kmod-sdhci-mt7620 wpad-openssl
   IMAGE_SIZE := 32448k
 endef
 TARGET_DEVICES += gnubee_gb-pc1
@@ -667,7 +667,7 @@ define Device/gnubee_gb-pc2
   $(Device/dsa-migration)
   DEVICE_VENDOR := GnuBee
   DEVICE_MODEL := Personal Cloud Two
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 kmod-sdhci-mt7620 -wpad-openssl
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 kmod-sdhci-mt7620 wpad-openssl
   IMAGE_SIZE := 32448k
 endef
 TARGET_DEVICES += gnubee_gb-pc2
@@ -866,7 +866,7 @@ define Device/jcg_y2
   JCG_MAXSIZE := 16064k
   DEVICE_VENDOR := JCG
   DEVICE_MODEL := Y2
-  DEVICE_PACKAGES := kmod-mt7615d_dbdc kmod-usb3 -luci-newapi -wpad-openssl
+  DEVICE_PACKAGES := kmod-mt7615d_dbdc kmod-usb3 -luci-newapi wpad-openssl
 endef
 TARGET_DEVICES += jcg_y2
 
@@ -974,7 +974,7 @@ define Device/mediatek_ap-mt7621a-v60
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Mediatek
   DEVICE_MODEL := AP-MT7621A-V60 EVB
-  DEVICE_PACKAGES := kmod-usb3 kmod-sdhci-mt7620 kmod-sound-mt7620 -wpad-openssl
+  DEVICE_PACKAGES := kmod-usb3 kmod-sdhci-mt7620 kmod-sound-mt7620 wpad-openssl
 endef
 TARGET_DEVICES += mediatek_ap-mt7621a-v60
 
@@ -984,7 +984,7 @@ define Device/mediatek_mt7621-eval-board
   IMAGE_SIZE := 15104k
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7621 EVB
-  DEVICE_PACKAGES := -wpad-openssl
+  DEVICE_PACKAGES := wpad-openssl
   SUPPORTED_DEVICES += mt7621
 endef
 TARGET_DEVICES += mediatek_mt7621-eval-board
@@ -1005,7 +1005,7 @@ endef
 define Device/mikrotik_routerboard-750gr3
   $(Device/MikroTik)
   DEVICE_MODEL := RouterBOARD 750Gr3
-  DEVICE_PACKAGES += -wpad-openssl
+  DEVICE_PACKAGES += wpad-openssl
   SUPPORTED_DEVICES += mikrotik,rb750gr3
 endef
 TARGET_DEVICES += mikrotik_routerboard-750gr3
@@ -1013,14 +1013,14 @@ TARGET_DEVICES += mikrotik_routerboard-750gr3
 define Device/mikrotik_routerboard-760igs
   $(Device/MikroTik)
   DEVICE_MODEL := RouterBOARD 760iGS
-  DEVICE_PACKAGES += kmod-sfp -wpad-openssl
+  DEVICE_PACKAGES += kmod-sfp wpad-openssl
 endef
 TARGET_DEVICES += mikrotik_routerboard-760igs
 
 define Device/mikrotik_routerboard-m11g
   $(Device/MikroTik)
   DEVICE_MODEL := RouterBOARD M11G
-  DEVICE_PACKAGES := -wpad-openssl
+  DEVICE_PACKAGES := wpad-openssl
   SUPPORTED_DEVICES += mikrotik,rbm11g
 endef
 TARGET_DEVICES += mikrotik_routerboard-m11g
@@ -1028,7 +1028,7 @@ TARGET_DEVICES += mikrotik_routerboard-m11g
 define Device/mikrotik_routerboard-m33g
   $(Device/MikroTik)
   DEVICE_MODEL := RouterBOARD M33G
-  DEVICE_PACKAGES := -wpad-openssl
+  DEVICE_PACKAGES := wpad-openssl
   SUPPORTED_DEVICES += mikrotik,rbm33g
 endef
 TARGET_DEVICES += mikrotik_routerboard-m33g
@@ -1245,7 +1245,7 @@ define Device/phicomm_k2p
   DEVICE_MODEL := K2P
   SUPPORTED_DEVICES += k2p
   DEVICE_COMPAT_VERSION := 1.1
-  DEVICE_PACKAGES := -luci-newapi -wpad-openssl kmod-mt7615d_dbdc wireless-tools
+  DEVICE_PACKAGES := -luci-newapi wpad-openssl kmod-mt7615d_dbdc wireless-tools
 endef
 TARGET_DEVICES += phicomm_k2p
 
@@ -1255,7 +1255,7 @@ define Device/planex_vr500
   IMAGE_SIZE := 65216k
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := VR500
-  DEVICE_PACKAGES := kmod-usb3 -wpad-openssl
+  DEVICE_PACKAGES := kmod-usb3 wpad-openssl
   SUPPORTED_DEVICES += vr500
 endef
 TARGET_DEVICES += planex_vr500
@@ -1349,7 +1349,7 @@ define Device/thunder_timecloud
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Thunder
   DEVICE_MODEL := Timecloud
-  DEVICE_PACKAGES := kmod-usb3 -wpad-openssl
+  DEVICE_PACKAGES := kmod-usb3 wpad-openssl
   SUPPORTED_DEVICES += timecloud
 endef
 TARGET_DEVICES += thunder_timecloud
@@ -1471,7 +1471,7 @@ define Device/ubnt_edgerouter_common
   KERNEL_INITRAMFS := $$(KERNEL) | \
 	ubnt-erx-factory-image $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.tar
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES += -wpad-openssl
+  DEVICE_PACKAGES += wpad-openssl
 endef
 
 define Device/ubnt_edgerouter-x
@@ -1527,7 +1527,7 @@ define Device/unielec_u7621-06-16m
   DEVICE_VENDOR := UniElec
   DEVICE_MODEL := U7621-06
   DEVICE_VARIANT := 16M
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 -wpad-openssl
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 wpad-openssl
   SUPPORTED_DEVICES += u7621-06-256M-16M unielec,u7621-06-256m-16m
 endef
 TARGET_DEVICES += unielec_u7621-06-16m
@@ -1539,7 +1539,7 @@ define Device/unielec_u7621-06-64m
   DEVICE_VENDOR := UniElec
   DEVICE_MODEL := U7621-06
   DEVICE_VARIANT := 64M
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 -wpad-openssl
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-sdhci-mt7620 kmod-usb3 wpad-openssl
   SUPPORTED_DEVICES += unielec,u7621-06-512m-64m
 endef
 TARGET_DEVICES += unielec_u7621-06-64m
@@ -1674,7 +1674,7 @@ define Device/xiaomi_mi-router-ac2100
   DEVICE_MODEL := Mi Router AC2100
   IMAGE_SIZE := 120320k
   DEVICE_PACKAGES += kmod-mt7603e kmod-mt7615d luci-app-mtwifi \
-	-wpad-openssl
+	wpad-openssl
 endef
 TARGET_DEVICES += xiaomi_mi-router-ac2100
 
@@ -1702,7 +1702,7 @@ define Device/xiaomi_redmi-router-ac2100
   DEVICE_MODEL := Redmi Router AC2100
   IMAGE_SIZE := 120320k
   DEVICE_PACKAGES += kmod-mt7603e kmod-mt7615d luci-app-mtwifi \
-	-wpad-openssl
+	wpad-openssl
 endef
 TARGET_DEVICES += xiaomi_redmi-router-ac2100
 
@@ -1711,7 +1711,7 @@ define Device/xiaoyu_xy-c5
   DEVICE_VENDOR := XiaoYu
   DEVICE_MODEL := XY-C5
   DEVICE_COMPAT_VERSION := 1.1
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 -wpad-openssl
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 wpad-openssl
 endef
 TARGET_DEVICES += xiaoyu_xy-c5
 
@@ -1721,7 +1721,7 @@ define Device/xzwifi_creativebox-v1
   DEVICE_VENDOR := CreativeBox
   DEVICE_MODEL := v1
   DEVICE_PACKAGES := kmod-ata-ahci kmod-mt7603 kmod-mt76x2 kmod-sdhci-mt7620 \
-	kmod-usb3 -wpad-openssl
+	kmod-usb3 wpad-openssl
 endef
 TARGET_DEVICES += xzwifi_creativebox-v1
 


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x ] 我知道

Hi maintainer,
I come across wireless issues (no hostapd) when building a firmware for newifi-d2, afterwards I found this. After correcting this and another issue, MTK wireless is working.
Please verify this, thank you.

BR