### PR TITLE
kernel: modules: fix kmod-mdio-devres dependency for 5.15

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1027,8 +1027,8 @@ define KernelPackage/of-mdio
   KCONFIG:=CONFIG_OF_MDIO
   FILES:= \
 	$(LINUX_DIR)/drivers/net/phy/fixed_phy.ko \
-	$(LINUX_DIR)/drivers/of/of_mdio.ko@lt5.10 \
-	$(LINUX_DIR)/drivers/net/mdio/of_mdio.ko@ge5.10
+	$(LINUX_DIR)/drivers/net/mdio/of_mdio.ko \
+	$(LINUX_DIR)/drivers/net/mdio/fwnode_mdio.ko@ge5.15
   AUTOLOAD:=$(call AutoLoad,41,of_mdio)
 endef
 


### PR DESCRIPTION
Fix:
Package kmod-mdio-devres is missing dependencies for the following libraries:
 of_mdio.ko
Package kmod-of-mdio is missing dependencies for the following libraries:
 fwnode_mdio.ko

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
