### PR TITLE
ramips: add support for C-Life XG1 [WIFI6]

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -48,6 +48,7 @@ ravpower,rp-wd03)
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x4000" "0x1000" "0x1000"
 	;;
+c-life,xg1|\
 jcg,q20)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;

--- a/target/linux/ramips/dts/mt7621_c-life_xg1.dts
+++ b/target/linux/ramips/dts/mt7621_c-life_xg1.dts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "c-life,xg1", "mediatek,mt7621-soc";
+	model = "C-Life XG1";
+
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_blue;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status_red {
+			label = "red:status";
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_blue: status_blue {
+			label = "blue:status";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+		};
+
+		partition@80000 {
+			label = "Nvram";
+			reg = <0x80000 0x40000>;
+			read-only;
+		};
+
+		partition@c0000 {
+			label = "Bdata";
+			reg = <0xc0000 0x40000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "Factory";
+			reg = <0x100000 0x80000>;
+			read-only;
+		};
+
+		partition@180000 {
+			label = "crash";
+			reg = <0x180000 0x40000>;
+			read-only;
+		};
+
+		partition@1c0000 {
+			label = "crash_log";
+			reg = <0x1c0000 0x40000>;
+			read-only;
+		};
+
+		partition@200000 {
+			label = "kernel";
+			reg = <0x200000 0x400000>;
+		};
+
+		partition@600000 {
+			label = "ubi";
+			reg = <0x600000 0x7980000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&gmac0 {
+	mtd-mac-address = <&factory 0x04>;
+};
+
+&gmac1 {
+	mtd-mac-address = <&factory 0x0a>;
+	phy-mode = "rgmii";
+	status = "okay";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+		pause;
+	};
+};
+
+&gsw {
+	mediatek,portmap = "llllw";
+	status = "okay";
+};
+
+&hnat {
+	mtketh-wan = "eth1";
+	mtketh-ppd = "eth0";
+	mtketh-lan = "eth0";
+	mtketh-max-gmac = <2>;
+	/delete-property/ mtkdsa-wan-port;
+};
+
+&switch0 {
+	status = "disabled";
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -380,6 +380,23 @@ define Device/buffalo_wsr-600dhp
 endef
 TARGET_DEVICES += buffalo_wsr-600dhp
 
+define Device/c-life_xg1
+  $(Device/dsa-migration)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  UBINIZE_OPTS := -E 5
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 91136k
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size
+  DEVICE_VENDOR := C-Life
+  DEVICE_MODEL := XG1
+  DEVICE_PACKAGES := kmod-mt7915e uboot-envtools kmod-usb3
+endef
+TARGET_DEVICES += c-life_xg1
+
 define Device/cudy_wr1300
   $(Device/dsa-migration)
   IMAGE_SIZE := 15872k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -45,6 +45,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan:1" "2:lan:2" "3:lan:3" "4:lan:4" "0:wan" "6@eth0"
 		;;
+	c-life,xg1)
+		ucidef_add_switch "switch0" \
+			"1:lan" "2:lan" "0:wan" "6u@eth0" "5u@eth1"
+		;;
 	d-team,newifi-d2)
 		ucidef_add_switch "switch0" \
 			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan:5" "6@eth0"
@@ -142,6 +146,11 @@ ramips_setup_macs()
 		local index="$(find_mtd_index "board_data")"
 		wan_mac="$(grep -m1 mac= "/dev/mtd${index}" | cut -d= -f2)"
 		lan_mac=$wan_mac
+		;;
+	c-life,xg1)
+		base_mac=$(cat /sys/class/net/eth0/address)
+		lan_mac=$(macaddr_add "$base_mac" -1)
+		wan_mac=$(macaddr_add "$lan_mac" -1)
 		;;
 	d-team,newifi-d2)
 		lan_mac=$(cat /sys/class/net/eth0/address)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -10,6 +10,12 @@ PHYNBR=${DEVPATH##*/phy}
 board=$(board_name)
 
 case "$board" in
+	c-life,xg1)
+		if [ "$PHYNBR" = "1" ]; then
+			base_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1)
+			macaddr_setbit_la "$base_mac" > /sys${DEVPATH}/macaddress
+		fi
+		;;
 	dlink,dir-853-a3)
 		[ "$PHYNBR" = "0" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary factory 0xe000)" \

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -77,6 +77,7 @@ platform_do_upgrade() {
 	asus,rt-ac85p|\
 	beeline,smartbox-giga|\
 	beeline,smartbox-turbo-plus|\
+	c-life,xg1|\
 	dlink,dir-1960-a1|\
 	dlink,dir-2640-a1|\
 	dlink,dir-2660-a1|\


### PR DESCRIPTION
  CPU: MediaTek MT7621AT
  Flash: Micron MT29F2G08ABAGAWP 128M
  RAM: 256 M
  WiFi: MT7915 2.4/5 GHz 2T2R
  Ethernet: 10/100/1000 Mbps x3
  LED: Status (red / blue / white / green / purple / cyan)
  USB: 2.0 x 1
  ZigBee/BlueTooth
  USB Audio: iec958 x 1
  Button: Reset
  Power: DC 12V,1.5A

开启ssh方法:
  打开网页:192.168.10.1,用户路由器底面标注的用户名密码完成登陆。
  然后打开网页:http://192.168.10.1/cgi-bin/luci/admin/mtk/console，在命令行中输入以下命令:
  echo -en "root\nroot\n" | passwd
  然后打开网页:http://192.168.10.1/cgi-bin/luci/pti/ssh_open
  即可ssh登陆192.168.10.1,用户名root,密码root

刷入openwrt:

开启ssh后，上传breed-mt7621-xiaomi-r3g.bin到路由器/tmp目录。
然后使用下面命令刷入breed:
mtd -r write /tmp/breed-mt7621-xiaomi-r3g.bin Bootloader
等待机器重启，等1分钟断开电源。
按住C-Life XG1机身正面的圆形IoT按钮(gpio 18),通电就能进入breed刷机.

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
