### PR TITLE
ath11k-firmware: Add missing board-2.bin for QCA6390

### DIFF
--- a/package/firmware/ath11k-firmware/Makefile
+++ b/package/firmware/ath11k-firmware/Makefile
@@ -83,6 +83,9 @@ define Package/ath11k-firmware-qca6390/install
 	$(INSTALL_DATA) \
 		$(PKG_BUILD_DIR)/QCA6390/hw2.0/1.0.1/WLAN.HST.1.0.1-05266-QCAHSTSWPLZ_V2_TO_X86-1/* \
 		$(1)/lib/firmware/ath11k/QCA6390/hw2.0/
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/QCA6390/hw2.0/board-2.bin \
+		$(1)/lib/firmware/ath11k/QCA6390/hw2.0/board-2.bin
 endef
 
 define Package/ath11k-firmware-qcn9074/install


### PR DESCRIPTION
board-2.bin is mandatory for ath11k to work with QCA6390.

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
