### PR TITLE
rockchip：修复linux 5.18 rk3399 wan pppoe拨号异常

### DIFF
--- a/target/linux/rockchip/patches-5.18/801-fix-stmmac_mdio.patch
+++ b/target/linux/rockchip/patches-5.18/801-fix-stmmac_mdio.patch
@@ -1,0 +1,24 @@
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_mdio.c
+@@ -498,6 +498,11 @@ int stmmac_mdio_register(struct net_devi
+ 	if (priv->plat->has_xgmac)
+ 		stmmac_xgmac2_mdio_read(new_bus, 0, MII_ADDR_C45);
+ 
++		stmmac_mdio_write(new_bus,0,31,2627);
++		stmmac_mdio_write(new_bus,0,25,0x1801);
++		stmmac_mdio_write(new_bus,0,31,0);
++		stmmac_mdio_write(new_bus,0,0,0x8000);
++
+ 	if (priv->plat->phy_node || mdio_node)
+ 		goto bus_register_done;
+ 
+--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
++++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+@@ -2907,6 +2907,8 @@ static int stmmac_init_dma_engine(struct
+ 	if (priv->extend_desc && (priv->mode == STMMAC_RING_MODE))
+ 		atds = 1;
+ 
++	msleep(1500);
++
+ 	ret = stmmac_reset(priv, priv->ioaddr);
+ 	if (ret) {
+ 		dev_err(priv->device, "Failed to reset the dma\n");


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [yes] 我知道
通过stmmac_mdio添加延时1.5秒wan复位https://github.com/DHDAXCW/DoorNet2/issues/5
