### PR TITLE
kernel: fixes build error and refresh 5.15 patches

### DIFF
--- a/target/linux/ath79/patches-5.15/408-mtd-redboot_partition_scan.patch
+++ b/target/linux/ath79/patches-5.15/408-mtd-redboot_partition_scan.patch
@@ -1,6 +1,6 @@
 --- a/drivers/mtd/parsers/redboot.c
 +++ b/drivers/mtd/parsers/redboot.c
-@@ -90,12 +90,18 @@ static int parse_redboot_partitions(stru
+@@ -91,12 +91,18 @@ static int parse_redboot_partitions(stru
  
  	parse_redboot_of(master);
  
@@ -19,7 +19,7 @@
  				return -EIO;
  			}
  			offset -= master->erasesize;
-@@ -108,10 +114,6 @@ nogood:
+@@ -109,10 +115,6 @@ nogood:
  				goto nogood;
  		}
  	}
@@ -30,7 +30,7 @@
  
  	pr_notice("Searching for RedBoot partition table in %s at offset 0x%lx\n",
  		  master->name, offset);
-@@ -183,6 +185,12 @@ nogood:
+@@ -184,6 +186,12 @@ nogood:
  	}
  	if (i == numslots) {
  		/* Didn't find it */

--- a/target/linux/generic/backport-5.15/850-v5.17-0007-PCI-aardvark-Mask-all-interrupts-when-unbinding-driv.patch
+++ b/target/linux/generic/backport-5.15/850-v5.17-0007-PCI-aardvark-Mask-all-interrupts-when-unbinding-driv.patch
@@ -18,7 +18,7 @@ Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
 
 --- a/drivers/pci/controller/pci-aardvark.c
 +++ b/drivers/pci/controller/pci-aardvark.c
-@@ -1874,6 +1874,27 @@ static int advk_pcie_remove(struct platf
+@@ -1889,6 +1889,27 @@ static int advk_pcie_remove(struct platf
  	advk_writel(pcie, PCIE_ISR1_ALL_MASK, PCIE_ISR1_REG);
  	advk_writel(pcie, PCIE_IRQ_ALL_MASK, HOST_CTRL_INT_STATUS_REG);
  

--- a/target/linux/generic/backport-5.15/850-v5.17-0008-PCI-aardvark-Fix-memory-leak-in-driver-unbind.patch
+++ b/target/linux/generic/backport-5.15/850-v5.17-0008-PCI-aardvark-Fix-memory-leak-in-driver-unbind.patch
@@ -21,7 +21,7 @@ Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
 
 --- a/drivers/pci/controller/pci-aardvark.c
 +++ b/drivers/pci/controller/pci-aardvark.c
-@@ -1912,6 +1912,9 @@ static int advk_pcie_remove(struct platf
+@@ -1927,6 +1927,9 @@ static int advk_pcie_remove(struct platf
  	val &= ~LINK_TRAINING_EN;
  	advk_writel(pcie, val, PCIE_CORE_CTRL0_REG);
  

--- a/target/linux/generic/backport-5.15/850-v5.17-0009-PCI-aardvark-Assert-PERST-when-unbinding-driver.patch
+++ b/target/linux/generic/backport-5.15/850-v5.17-0009-PCI-aardvark-Assert-PERST-when-unbinding-driver.patch
@@ -20,7 +20,7 @@ Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
 
 --- a/drivers/pci/controller/pci-aardvark.c
 +++ b/drivers/pci/controller/pci-aardvark.c
-@@ -1915,6 +1915,10 @@ static int advk_pcie_remove(struct platf
+@@ -1930,6 +1930,10 @@ static int advk_pcie_remove(struct platf
  	/* Free config space for emulated root bridge */
  	pci_bridge_emul_cleanup(&pcie->bridge);
  

--- a/target/linux/generic/backport-5.15/850-v5.17-0010-PCI-aardvark-Disable-link-training-when-unbinding-dr.patch
+++ b/target/linux/generic/backport-5.15/850-v5.17-0010-PCI-aardvark-Disable-link-training-when-unbinding-dr.patch
@@ -20,7 +20,7 @@ Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
 
 --- a/drivers/pci/controller/pci-aardvark.c
 +++ b/drivers/pci/controller/pci-aardvark.c
-@@ -1919,6 +1919,11 @@ static int advk_pcie_remove(struct platf
+@@ -1934,6 +1934,11 @@ static int advk_pcie_remove(struct platf
  	if (pcie->reset_gpio)
  		gpiod_set_value_cansleep(pcie->reset_gpio, 1);
  

--- a/target/linux/generic/backport-5.15/850-v5.17-0011-PCI-aardvark-Disable-common-PHY-when-unbinding-drive.patch
+++ b/target/linux/generic/backport-5.15/850-v5.17-0011-PCI-aardvark-Disable-common-PHY-when-unbinding-drive.patch
@@ -18,7 +18,7 @@ Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
 
 --- a/drivers/pci/controller/pci-aardvark.c
 +++ b/drivers/pci/controller/pci-aardvark.c
-@@ -1634,6 +1634,9 @@ static int advk_pcie_enable_phy(struct a
+@@ -1649,6 +1649,9 @@ static int advk_pcie_enable_phy(struct a
  		return ret;
  	}
  

--- a/target/linux/generic/hack-5.15/710-net-dsa-mv88e6xxx-default-VID-1.patch
+++ b/target/linux/generic/hack-5.15/710-net-dsa-mv88e6xxx-default-VID-1.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -2321,6 +2321,7 @@ static int mv88e6xxx_port_fdb_add(struct
+@@ -2320,6 +2320,7 @@ static int mv88e6xxx_port_fdb_add(struct
  	struct mv88e6xxx_chip *chip = ds->priv;
  	int err;
  
@@ -8,7 +8,7 @@
  	mv88e6xxx_reg_lock(chip);
  	err = mv88e6xxx_port_db_load_purge(chip, port, addr, vid,
  					   MV88E6XXX_G1_ATU_DATA_STATE_UC_STATIC);
-@@ -2335,6 +2336,7 @@ static int mv88e6xxx_port_fdb_del(struct
+@@ -2334,6 +2335,7 @@ static int mv88e6xxx_port_fdb_del(struct
  	struct mv88e6xxx_chip *chip = ds->priv;
  	int err;
  

--- a/target/linux/generic/hack-5.15/711-net-dsa-mv88e6xxx-disable-ATU-violation.patch
+++ b/target/linux/generic/hack-5.15/711-net-dsa-mv88e6xxx-disable-ATU-violation.patch
@@ -1,6 +1,6 @@
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -2980,6 +2980,9 @@ static int mv88e6xxx_setup_port(struct m
+@@ -2982,6 +2982,9 @@ static int mv88e6xxx_setup_port(struct m
  	else
  		reg = 1 << port;
  

--- a/target/linux/generic/hack-5.15/953-net-patch-linux-kernel-to-support-shortcut-fe.patch
+++ b/target/linux/generic/hack-5.15/953-net-patch-linux-kernel-to-support-shortcut-fe.patch
@@ -131,7 +131,7 @@
 +	int (*fast_recv)(struct sk_buff *skb);
 +#endif
 +
- 	net_timestamp_check(!netdev_tstamp_prequeue, skb);
+ 	net_timestamp_check(!READ_ONCE(netdev_tstamp_prequeue), skb);
  
  	trace_netif_receive_skb(skb);
 @@ -5299,6 +5316,15 @@ another_round:

--- a/target/linux/generic/pending-5.15/419-mtd-redboot-add-of_match_table-with-DT-binding.patch
+++ b/target/linux/generic/pending-5.15/419-mtd-redboot-add-of_match_table-with-DT-binding.patch
@@ -12,7 +12,7 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 
 --- a/drivers/mtd/parsers/redboot.c
 +++ b/drivers/mtd/parsers/redboot.c
-@@ -304,6 +304,7 @@ nogood:
+@@ -305,6 +305,7 @@ nogood:
  
  static const struct of_device_id mtd_parser_redboot_of_match_table[] = {
  	{ .compatible = "redboot-fis" },

--- a/target/linux/generic/pending-5.15/760-net-dsa-mv88e6xxx-fix-vlan-setup.patch
+++ b/target/linux/generic/pending-5.15/760-net-dsa-mv88e6xxx-fix-vlan-setup.patch
@@ -17,7 +17,7 @@ Signed-off-by: DENG Qingfang <dqfext@gmail.com>
 
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -3193,6 +3193,7 @@ static int mv88e6xxx_setup(struct dsa_sw
+@@ -3192,6 +3192,7 @@ static int mv88e6xxx_setup(struct dsa_sw
  
  	chip->ds = ds;
  	ds->slave_mii_bus = mv88e6xxx_default_mdio_bus(chip);

--- a/target/linux/generic/pending-5.15/768-net-dsa-mv88e6xxx-Request-assisted-learning-on-CPU-port.patch
+++ b/target/linux/generic/pending-5.15/768-net-dsa-mv88e6xxx-Request-assisted-learning-on-CPU-port.patch
@@ -17,7 +17,7 @@ Signed-off-by: Tobias Waldekranz <tobias@waldekranz.com>
 
 --- a/drivers/net/dsa/mv88e6xxx/chip.c
 +++ b/drivers/net/dsa/mv88e6xxx/chip.c
-@@ -6319,6 +6319,7 @@ static int mv88e6xxx_register_switch(str
+@@ -6320,6 +6320,7 @@ static int mv88e6xxx_register_switch(str
  	ds->ops = &mv88e6xxx_switch_ops;
  	ds->ageing_time_min = chip->info->age_time_coeff;
  	ds->ageing_time_max = chip->info->age_time_coeff * U8_MAX;

--- a/target/linux/generic/pending-5.15/773-net-sfp-add-support-for-HALNy-GPON-SFP.patch
+++ b/target/linux/generic/pending-5.15/773-net-sfp-add-support-for-HALNy-GPON-SFP.patch
@@ -24,7 +24,7 @@ Signed-off-by: Russell King (Oracle) <rmk+kernel@armlinux.org.uk>
 +	if (bus->sfp_quirk && bus->sfp_quirk->modes)
  		bus->sfp_quirk->modes(id, modes);
  
- 	bitmap_or(support, support, modes, __ETHTOOL_LINK_MODE_MASK_NBITS);
+ 	linkmode_or(support, support, modes);
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
 @@ -320,6 +320,23 @@ static void sfp_fixup_ignore_tx_fault(st

--- a/target/linux/generic/pending-5.15/850-0016-PCI-aardvark-Add-support-for-PME-interrupts.patch
+++ b/target/linux/generic/pending-5.15/850-0016-PCI-aardvark-Add-support-for-PME-interrupts.patch
@@ -25,7 +25,7 @@ Signed-off-by: Marek Behún <kabel@kernel.org>
 
 --- a/drivers/pci/controller/pci-aardvark.c
 +++ b/drivers/pci/controller/pci-aardvark.c
-@@ -1553,6 +1553,22 @@ static void advk_pcie_handle_int(struct
+@@ -1568,6 +1568,22 @@ static void advk_pcie_handle_int(struct
  			dev_err_ratelimited(&pcie->pdev->dev, "unhandled ERR IRQ\n");
  	}
  

--- a/target/linux/generic/pending-5.15/851-0006-Revert-PCI-aardvark-Fix-initialization-with-old-Marv.patch
+++ b/target/linux/generic/pending-5.15/851-0006-Revert-PCI-aardvark-Fix-initialization-with-old-Marv.patch
@@ -23,7 +23,7 @@ Acked-by: Miquel Raynal <miquel.raynal@bootlin.com>
 
 --- a/drivers/pci/controller/pci-aardvark.c
 +++ b/drivers/pci/controller/pci-aardvark.c
-@@ -1631,9 +1631,7 @@ static int advk_pcie_enable_phy(struct a
+@@ -1647,9 +1647,7 @@ static int advk_pcie_enable_phy(struct a
  	}
  
  	ret = phy_power_on(pcie->phy);

--- a/target/linux/rockchip/patches-5.15/007-arm64-dts-rockchip-add-EEPROM-node-for-NanoPi-R4S.patch
+++ b/target/linux/rockchip/patches-5.15/007-arm64-dts-rockchip-add-EEPROM-node-for-NanoPi-R4S.patch
@@ -13,7 +13,7 @@ Signed-off-by: Tianling Shen <cnsztl@gmail.com>
 
 --- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
-@@ -75,6 +75,19 @@ &emmc_phy {
+@@ -68,6 +68,19 @@
  	status = "disabled";
  };
  

--- a/target/linux/rockchip/patches-5.15/009-v5.16-drivers-rockchip-thermal-Allow-more-resets-for-tsadc.patch
+++ b/target/linux/rockchip/patches-5.15/009-v5.16-drivers-rockchip-thermal-Allow-more-resets-for-tsadc.patch
@@ -17,7 +17,7 @@ Signed-off-by: Daniel Lezcano <daniel.lezcano@linaro.org>
 
 --- a/drivers/thermal/rockchip_thermal.c
 +++ b/drivers/thermal/rockchip_thermal.c
-@@ -1383,7 +1383,7 @@ static int rockchip_thermal_probe(struct platform_device *pdev)
+@@ -1383,7 +1383,7 @@ static int rockchip_thermal_probe(struct
  	if (IS_ERR(thermal->regs))
  		return PTR_ERR(thermal->regs);
  

--- a/target/linux/rockchip/patches-5.15/010-v5.16-net-stmmac-Add-GFP_DMA32-for-rx-buffers-if-no-64.patch
+++ b/target/linux/rockchip/patches-5.15/010-v5.16-net-stmmac-Add-GFP_DMA32-for-rx-buffers-if-no-64.patch
@@ -15,7 +15,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
 +++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
-@@ -1463,16 +1463,20 @@ static int stmmac_init_rx_buffers(struct stmmac_priv *priv, struct dma_desc *p,
+@@ -1455,16 +1455,20 @@ static int stmmac_init_rx_buffers(struct
  {
  	struct stmmac_rx_queue *rx_q = &priv->rx_queue[queue];
  	struct stmmac_rx_buffer *buf = &rx_q->buf_pool[i];
@@ -38,7 +38,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  		if (!buf->sec_page)
  			return -ENOMEM;
  
-@@ -4496,6 +4500,10 @@ static inline void stmmac_rx_refill(struct stmmac_priv *priv, u32 queue)
+@@ -4496,6 +4500,10 @@ static inline void stmmac_rx_refill(stru
  	struct stmmac_rx_queue *rx_q = &priv->rx_queue[queue];
  	int dirty = stmmac_rx_dirty(priv, queue);
  	unsigned int entry = rx_q->dirty_rx;
@@ -49,7 +49,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  
  	while (dirty-- > 0) {
  		struct stmmac_rx_buffer *buf = &rx_q->buf_pool[entry];
-@@ -4508,13 +4516,13 @@ static inline void stmmac_rx_refill(struct stmmac_priv *priv, u32 queue)
+@@ -4508,13 +4516,13 @@ static inline void stmmac_rx_refill(stru
  			p = rx_q->dma_rx + entry;
  
  		if (!buf->page) {

--- a/target/linux/rockchip/patches-5.15/032-v5.17-phy-rockchip-inno-usb2-support-address-cells.patch
+++ b/target/linux/rockchip/patches-5.15/032-v5.17-phy-rockchip-inno-usb2-support-address-cells.patch
@@ -20,7 +20,7 @@ Signed-off-by: Vinod Koul <vkoul@kernel.org>
 
 --- a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
 +++ b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
-@@ -1090,12 +1090,21 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
+@@ -1098,12 +1098,21 @@ static int rockchip_usb2phy_probe(struct
  		rphy->usbgrf = NULL;
  	}
  

--- a/target/linux/rockchip/patches-5.15/033-v5.17-phy-rockchip-inno-usb2-support-standalone-phy-nodes.patch
+++ b/target/linux/rockchip/patches-5.15/033-v5.17-phy-rockchip-inno-usb2-support-standalone-phy-nodes.patch
@@ -17,7 +17,7 @@ Signed-off-by: Vinod Koul <vkoul@kernel.org>
 
 --- a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
 +++ b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
-@@ -1073,12 +1073,19 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
+@@ -1081,12 +1081,19 @@ static int rockchip_usb2phy_probe(struct
  		return -EINVAL;
  	}
  

--- a/target/linux/rockchip/patches-5.15/034-v5.17-phy-rockchip-inno-usb2-support-muxed-interrupts.patch
+++ b/target/linux/rockchip/patches-5.15/034-v5.17-phy-rockchip-inno-usb2-support-muxed-interrupts.patch
@@ -33,7 +33,7 @@ Signed-off-by: Vinod Koul <vkoul@kernel.org>
  	const struct rockchip_usb2phy_cfg	*phy_cfg;
  	struct rockchip_usb2phy_port	ports[USB2PHY_NUM_PORTS];
  };
-@@ -926,6 +928,102 @@ static irqreturn_t rockchip_usb2phy_otg_mux_irq(int irq, void *data)
+@@ -934,6 +936,102 @@ static irqreturn_t rockchip_usb2phy_otg_
  		return IRQ_NONE;
  }
  
@@ -136,7 +136,7 @@ Signed-off-by: Vinod Koul <vkoul@kernel.org>
  static int rockchip_usb2phy_host_port_init(struct rockchip_usb2phy *rphy,
  					   struct rockchip_usb2phy_port *rport,
  					   struct device_node *child_np)
-@@ -939,18 +1037,9 @@ static int rockchip_usb2phy_host_port_init(struct rockchip_usb2phy *rphy,
+@@ -947,18 +1045,9 @@ static int rockchip_usb2phy_host_port_in
  	mutex_init(&rport->mutex);
  	INIT_DELAYED_WORK(&rport->sm_work, rockchip_usb2phy_sm_work);
  
@@ -157,7 +157,7 @@ Signed-off-by: Vinod Koul <vkoul@kernel.org>
  		return ret;
  	}
  
-@@ -999,44 +1088,10 @@ static int rockchip_usb2phy_otg_port_init(struct rockchip_usb2phy *rphy,
+@@ -1007,44 +1096,10 @@ static int rockchip_usb2phy_otg_port_ini
  	INIT_DELAYED_WORK(&rport->chg_work, rockchip_chg_detect_work);
  	INIT_DELAYED_WORK(&rport->otg_sm_work, rockchip_usb2phy_otg_sm_work);
  
@@ -206,7 +206,7 @@ Signed-off-by: Vinod Koul <vkoul@kernel.org>
  
  	if (!IS_ERR(rphy->edev)) {
  		rport->event_nb.notifier_call = rockchip_otg_event;
-@@ -1116,6 +1171,7 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
+@@ -1124,6 +1179,7 @@ static int rockchip_usb2phy_probe(struct
  	phy_cfgs = match->data;
  	rphy->chg_state = USB_CHG_STATE_UNDEFINED;
  	rphy->chg_type = POWER_SUPPLY_TYPE_UNKNOWN;
@@ -214,7 +214,7 @@ Signed-off-by: Vinod Koul <vkoul@kernel.org>
  	platform_set_drvdata(pdev, rphy);
  
  	ret = rockchip_usb2phy_extcon_register(rphy);
-@@ -1195,6 +1251,20 @@ static int rockchip_usb2phy_probe(struct platform_device *pdev)
+@@ -1203,6 +1259,20 @@ next_child:
  	}
  
  	provider = devm_of_phy_provider_register(dev, of_phy_simple_xlate);

--- a/target/linux/rockchip/patches-5.15/035-v5.17-phy-rockchip-inno-usb2-add-rk3568-support.patch
+++ b/target/linux/rockchip/patches-5.15/035-v5.17-phy-rockchip-inno-usb2-add-rk3568-support.patch
@@ -16,7 +16,7 @@ Signed-off-by: Vinod Koul <vkoul@kernel.org>
 
 --- a/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
 +++ b/drivers/phy/rockchip/phy-rockchip-inno-usb2.c
-@@ -1092,6 +1092,7 @@ static int rockchip_usb2phy_otg_port_init(struct rockchip_usb2phy *rphy,
+@@ -1100,6 +1100,7 @@ static int rockchip_usb2phy_otg_port_ini
  	if (ret) {
  		dev_err(rphy->dev, "failed to init irq for host port\n");
  		goto out;
@@ -24,7 +24,7 @@ Signed-off-by: Vinod Koul <vkoul@kernel.org>
  
  	if (!IS_ERR(rphy->edev)) {
  		rport->event_nb.notifier_call = rockchip_otg_event;
-@@ -1503,6 +1504,69 @@ static const struct rockchip_usb2phy_cfg rk3399_phy_cfgs[] = {
+@@ -1511,6 +1512,69 @@ static const struct rockchip_usb2phy_cfg
  	{ /* sentinel */ }
  };
  
@@ -94,7 +94,7 @@ Signed-off-by: Vinod Koul <vkoul@kernel.org>
  static const struct rockchip_usb2phy_cfg rv1108_phy_cfgs[] = {
  	{
  		.reg = 0x100,
-@@ -1552,6 +1616,7 @@ static const struct of_device_id rockchip_usb2phy_dt_match[] = {
+@@ -1560,6 +1624,7 @@ static const struct of_device_id rockchi
  	{ .compatible = "rockchip,rk3328-usb2phy", .data = &rk3328_phy_cfgs },
  	{ .compatible = "rockchip,rk3366-usb2phy", .data = &rk3366_phy_cfgs },
  	{ .compatible = "rockchip,rk3399-usb2phy", .data = &rk3399_phy_cfgs },

--- a/target/linux/rockchip/patches-5.15/036-v5.18-arm64-dts-rockchip-rename-and-sort-the-rk356x-usb2-phy.patch
+++ b/target/linux/rockchip/patches-5.15/036-v5.18-arm64-dts-rockchip-rename-and-sort-the-rk356x-usb2-phy.patch
@@ -57,7 +57,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
  		phy-names = "usb";
  		status = "disabled";
  	};
-@@ -1211,7 +1211,7 @@
+@@ -1195,7 +1195,7 @@
  		status = "disabled";
  	};
  
@@ -66,7 +66,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
  		compatible = "rockchip,rk3568-usb2phy";
  		reg = <0x0 0xfe8a0000 0x0 0x10000>;
  		clocks = <&pmucru CLK_USBPHY0_REF>;
-@@ -1222,18 +1222,18 @@
+@@ -1206,18 +1206,18 @@
  		#clock-cells = <0>;
  		status = "disabled";
  
@@ -88,7 +88,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
  		compatible = "rockchip,rk3568-usb2phy";
  		reg = <0x0 0xfe8b0000 0x0 0x10000>;
  		clocks = <&pmucru CLK_USBPHY1_REF>;
-@@ -1244,12 +1244,12 @@
+@@ -1228,12 +1228,12 @@
  		#clock-cells = <0>;
  		status = "disabled";
  

--- a/target/linux/rockchip/patches-5.15/037-v5.18-phy-rockchip-add-naneng-combo-phy-for-RK3568.patch
+++ b/target/linux/rockchip/patches-5.15/037-v5.18-phy-rockchip-add-naneng-combo-phy-for-RK3568.patch
@@ -39,7 +39,7 @@ Signed-off-by: Vinod Koul <vkoul@kernel.org>
  	depends on (ARCH_ROCKCHIP && OF) || COMPILE_TEST
 --- a/drivers/phy/rockchip/Makefile
 +++ b/drivers/phy/rockchip/Makefile
-@@ -6,6 +6,7 @@ obj-$(CONFIG_PHY_ROCKCHIP_INNO_CSIDPHY)	+= phy-rockchip-inno-csidphy.o
+@@ -6,6 +6,7 @@ obj-$(CONFIG_PHY_ROCKCHIP_INNO_CSIDPHY)
  obj-$(CONFIG_PHY_ROCKCHIP_INNO_DSIDPHY)	+= phy-rockchip-inno-dsidphy.o
  obj-$(CONFIG_PHY_ROCKCHIP_INNO_HDMI)	+= phy-rockchip-inno-hdmi.o
  obj-$(CONFIG_PHY_ROCKCHIP_INNO_USB2)	+= phy-rockchip-inno-usb2.o

--- a/target/linux/rockchip/patches-5.15/038-v5.18-arm64-dts-rockchip-add-naneng-combo-phy-nodes-for.patch
+++ b/target/linux/rockchip/patches-5.15/038-v5.18-arm64-dts-rockchip-add-naneng-combo-phy-nodes-for.patch
@@ -29,7 +29,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
  	qos_pcie3x1: qos@fe190080 {
  		compatible = "rockchip,rk3568-qos", "syscon";
  		reg = <0x0 0xfe190080 0x0 0x20>;
-@@ -71,6 +76,22 @@
+@@ -69,6 +74,22 @@
  			queue0 {};
  		};
  	};
@@ -54,7 +54,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
  &cpu0_opp_table {
 --- a/arch/arm64/boot/dts/rockchip/rk356x.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-@@ -296,11 +296,26 @@
+@@ -262,11 +262,26 @@
  		};
  	};
  
@@ -81,7 +81,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
  	usb2phy0_grf: syscon@fdca0000 {
  		compatible = "rockchip,rk3568-usb2phy-grf", "syscon";
  		reg = <0x0 0xfdca0000 0x0 0x8000>;
-@@ -1307,6 +1322,38 @@
+@@ -1195,6 +1210,38 @@
  		status = "disabled";
  	};
  

--- a/target/linux/rockchip/patches-5.15/040-v5.18-usb-dwc3-core-do-not-use-3.0-clock-when-operating-in-2.0.patch
+++ b/target/linux/rockchip/patches-5.15/040-v5.18-usb-dwc3-core-do-not-use-3.0-clock-when-operating-in-2.0.patch
@@ -22,7 +22,7 @@ Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
 
 --- a/drivers/usb/dwc3/core.c
 +++ b/drivers/usb/dwc3/core.c
-@@ -1061,6 +1061,11 @@ static int dwc3_core_init(struct dwc3 *dwc)
+@@ -1067,6 +1067,11 @@ static int dwc3_core_init(struct dwc3 *d
  		if (dwc->parkmode_disable_ss_quirk)
  			reg |= DWC3_GUCTL1_PARKMODE_DISABLE_SS;
  

--- a/target/linux/rockchip/patches-5.15/050-v5.18-mmc-dw_mmc-Support-setting-f_min-from-host-drivers.patch
+++ b/target/linux/rockchip/patches-5.15/050-v5.18-mmc-dw_mmc-Support-setting-f_min-from-host-drivers.patch
@@ -20,7 +20,7 @@ Signed-off-by: Ulf Hansson <ulf.hansson@linaro.org>
 
 --- a/drivers/mmc/host/dw_mmc.c
 +++ b/drivers/mmc/host/dw_mmc.c
-@@ -2853,7 +2853,12 @@ static int dw_mci_init_slot_caps(struct dw_mci_slot *slot)
+@@ -2853,7 +2853,12 @@ static int dw_mci_init_slot_caps(struct
  	if (host->pdata->caps2)
  		mmc->caps2 = host->pdata->caps2;
  

--- a/target/linux/rockchip/patches-5.15/051-v5.18-mmc-dw-mmc-rockchip-Fix-handling-invalid-clock-rates.patch
+++ b/target/linux/rockchip/patches-5.15/051-v5.18-mmc-dw-mmc-rockchip-Fix-handling-invalid-clock-rates.patch
@@ -35,7 +35,7 @@ Signed-off-by: Ulf Hansson <ulf.hansson@linaro.org>
  
  struct dw_mci_rockchip_priv_data {
  	struct clk		*drv_clk;
-@@ -51,7 +53,7 @@ static void dw_mci_rk3288_set_ios(struct dw_mci *host, struct mmc_ios *ios)
+@@ -51,7 +53,7 @@ static void dw_mci_rk3288_set_ios(struct
  
  	ret = clk_set_rate(host->ciu_clk, cclkin);
  	if (ret)
@@ -44,7 +44,7 @@ Signed-off-by: Ulf Hansson <ulf.hansson@linaro.org>
  
  	bus_hz = clk_get_rate(host->ciu_clk) / RK3288_CLKGEN_DIV;
  	if (bus_hz != host->bus_hz) {
-@@ -290,13 +292,30 @@ static int dw_mci_rk3288_parse_dt(struct dw_mci *host)
+@@ -290,13 +292,30 @@ static int dw_mci_rk3288_parse_dt(struct
  
  static int dw_mci_rockchip_init(struct dw_mci *host)
  {

--- a/target/linux/rockchip/patches-5.15/053-v5.18-mfd-rk808-Add-reboot-support-to-rk808.c.patch
+++ b/target/linux/rockchip/patches-5.15/053-v5.18-mfd-rk808-Add-reboot-support-to-rk808.c.patch
@@ -70,7 +70,7 @@ Link: https://lore.kernel.org/r/20220208194023.929720-1-pgwipeout@gmail.com
  static void rk8xx_shutdown(struct i2c_client *client)
  {
  	struct rk808 *rk808 = i2c_get_clientdata(client);
-@@ -727,6 +757,18 @@ static int rk808_probe(struct i2c_client *client,
+@@ -727,6 +757,18 @@ static int rk808_probe(struct i2c_client
  	if (of_property_read_bool(np, "rockchip,system-power-controller")) {
  		rk808_i2c_client = client;
  		pm_power_off = rk808_pm_power_off;
@@ -89,7 +89,7 @@ Link: https://lore.kernel.org/r/20220208194023.929720-1-pgwipeout@gmail.com
  	}
  
  	return 0;
-@@ -749,6 +791,8 @@ static int rk808_remove(struct i2c_client *client)
+@@ -749,6 +791,8 @@ static int rk808_remove(struct i2c_clien
  	if (pm_power_off == rk808_pm_power_off)
  		pm_power_off = NULL;
  

--- a/target/linux/rockchip/patches-5.15/054-v5.19-soc-rockchip-set-dwc3-clock-for-rk3566.patch
+++ b/target/linux/rockchip/patches-5.15/054-v5.19-soc-rockchip-set-dwc3-clock-for-rk3566.patch
@@ -18,7 +18,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
 
 --- a/drivers/soc/rockchip/grf.c
 +++ b/drivers/soc/rockchip/grf.c
-@@ -108,6 +108,20 @@ static const struct rockchip_grf_info rk3399_grf __initconst = {
+@@ -108,6 +108,20 @@ static const struct rockchip_grf_info rk
  	.num_values = ARRAY_SIZE(rk3399_defaults),
  };
  
@@ -39,7 +39,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
  static const struct of_device_id rockchip_grf_dt_match[] __initconst = {
  	{
  		.compatible = "rockchip,rk3036-grf",
-@@ -130,6 +144,9 @@ static const struct of_device_id rockchip_grf_dt_match[] __initconst = {
+@@ -130,6 +144,9 @@ static const struct of_device_id rockchi
  	}, {
  		.compatible = "rockchip,rk3399-grf",
  		.data = (void *)&rk3399_grf,

--- a/target/linux/rockchip/patches-5.15/055-v5.19-arm64-dts-rockchip-add-rk356x-dwc3-usb3-nodes.patch
+++ b/target/linux/rockchip/patches-5.15/055-v5.19-arm64-dts-rockchip-add-rk356x-dwc3-usb3-nodes.patch
@@ -67,7 +67,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
 +};
 --- a/arch/arm64/boot/dts/rockchip/rk356x.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-@@ -258,6 +258,40 @@
+@@ -224,6 +224,40 @@
  		status = "disabled";
  	};
  
@@ -108,7 +108,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
  	gic: interrupt-controller@fd400000 {
  		compatible = "arm,gic-v3";
  		reg = <0x0 0xfd400000 0 0x10000>, /* GICD */
-@@ -325,7 +359,6 @@
+@@ -291,7 +325,6 @@
  	};
  
  	pipegrf: syscon@fdc50000 {

--- a/target/linux/rockchip/patches-5.15/056-v5.19-PCI-rockchip-dwc-Reset-core-at-driver-probe.patch
+++ b/target/linux/rockchip/patches-5.15/056-v5.19-PCI-rockchip-dwc-Reset-core-at-driver-probe.patch
@@ -19,7 +19,7 @@ Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
 
 --- a/drivers/pci/controller/dwc/pcie-dw-rockchip.c
 +++ b/drivers/pci/controller/dwc/pcie-dw-rockchip.c
-@@ -152,6 +152,11 @@ static int rockchip_pcie_resource_get(struct platform_device *pdev,
+@@ -152,6 +152,11 @@ static int rockchip_pcie_resource_get(st
  	if (IS_ERR(rockchip->rst_gpio))
  		return PTR_ERR(rockchip->rst_gpio);
  
@@ -31,7 +31,7 @@ Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
  	return 0;
  }
  
-@@ -182,18 +187,6 @@ static void rockchip_pcie_phy_deinit(struct rockchip_pcie *rockchip)
+@@ -182,18 +187,6 @@ static void rockchip_pcie_phy_deinit(str
  	phy_power_off(rockchip->phy);
  }
  
@@ -50,7 +50,7 @@ Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
  static const struct dw_pcie_ops dw_pcie_ops = {
  	.link_up = rockchip_pcie_link_up,
  	.start_link = rockchip_pcie_start_link,
-@@ -222,6 +215,10 @@ static int rockchip_pcie_probe(struct platform_device *pdev)
+@@ -222,6 +215,10 @@ static int rockchip_pcie_probe(struct pl
  	if (ret)
  		return ret;
  
@@ -61,7 +61,7 @@ Signed-off-by: Lorenzo Pieralisi <lorenzo.pieralisi@arm.com>
  	/* DON'T MOVE ME: must be enable before PHY init */
  	rockchip->vpcie3v3 = devm_regulator_get_optional(dev, "vpcie3v3");
  	if (IS_ERR(rockchip->vpcie3v3)) {
-@@ -241,7 +238,7 @@ static int rockchip_pcie_probe(struct platform_device *pdev)
+@@ -241,7 +238,7 @@ static int rockchip_pcie_probe(struct pl
  	if (ret)
  		goto disable_regulator;
  

--- a/target/linux/rockchip/patches-5.15/057-v5.19-PCI-rockchip-dwc-Add-legacy-interrupt-support.patch
+++ b/target/linux/rockchip/patches-5.15/057-v5.19-PCI-rockchip-dwc-Add-legacy-interrupt-support.patch
@@ -61,7 +61,7 @@ Reviewed-by: Marc Zyngier <maz@kernel.org>
  };
  
  static int rockchip_pcie_readl_apb(struct rockchip_pcie *rockchip,
-@@ -65,6 +72,78 @@ static void rockchip_pcie_writel_apb(struct rockchip_pcie *rockchip,
+@@ -65,6 +72,78 @@ static void rockchip_pcie_writel_apb(str
  	writel_relaxed(val, rockchip->apb_base + reg);
  }
  
@@ -140,7 +140,7 @@ Reviewed-by: Marc Zyngier <maz@kernel.org>
  static void rockchip_pcie_enable_ltssm(struct rockchip_pcie *rockchip)
  {
  	rockchip_pcie_writel_apb(rockchip, PCIE_CLIENT_ENABLE_LTSSM,
-@@ -111,7 +190,20 @@ static int rockchip_pcie_host_init(struct pcie_port *pp)
+@@ -111,7 +190,20 @@ static int rockchip_pcie_host_init(struc
  {
  	struct dw_pcie *pci = to_dw_pcie_from_pp(pp);
  	struct rockchip_pcie *rockchip = to_rockchip_pcie(pci);

--- a/target/linux/rockchip/patches-5.15/058-v5.19-arm64-dts-rockchip-add-rk356x-sfc-support.patch
+++ b/target/linux/rockchip/patches-5.15/058-v5.19-arm64-dts-rockchip-add-rk356x-sfc-support.patch
@@ -15,7 +15,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
 
 --- a/arch/arm64/boot/dts/rockchip/rk356x.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-@@ -778,6 +778,17 @@
+@@ -729,6 +729,17 @@
  		status = "disabled";
  	};
  

--- a/target/linux/rockchip/patches-5.15/059-v5.19-arm64-dts-rockchip-add-clocks-to-rk356x-cru.patch
+++ b/target/linux/rockchip/patches-5.15/059-v5.19-arm64-dts-rockchip-add-clocks-to-rk356x-cru.patch
@@ -15,7 +15,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
 
 --- a/arch/arm64/boot/dts/rockchip/rk356x.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-@@ -397,6 +397,8 @@
+@@ -363,6 +363,8 @@
  	cru: clock-controller@fdd20000 {
  		compatible = "rockchip,rk3568-cru";
  		reg = <0x0 0xfdd20000 0x0 0x1000>;

--- a/target/linux/rockchip/patches-5.15/060-v5.20-arm64-dts-rockchip-Add-rk3568-PCIe2x1-controller.patch
+++ b/target/linux/rockchip/patches-5.15/060-v5.20-arm64-dts-rockchip-Add-rk3568-PCIe2x1-controller.patch
@@ -15,7 +15,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
 
 --- a/arch/arm64/boot/dts/rockchip/rk356x.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk356x.dtsi
-@@ -752,6 +752,56 @@
+@@ -703,6 +703,56 @@
  		reg = <0x0 0xfe1a8100 0x0 0x20>;
  	};
  

--- a/target/linux/rockchip/patches-5.15/061-v5.20-arm64-enable-THP_SWAP-for-arm64.patch
+++ b/target/linux/rockchip/patches-5.15/061-v5.20-arm64-enable-THP_SWAP-for-arm64.patch
@@ -68,8 +68,8 @@ Signed-off-by: Will Deacon <will@kernel.org>
 
 --- a/arch/arm64/Kconfig
 +++ b/arch/arm64/Kconfig
-@@ -101,6 +101,7 @@ config ARM64
- 	select ARCH_WANT_HUGETLB_PAGE_OPTIMIZE_VMEMMAP
+@@ -95,6 +95,7 @@ config ARM64
+ 	select ARCH_WANT_HUGE_PMD_SHARE if ARM64_4K_PAGES || (ARM64_16K_PAGES && !ARM64_VA_BITS_36)
  	select ARCH_WANT_LD_ORPHAN_WARN
  	select ARCH_WANTS_NO_INSTR
 +	select ARCH_WANTS_THP_SWAP if ARM64_4K_PAGES
@@ -78,7 +78,7 @@ Signed-off-by: Will Deacon <will@kernel.org>
  	select ARM_ARCH_TIMER
 --- a/arch/arm64/include/asm/pgtable.h
 +++ b/arch/arm64/include/asm/pgtable.h
-@@ -45,6 +45,12 @@
+@@ -44,6 +44,12 @@
  	__flush_tlb_range(vma, addr, end, PUD_SIZE, false, 1)
  #endif /* CONFIG_TRANSPARENT_HUGEPAGE */
  
@@ -93,7 +93,7 @@ Signed-off-by: Will Deacon <will@kernel.org>
   * use broadcast TLB invalidation instructions, therefore a spurious page
 --- a/include/linux/huge_mm.h
 +++ b/include/linux/huge_mm.h
-@@ -461,4 +461,16 @@ static inline int split_folio_to_list(struct folio *folio,
+@@ -495,4 +495,16 @@ static inline unsigned long thp_size(str
  	return PAGE_SIZE << thp_order(page);
  }
  
@@ -112,7 +112,7 @@ Signed-off-by: Will Deacon <will@kernel.org>
  #endif /* _LINUX_HUGE_MM_H */
 --- a/mm/swap_slots.c
 +++ b/mm/swap_slots.c
-@@ -307,7 +307,7 @@ swp_entry_t folio_alloc_swap(struct folio *folio)
+@@ -308,7 +308,7 @@ swp_entry_t get_swap_page(struct page *p
  	entry.val = 0;
  
  	if (PageTransHuge(page)) {

--- a/target/linux/rockchip/patches-5.15/105-rockchip-rock-pi-4.patch
+++ b/target/linux/rockchip/patches-5.15/105-rockchip-rock-pi-4.patch
@@ -1,6 +1,6 @@
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -26,6 +26,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3318-a9
+@@ -26,6 +26,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-gr
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-gru-kevin.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-gru-scarlet-inx.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-gru-scarlet-kd.dtb

--- a/target/linux/rockchip/patches-5.15/106-arm64-rockchip-add-OF-node-for-pcie-eth-on-NanoPi-R4S.patch
+++ b/target/linux/rockchip/patches-5.15/106-arm64-rockchip-add-OF-node-for-pcie-eth-on-NanoPi-R4S.patch
@@ -1,6 +1,6 @@
 --- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
-@@ -101,6 +101,19 @@
+@@ -96,6 +96,19 @@
  	max-link-speed = <1>;
  	num-lanes = <1>;
  	vpcie3v3-supply = <&vcc3v3_sys>;

--- a/target/linux/rockchip/patches-5.15/108-drivers-phy-rockchip-Support-PCIe-v3.patch
+++ b/target/linux/rockchip/patches-5.15/108-drivers-phy-rockchip-Support-PCIe-v3.patch
@@ -46,7 +46,7 @@ Signed-off-by: Frank Wunderlich <frank-w@public-files.de>
  	depends on OF && (ARCH_ROCKCHIP || COMPILE_TEST)
 --- a/drivers/phy/rockchip/Makefile
 +++ b/drivers/phy/rockchip/Makefile
-@@ -8,5 +8,6 @@ obj-$(CONFIG_PHY_ROCKCHIP_INNO_HDMI)	+= phy-rockchip-inno-hdmi.o
+@@ -8,5 +8,6 @@ obj-$(CONFIG_PHY_ROCKCHIP_INNO_HDMI)	+=
  obj-$(CONFIG_PHY_ROCKCHIP_INNO_USB2)	+= phy-rockchip-inno-usb2.o
  obj-$(CONFIG_PHY_ROCKCHIP_NANENG_COMBO_PHY)	+= phy-rockchip-naneng-combphy.o
  obj-$(CONFIG_PHY_ROCKCHIP_PCIE)		+= phy-rockchip-pcie.o

--- a/target/linux/rockchip/patches-5.15/109-arm64-dts-rockchip-rk3568-Add-PCIe-v3-nodes.patch
+++ b/target/linux/rockchip/patches-5.15/109-arm64-dts-rockchip-rk3568-Add-PCIe-v3-nodes.patch
@@ -13,7 +13,7 @@ Signed-off-by: Frank Wunderlich <frank-w@public-files.de>
 
 --- a/arch/arm64/boot/dts/rockchip/rk3568.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3568.dtsi
-@@ -42,6 +42,128 @@ qos_sata0: qos@fe190200 {
+@@ -42,6 +42,128 @@
  		reg = <0x0 0xfe190200 0x0 0x20>;
  	};
  

--- a/target/linux/rockchip/patches-5.15/202-rockchip-rk3328-Add-support-for-OrangePi-R1-Plus.patch
+++ b/target/linux/rockchip/patches-5.15/202-rockchip-rk3328-Add-support-for-OrangePi-R1-Plus.patch
@@ -1,13 +1,13 @@
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -7,6 +7,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3326-od
+@@ -10,6 +10,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3326-od
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-a1.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-evb.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2s.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-orangepi-r1-plus.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock64.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock-pi-e.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-roc-cc.dtb
- dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-evb-act8846.dtb
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus.dts
 @@ -0,0 +1,39 @@

--- a/target/linux/rockchip/patches-5.15/203-rockchip-rk3328-Add-support-for-OrangePi-R1-Plus-LTS.patch
+++ b/target/linux/rockchip/patches-5.15/203-rockchip-rk3328-Add-support-for-OrangePi-R1-Plus-LTS.patch
@@ -1,13 +1,13 @@
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -9,6 +9,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-ev
- dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2c.dtb
+@@ -11,6 +11,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-a1
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-evb.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2s.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-orangepi-r1-plus.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-orangepi-r1-plus-lts.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock64.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock-pi-e.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-roc-cc.dtb
- dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-evb-act8846.dtb
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus-lts.dts
 @@ -0,0 +1,66 @@

--- a/target/linux/rockchip/patches-5.15/204-rockchip-rk3328-Add-support-for-FriendlyARM-NanoPi-R.patch
+++ b/target/linux/rockchip/patches-5.15/204-rockchip-rk3328-Add-support-for-FriendlyARM-NanoPi-R.patch
@@ -1,13 +1,13 @@
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -6,6 +6,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3318-a9
+@@ -9,6 +9,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3318-a9
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3326-odroid-go2.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-a1.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-evb.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2c.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2s.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-orangepi-r1-plus.dtb
- dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock64.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-orangepi-r1-plus-lts.dtb
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2c.dts
 @@ -0,0 +1,51 @@

--- a/target/linux/rockchip/patches-5.15/205-rockchip-rk3328-add-support-for-FriendlyARM-NanoPi-Neo3.patch
+++ b/target/linux/rockchip/patches-5.15/205-rockchip-rk3328-add-support-for-FriendlyARM-NanoPi-Neo3.patch
@@ -33,21 +33,16 @@ to status_led in accordance with the board schematics.
  2 files changed, 397 insertions(+)
  create mode 100644 arch/arm64/boot/dts/rockchip/rk3328-nanopi-neo3.dts
 
-diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
-index 479906f3a..5f6ffb496 100644
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -3,6 +3,7 @@
- dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-doornet1.dtb
+@@ -11,6 +11,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-a1
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-evb.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2c.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-r2s.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-nanopi-neo3.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-orangepi-r1-plus.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-orangepi-r1-plus-lts.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-rock64.dtb
- dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-roc-cc.dtb
-diff --git a/arch/arm64/boot/dts/rockchip/rk3328-nanopi-neo3.dts b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-neo3.dts
-new file mode 100644
-index 000000000..1eb7fd5f7
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-neo3.dts
 @@ -0,0 +1,394 @@
@@ -445,6 +440,3 @@ index 000000000..1eb7fd5f7
 +		realtek,led-data = <0x87>;
 +	};
 +};
--- 
-2.34.1
-

--- a/target/linux/rockchip/patches-5.15/803-PM-devfreq-rockchip-add-devfreq-driver-for-rk3328-dmc.patch
+++ b/target/linux/rockchip/patches-5.15/803-PM-devfreq-rockchip-add-devfreq-driver-for-rk3328-dmc.patch
@@ -13,7 +13,7 @@ Signed-off-by: hmz007 <hmz007@gmail.com>
 
 --- a/drivers/devfreq/Kconfig
 +++ b/drivers/devfreq/Kconfig
-@@ -120,6 +120,18 @@ config ARM_TEGRA20_DEVFREQ
+@@ -120,6 +120,18 @@ config ARM_TEGRA_DEVFREQ
  	  It reads ACTMON counters of memory controllers and adjusts the
  	  operating frequencies and voltages with OPP support.
  
@@ -34,7 +34,7 @@ Signed-off-by: hmz007 <hmz007@gmail.com>
  	depends on (ARCH_ROCKCHIP && HAVE_ARM_SMCCC) || \
 --- a/drivers/devfreq/Makefile
 +++ b/drivers/devfreq/Makefile
-@@ -11,6 +11,7 @@ obj-$(CONFIG_ARM_EXYNOS_BUS_DEVFREQ)	+=
+@@ -11,6 +11,7 @@ obj-$(CONFIG_DEVFREQ_GOV_PASSIVE)	+= gov
  obj-$(CONFIG_ARM_EXYNOS_BUS_DEVFREQ)	+= exynos-bus.o
  obj-$(CONFIG_ARM_IMX_BUS_DEVFREQ)	+= imx-bus.o
  obj-$(CONFIG_ARM_IMX8M_DDRC_DEVFREQ)	+= imx8m-ddrc.o

--- a/target/linux/rockchip/patches-5.15/807-arm64-dts-nanopi-r2s-add-rk3328-dmc-relate-node.patch
+++ b/target/linux/rockchip/patches-5.15/807-arm64-dts-nanopi-r2s-add-rk3328-dmc-relate-node.patch
@@ -24,7 +24,7 @@ Signed-off-by: hmz007 <hmz007@gmail.com>
  #include "rk3328.dtsi"
  
  / {
-@@ -114,6 +115,72 @@
+@@ -119,6 +120,72 @@
  		regulator-boot-on;
  		vin-supply = <&vdd_5v>;
  	};
@@ -97,7 +97,7 @@ Signed-off-by: hmz007 <hmz007@gmail.com>
  };
  
  &cpu0 {
-@@ -132,6 +199,10 @@
+@@ -137,6 +204,10 @@
  	cpu-supply = <&vdd_arm>;
  };
  
@@ -108,7 +108,7 @@ Signed-off-by: hmz007 <hmz007@gmail.com>
  &display_subsystem {
  	status = "disabled";
  };
-@@ -195,6 +266,7 @@
+@@ -206,6 +277,7 @@
  				regulator-name = "vdd_log";
  				regulator-always-on;
  				regulator-boot-on;
@@ -116,7 +116,7 @@ Signed-off-by: hmz007 <hmz007@gmail.com>
  				regulator-min-microvolt = <712500>;
  				regulator-max-microvolt = <1450000>;
  				regulator-ramp-delay = <12500>;
-@@ -209,6 +281,7 @@
+@@ -220,6 +292,7 @@
  				regulator-name = "vdd_arm";
  				regulator-always-on;
  				regulator-boot-on;

--- a/target/linux/rockchip/patches-5.15/900-arm64-boot-add-dts-files.patch.patch
+++ b/target/linux/rockchip/patches-5.15/900-arm64-boot-add-dts-files.patch.patch
@@ -1,6 +1,7 @@
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -58,3 +58,11 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-sapphire.dtb
+@@ -57,4 +57,12 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-ro
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-sapphire.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-sapphire-excavator.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399pro-rock-pi-n10.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-r4se.dtb

--- a/target/linux/rockchip/patches-5.15/992-rockchip-rk3399-overclock-to-2.2-1.8-GHz.patch
+++ b/target/linux/rockchip/patches-5.15/992-rockchip-rk3399-overclock-to-2.2-1.8-GHz.patch
@@ -16,7 +16,7 @@ Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>
 +++ b/arch/arm64/boot/dts/rockchip/rk3399-opp.dtsi
 @@ -33,6 +33,14 @@
  			opp-hz = /bits/ 64 <1416000000>;
- 			opp-microvolt = <1125000>;
+ 			opp-microvolt = <1125000 1125000 1250000>;
  		};
 +		opp06 {
 +			opp-hz = /bits/ 64 <1608000000>;
@@ -31,7 +31,7 @@ Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>
  	cluster1_opp: opp-table1 {
 @@ -72,6 +80,14 @@
  			opp-hz = /bits/ 64 <1800000000>;
- 			opp-microvolt = <1200000>;
+ 			opp-microvolt = <1200000 1200000 1250000>;
  		};
 +		opp08 {
 +			opp-hz = /bits/ 64 <2016000000>;

--- a/target/linux/x86/patches-5.15/991-fix-i915-guc-icl.patch
+++ b/target/linux/x86/patches-5.15/991-fix-i915-guc-icl.patch
@@ -1,11 +1,9 @@
-diff --git a/drivers/gpu/drm/i915/gt/intel_workarounds.c b/drivers/gpu/drm/i915/gt/intel_workarounds.c
-index c3211325c2d3..3113266c286e 100644
 --- a/drivers/gpu/drm/i915/gt/intel_workarounds.c
 +++ b/drivers/gpu/drm/i915/gt/intel_workarounds.c
-@@ -1224,6 +1224,15 @@ icl_gt_workarounds_init(struct intel_gt *gt, struct i915_wa_list *wal)
-		    GAMT_CHKN_BIT_REG,
-		    GAMT_CHKN_DISABLE_L3_COH_PIPE);
-
+@@ -1049,6 +1049,15 @@ icl_gt_workarounds_init(struct drm_i915_
+ 		    GAMT_CHKN_BIT_REG,
+ 		    GAMT_CHKN_DISABLE_L3_COH_PIPE);
+ 
 +	/* Wa_1407352427:icl,ehl */
 +	wa_write_or(wal, UNSLICE_UNIT_LEVEL_CLKGATE2,
 +		    PSDUNIT_CLKGATE_DIS);
@@ -15,13 +13,13 @@ index c3211325c2d3..3113266c286e 100644
 +		    SUBSLICE_UNIT_LEVEL_CLKGATE,
 +		    GWUNIT_CLKGATE_DIS);
 +
-	/* Wa_1607087056:icl,ehl,jsl */
-	if (IS_ICELAKE(i915) ||
-	    IS_JSL_EHL_GRAPHICS_STEP(i915, STEP_A0, STEP_B0))
-@@ -2269,15 +2278,6 @@ rcs_engine_wa_init(struct intel_engine_cs *engine, struct i915_wa_list *wal)
-		wa_write_or(wal, UNSLICE_UNIT_LEVEL_CLKGATE,
-			    VSUNIT_CLKGATE_DIS | HSUNIT_CLKGATE_DIS);
-
+ 	/* Wa_1607087056:icl,ehl,jsl */
+ 	if (IS_ICELAKE(i915) ||
+ 	    IS_JSL_EHL_GT_STEP(i915, STEP_A0, STEP_B0))
+@@ -1745,15 +1754,6 @@ rcs_engine_wa_init(struct intel_engine_c
+ 		wa_write_or(wal, UNSLICE_UNIT_LEVEL_CLKGATE,
+ 			    VSUNIT_CLKGATE_DIS | HSUNIT_CLKGATE_DIS);
+ 
 -		/* Wa_1407352427:icl,ehl */
 -		wa_write_or(wal, UNSLICE_UNIT_LEVEL_CLKGATE2,
 -			    PSDUNIT_CLKGATE_DIS);
@@ -31,6 +29,6 @@ index c3211325c2d3..3113266c286e 100644
 -			    SUBSLICE_UNIT_LEVEL_CLKGATE,
 -			    GWUNIT_CLKGATE_DIS);
 -
-		/*
-		 * Wa_1408767742:icl[a2..forever],ehl[all]
-		 * Wa_1605460711:icl[a0..c0]
+ 		/*
+ 		 * Wa_1408767742:icl[a2..forever],ehl[all]
+ 		 * Wa_1605460711:icl[a0..c0]

--- a/target/linux/x86/patches-5.15/992-enable-intel-guc.patch
+++ b/target/linux/x86/patches-5.15/992-enable-intel-guc.patch
@@ -1,8 +1,8 @@
 --- a/drivers/gpu/drm/i915/gt/uc/intel_uc.c
 +++ b/drivers/gpu/drm/i915/gt/uc/intel_uc.c
-@@ -26,7 +26,7 @@ static void uc_expand_default_options(st
+@@ -23,7 +23,7 @@ static void uc_expand_default_options(st
  		return;
-
+ 
  	/* Don't enable GuC/HuC on pre-Gen12 */
 -	if (GRAPHICS_VER(i915) < 12) {
 +	if (GRAPHICS_VER(i915) < 9) {


### PR DESCRIPTION
Manually rebased:
    target/linux/generic/hack-5.15/953-net-patch-linux-kernel-to-support-shortcut-fe.patch

All other patches automatically rebased.

Build system: x86_64
Build-tested: rk3568/fastrhino_r66s

Signed-off-by: Linhui Liu <liulinhui36@gmail.com>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
*  [x] 我知道
