### PR TITLE
armvirt: switch to Kernel 5.10

### DIFF
--- a/target/linux/armvirt/Makefile
+++ b/target/linux/armvirt/Makefile
@@ -9,8 +9,7 @@ BOARDNAME:=QEMU ARM Virtual Machine
 FEATURES:=fpu pci rtc usb
 FEATURES+=cpiogz ext4 ramdisk squashfs targz
 
-KERNEL_PATCHVER:=5.4
-KERNEL_TESTING_PATCHVER:=5.10
+KERNEL_PATCHVER:=5.10
 
 include $(INCLUDE_DIR)/target.mk
 

--- a/target/linux/armvirt/Makefile
+++ b/target/linux/armvirt/Makefile
@@ -10,6 +10,7 @@ FEATURES:=fpu pci rtc usb
 FEATURES+=cpiogz ext4 ramdisk squashfs targz
 
 KERNEL_PATCHVER:=5.10
+KERNEL_TESTING_PATCHVER:=5.15
 
 include $(INCLUDE_DIR)/target.mk
 


### PR DESCRIPTION
Armvirt is a development and testing platform and should therefore use
the latest OpenWrt Kernel by default.

Tested via qemu.

Acked-by: Rosen Penev <rosenp@gmail.com>
Acked-by: Yousong Zhou <yszhou4tech@gmail.com>

Signed-off-by: Paul Spooren <mail@aparcar.org>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
