### PR TITLE
hostapd: fix this patch to cause some wireless driver DFS detection

### DIFF
--- a/package/network/services/hostapd/patches/800-hostapd-2.10-lar.patch
+++ b/package/network/services/hostapd/patches/800-hostapd-2.10-lar.patch
@@ -1,10 +1,11 @@
 diff -ru a/src/ap/hw_features.c b/src/ap/hw_features.c
 --- a/src/ap/hw_features.c	2022-01-16 15:51:29.000000000 -0500
 +++ b/src/ap/hw_features.c	2022-07-06 22:57:53.007315518 -0500
-@@ -26,6 +26,17 @@
+@@ -24,6 +24,19 @@
  #include "beacon.h"
  #include "hw_features.h"
  
++#ifdef CONFIG_IWLWIFI
 +static void ieee80211n_do_nothing(struct hostapd_iface *iface)
 +{
 +			wpa_printf(MSG_DEBUG,
@@ -16,13 +17,15 @@ diff -ru a/src/ap/hw_features.c b/src/ap/hw_features.c
 +static void ieee80211n_scan_channels_5g(struct hostapd_iface *iface,
 +					struct wpa_driver_scan_params *params);
 +
++#endif
  
  void hostapd_free_hw_features(struct hostapd_hw_modes *hw_features,
  			      size_t num_hw_features)
-@@ -82,6 +93,33 @@
+@@ -82,6 +93,35 @@
  
  	if (hostapd_drv_none(hapd))
  		return -1;
++#ifdef CONFIG_IWLWIFI
 +
 +
 +	if (!iface->conf->noscan) { 
@@ -50,37 +53,35 @@ diff -ru a/src/ap/hw_features.c b/src/ap/hw_features.c
 +                }
 +        } 
 +	}
++#endif
  	modes = hostapd_get_hw_feature_data(hapd, &num_modes, &flags,
  					    &dfs_domain);
  	if (modes == NULL) {
-
-@@ -308,7 +346,6 @@
- 			       sec_chan);
- }
- 
--
- static void ieee80211n_check_scan(struct hostapd_iface *iface)
- {
- 	struct wpa_scan_results *scan_res;
-@@ -517,8 +554,10 @@
- 	int ret;
+@@ -518,8 +556,15 @@
  
  	/* Check that HT40 is used and PRI / SEC switch is allowed */
--	if (!iface->conf->secondary_channel || iface->conf->no_pri_sec_switch)
-+	if (!iface->conf->secondary_channel || iface->conf->no_pri_sec_switch || iface->conf->noscan) {
+ 	if (!iface->conf->secondary_channel || iface->conf->no_pri_sec_switch ||
++#ifdef CONFIG_IWLWIFI
++		iface->conf->noscan) {
 +                wpa_printf(MSG_DEBUG, "Not scanning due to noscan?");
++		return 0;
++	}
++#else
+ 		iface->conf->noscan)
  		return 0;
-+        }
++#endif
  
  	hostapd_set_state(iface, HAPD_IFACE_HT_SCAN);
  	wpa_printf(MSG_DEBUG, "Scan for neighboring BSSes prior to enabling "
-@@ -916,7 +954,7 @@
+@@ -916,7 +954,11 @@
  	if (!hostapd_is_usable_edmg(iface))
  		return 0;
  
--	if (!iface->conf->secondary_channel)
++#ifdef CONFIG_IWLWIFI
 +	if (!iface->conf->secondary_channel || iface->conf->noscan)
++#else
+ 	if (!iface->conf->secondary_channel)
++#endif
  		return 1;
  
  	if (hostapd_is_usable_chan(iface, iface->freq +
-


### PR DESCRIPTION
由于此补丁 (a5133362edb5d2ff1708bd65de0801141a8eda99) 是针对 ax200/ax210，
但它影响了部分无线驱动检测 DFS 导致开不起 160MHz，故作此修改。
已在 ath11k 编译运行，能够重新开启 160MHz。但我没有条件，未在 ax200/ax210 进行编译运行。