### PR TITLE
Add device support: Prafly_m8621t Marvell 88F6281 based on LCE patch (Modified by Jerry Yang) 

### DIFF
--- a/target/linux/kirkwood/base-files/etc/board.d/02_network
+++ b/target/linux/kirkwood/base-files/etc/board.d/02_network
@@ -43,6 +43,9 @@ zyxel,nsa325)
 	ucidef_set_interface_lan "eth0" "dhcp"
 	ucidef_set_interface_macaddr "lan" $( mtd_get_mac_ascii uboot_env ethaddr )
 	;;
+Prafly,m8621t)
+	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
+	;;
 *)
 	ucidef_set_interface_lan "eth0"
 	;;

--- a/target/linux/kirkwood/files/arch/arm/boot/dts/kirkwood-m8621t.dts
+++ b/target/linux/kirkwood/files/arch/arm/boot/dts/kirkwood-m8621t.dts
@@ -1,0 +1,237 @@
+/*
+ * kirkwood-pogo_e02.dts - Device tree file for Pogoplug E02
+ *
+ * Copyright (C) 2015 Christoph Junghans <ottxor@gentoo.org>
+ *
+ * based on information of dts files from
+ *  Arch Linux ARM by Oleg Rakhmanov <moonman.ca@gmail.com>
+ *  OpenWrt by Felix Kaechele <heffer@fedoraproject.org>
+ *
+ * This file is licensed under the terms of the GNU General Public
+ * License version 2.  This program is licensed "as is" without any
+ * warranty of any kind, whether express or implied.
+ */
+
+/dts-v1/;
+
+#include "kirkwood.dtsi"
+#include "kirkwood-6281.dtsi"
+
+/ {
+	model = "Prafly m8621t";
+	compatible = "Prafly,m8621t", "cloudengines,pogoe02", "marvell,kirkwood-88f6281","marvell,kirkwood";
+
+	aliases {
+		led-boot = &led_health;
+		led-running = &led_health;
+	};
+
+	memory {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+		stdout-path = &uart0;
+	};
+	
+	mbus {
+		pcie-controller {
+			status = "okay";
+
+			pcie@1,0 {
+				status = "okay";
+			};
+
+			pcie@2,0 {
+				status = "okay";
+			};
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_health: health {
+			label = "Prafly:green:health";
+			gpios = <&gpio1 16 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_sata: sata {
+			label = "Prafly:orange:sata";
+			gpios = <&gpio1 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	regulators {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		pinctrl-0 = <&pmx_usb_power_enable>;
+		pinctrl-names = "default";
+
+		usb_power: regulator@1 {
+			compatible = "regulator-fixed";
+			reg = <1>;
+			regulator-name = "USB Power";
+			regulator-min-microvolt = <5000000>;
+			regulator-max-microvolt = <5000000>;
+			enable-active-high;
+			regulator-always-on;
+			regulator-boot-on;
+			gpio = <&gpio0 29 GPIO_ACTIVE_HIGH>;
+		};
+	};
+	
+	ocp@f1000000 {
+		pinctrl: pin-controller@10000 {
+			pinctrl-names = "default";
+
+			pmx_sdio_cd: pmx-sdio-cd {
+				marvell,pins = "mpp28";
+				marvell,function = "gpio";
+			};
+		};
+
+		serial@12000 {
+			status = "okay";
+		};
+
+		sata@80000 {
+			status = "okay";
+			nr-ports = <2>;
+		};
+
+		mvsdio@90000 {
+			pinctrl-0 = <&pmx_sdio &pmx_sdio_cd>;
+			pinctrl-names = "default";
+			status = "okay";
+			cd-gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
+			/* No WP GPIO */
+		};
+	};
+
+};
+
+&pciec {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&pinctrl {
+	pinctrl-0 = < &pmx_usb_power_enable &pmx_led_orange &pmx_led_green >;
+	pinctrl-names = "default";
+
+	pmx_usb_power_enable: pmx-usb-power-enable {
+		marvell,pins = "mpp29";
+		marvell,function = "gpio";
+	};
+
+	pmx_led_green: pmx-led-green {
+		marvell,pins = "mpp48";
+		marvell,function = "gpio";
+	};
+
+	pmx_led_orange: pmx-led-orange {
+		marvell,pins = "mpp49";
+		marvell,function = "gpio";
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&nand {
+	chip-delay = <40>;
+	status = "okay";
+
+	partition@0 {
+		label = "u-boot";
+		reg = <0x0000000 0x100000>;
+		read-only;
+	};
+
+	partition@100000 {
+		label = "uImage";
+		reg = <0x0100000 0x400000>;
+	};
+
+	partition@500000 {
+		label = "rootfs";
+		reg = <0x0500000 0x6000000>;
+	};
+
+	partition@6500000 {
+		label = "root";
+		reg = <0x06500000 0x6b00000>;
+	};
+};
+
+&mdio {
+	status = "okay";
+
+	switch: switch@01 {
+		compatible = "marvell,mv88e6085";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x11>;
+		
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			
+			port@0 {
+				reg = <0>;
+				label = "lan1";
+			};
+	
+			port@1 {
+				reg = <1>;
+				label = "lan2";
+			};
+	
+			port@2 {
+				reg = <2>;
+				label = "lan3";
+			};
+	
+			port@3 {
+				reg = <3>;
+				label = "lan4";
+			};
+	
+			port@4 {
+				reg = <4>;
+				label = "wan";
+			};
+	
+			port@6 {
+				reg = <6>;
+				label = "cpu";
+				ethernet = <&eth0port>;
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+	ethernet0-port@0 {
+		speed = <1000>;
+		duplex = <1>;
+	};
+};
+
+&eth1 {
+	status = "disabled";
+};

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -139,6 +139,15 @@ define Device/linksys_ea4500
 endef
 TARGET_DEVICES += linksys_ea4500
 
+define Device/Prafly_m8621t
+  DEVICE_VENDOR := Prafly
+  DEVICE_MODEL := m8621t
+  DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 kmod-switch-mvswe61xxx kmod-ata-core kmod-mmc kmod-mvsdio kmod-usb2
+  KERNEL_INSTALL := 1
+  SUPPORTED_DEVICES += m8621t
+endef
+TARGET_DEVICES += Prafly_m8621t
+
 define Device/raidsonic_ib-nas62x0
   DEVICE_VENDOR := RaidSonic
   DEVICE_MODEL := ICY BOX IB-NAS62x0


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

Hardware all same with the Surfilter Net110, only the switch reg = <0x11> ,and wan reg = <4>, flash 512MiB

Hwinfo:
CPU: Feroceon 88FR131 Marwell 88F6281 ARMv5TE 1.2Ghz
RAM: 512MB (256MB + 256MB)
NAND: Samsung NAND 512MiB
SWITCH: Marvell 88E6171
PORT: 5 Gbps
Mini-Pcie: 1 half-size
SATA: 2 SATA
USB: 1 USB2
Other: console , SDHCI/MMC , Reset
