### PR TITLE
firmware: fix WCN6855 firmware hw2.1 link

### DIFF
--- a/package/firmware/ath11k-firmware/Makefile
+++ b/package/firmware/ath11k-firmware/Makefile
@@ -103,7 +103,7 @@ define Package/ath11k-firmware-wcn6855/install
 	$(INSTALL_DATA) \
 		$(PKG_BUILD_DIR)/WCN6855/hw2.0/regdb.bin \
 		$(1)/lib/firmware/ath11k/WCN6855/hw2.0/regdb.bin
-	$(LN) $(1)/lib/firmware/ath11k/WCN6855/hw2.0 $(1)/lib/firmware/ath11k/WCN6855/hw2.1
+	$(LN) ./hw2.0 $(1)/lib/firmware/ath11k/WCN6855/hw2.1
 endef
 
 $(eval $(call BuildPackage,ath11k-firmware-ipq6018))


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

Before:

`/lib/firmware/ath11k/WCN6855/hw2.1` links to an abselute path on compiling machine.

<img width="1491" alt="image" src="https://user-images.githubusercontent.com/1812118/189483693-6f388f95-e129-4e23-b717-a419fe28cc46.png">

After:

It should always link to `./hw2.0`.

<img width="1492" alt="image" src="https://user-images.githubusercontent.com/1812118/189483698-7d209d9e-1bc2-4a93-b47e-35fd4fed76c2.png">
