### PR TITLE
kernel: mdio-devres: fix of-mdio dependency

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -142,7 +142,7 @@ $(eval $(call KernelPackage,mii))
 define KernelPackage/mdio-devres
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Supports MDIO device registration
-  DEPENDS:=@(LINUX_5_10||LINUX_5_15||LINUX_5_18||LINUX_5_19) +kmod-libphy PACKAGE_kmod-of-mdio:kmod-of-mdio
+  DEPENDS:=@(LINUX_5_10||LINUX_5_15||LINUX_5_18||LINUX_5_19) +kmod-libphy +(TARGET_armvirt||TARGET_bcm27xx_bcm2708||TARGET_tegra):kmod-of-mdio
   KCONFIG:=CONFIG_MDIO_DEVRES
   HIDDEN:=1
   FILES:=$(LINUX_DIR)/drivers/net/phy/mdio_devres.ko


### PR DESCRIPTION
armvirt/64 when compiled with ALL_KMODS=y reports following:

 Package kmod-mdio-devres is missing dependencies for the following libraries:
 of_mdio.ko

Signed-off-by: Petr Štetiar <ynezz@true.cz>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
