### PR TITLE
linux-firmware: fix Intel GUC firmware support for N5105/N6005

### DIFF
--- a/package/firmware/linux-firmware/intel.mk
+++ b/package/firmware/linux-firmware/intel.mk
@@ -227,6 +227,7 @@ define Package/i915-firmware/install
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/i915/ehl_guc_49.0.1.bin $(1)/lib/firmware/i915/
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/i915/ehl_guc_62.0.0.bin $(1)/lib/firmware/i915/
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/i915/ehl_guc_69.0.3.bin $(1)/lib/firmware/i915/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/i915/ehl_guc_70.1.1.bin $(1)/lib/firmware/i915/
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/i915/ehl_huc_9.0.0.bin $(1)/lib/firmware/i915/
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/i915/glk_dmc_ver1_04.bin $(1)/lib/firmware/i915/
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/i915/glk_guc_32.0.3.bin $(1)/lib/firmware/i915/


### PR DESCRIPTION
N5105/6005 的 GUC 最新固件应为 ehl_guc_70.1.1.bin, 使用 ehl_guc_69.0.3.bin 将不能正常加载 GUC 固件

**ehl_guc_69.0.3.bin** `root@OpenWrt[x86_64]:~# dmesg | grep i915`
> [   15.693599] i915 0000:00:02.0: [drm] Finished loading DMC firmware i915/icl_dmc_ver1_09.bin (v1.9)
[   19.317088] i915 0000:00:02.0: GuC firmware i915/ehl_guc_70.1.1.bin: fetch failed with error -12
[   19.318104] i915 0000:00:02.0: Please file a bug on drm/i915; see https://gitlab.freedesktop.org/drm/intel/-/wikis/How-to-file-i915-bugs for details.
[   19.319601] i915 0000:00:02.0: [drm] GuC firmware(s) can be downloaded from https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/tree/i915
[   19.321752] i915 0000:00:02.0: [drm] GuC firmware i915/ehl_guc_70.1.1.bin version 0.0
[   19.322603] i915 0000:00:02.0: GuC initialization failed -8
[   19.323276] i915 0000:00:02.0: Enabling uc failed (-5)
[   19.323848] i915 0000:00:02.0: Failed to initialize GPU, declaring it wedged!
[   19.339098] i915 0000:00:02.0: [drm:add_taint_for_CI [i915]] CI tainted:0x9 by intel_gt_set_wedged_on_init+0x47/0x50 [i915]
[   19.463388] [drm] Initialized i915 1.6.0 20201103 for 0000:00:02.0 on minor 0
[   19.585669] fbcon: i915drmfb (fb0) is primary device
[   19.635686] i915 0000:00:02.0: [drm] fb0: i915drmfb frame buffer device

**ehl_guc_70.1.1.bin** `root@OpenWrt[x86_64]:~# dmesg | grep i915`
> [   15.782124] i915 0000:00:02.0: [drm] Finished loading DMC firmware i915/icl_dmc_ver1_09.bin (v1.9)
[   15.807568] i915 0000:00:02.0: [drm] GuC firmware i915/ehl_guc_70.1.1.bin version 70.1
[   15.808411] i915 0000:00:02.0: [drm] HuC firmware i915/ehl_huc_9.0.0.bin version 9.0
[   15.824779] i915 0000:00:02.0: [drm] HuC authenticated
[   15.825842] i915 0000:00:02.0: [drm] GuC submission enabled
[   15.826473] i915 0000:00:02.0: [drm] GuC SLPC disabled
[   15.842051] [drm] Initialized i915 1.6.0 20201103 for 0000:00:02.0 on minor 0
[   15.955659] fbcon: i915drmfb (fb0) is primary device
[   15.995663] i915 0000:00:02.0: [drm] fb0: i915drmfb frame buffer device

Tested on N5105 k5.19.5

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
