### PR TITLE
Enable intel_gpu Guc huc

### DIFF
--- a/target/linux/x86/patches-5.19/992-intel-guc.patch
+++ b/target/linux/x86/patches-5.19/992-intel-guc.patch
@@ -1,0 +1,18 @@
+--- a/drivers/gpu/drm/i915/gt/uc/intel_uc.c
++++ b/drivers/gpu/drm/i915/gt/uc/intel_uc.c
+@@ -27,13 +27,13 @@ static void uc_expand_default_options(st
+ 
+ 	/* Don't enable GuC/HuC on pre-Gen12 */
+ 	if (GRAPHICS_VER(i915) < 12) {
+-		i915->params.enable_guc = 0;
++		i915->params.enable_guc = 3;
+ 		return;
+ 	}
+ 
+ 	/* Don't enable GuC/HuC on older Gen12 platforms */
+ 	if (IS_TIGERLAKE(i915) || IS_ROCKETLAKE(i915)) {
+-		i915->params.enable_guc = 0;
++		i915->params.enable_guc = 3;
+ 		return;
+ 	}
+ 


### PR DESCRIPTION
慎重合并。。。我没办法对用户端设备GPU型号做出判断

启用intel核显低电压模式，提高转码性能。某种程度上讲，此模式为真正的硬件解码模式。
仅支持 H.264 HEVC两种编码器。

注意：

过旧型号的GPU可能不起作用或出现异常，如出现异常，移除此补丁或取消i915驱动即可
不影响直通等虚拟化动作，但在直通或虚拟化下此功能失效（驱动不允许，无解）
不影响Docker
即使加载成功还需要软件调用，软件不支持白搭。
Jellyfin支持此模式
基本上只能应用于物理机openwrt

目前只通过加载测试，实际使用暂未测试。
加载通过：
i5-10500T  UHD630
i5-11500T UHD750

成功表现：
内核日志搜索 i915  可见有字段 guc 等固件加载成功提示。
