### PR TITLE
uboot-rockchip:fix r4se uboot sd card not bootable

### DIFF
--- a/package/boot/uboot-rockchip/patches/305-rockchip-rk3399-Add-support-for-FriendlyARM-NanoPi-R.patch
+++ b/package/boot/uboot-rockchip/patches/305-rockchip-rk3399-Add-support-for-FriendlyARM-NanoPi-R.patch
@@ -10,7 +10,7 @@
  	rk3399-puma-haikou.dtb \
 --- /dev/null
 +++ b/arch/arm/dts/rk3399-nanopi-r4se.dts
-@@ -0,0 +1,29 @@
+@@ -0,0 +1,32 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * FriendlyElec NanoPC-T4 board device tree source
@@ -39,6 +39,9 @@
 +	bus-width = <8>;
 +	non-removable;
 +	status = "okay";
++};
++&sdmmc {
++ pinctrl-0 = < &sdmmc_cd>;
 +};
 --- /dev/null
 +++ b/configs/nanopi-r4se-rk3399_defconfig

--- a/package/boot/uboot-rockchip/patches/305-rockchip-rk3399-Add-support-for-FriendlyARM-NanoPi-R.patch
+++ b/package/boot/uboot-rockchip/patches/305-rockchip-rk3399-Add-support-for-FriendlyARM-NanoPi-R.patch
@@ -41,7 +41,7 @@
 +	status = "okay";
 +};
 +&sdmmc {
-+ pinctrl-0 = < &sdmmc_cd>;
++ pinctrl-0 = <&sdmmc_cd>;
 +};
 --- /dev/null
 +++ b/configs/nanopi-r4se-rk3399_defconfig

--- a/target/linux/rockchip/files/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4se.dts
+++ b/target/linux/rockchip/files/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4se.dts
@@ -19,6 +19,13 @@
 	model = "FriendlyElec NanoPi R4SE";
 	compatible = "friendlyarm,nanopi-r4se", "rockchip,rk3399";
 
+	aliases {
+		led-boot = &sys_led;
+		led-failsafe = &sys_led;
+		led-running = &sys_led;
+		led-upgrade = &sys_led;
+	};
+	
 	/delete-node/ display-subsystem;
 
 	gpio-leds {

--- a/target/linux/rockchip/files/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4se.dts
+++ b/target/linux/rockchip/files/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4se.dts
@@ -33,7 +33,7 @@
 
 		sys_led: led-sys {
 			gpios = <&gpio0 RK_PB5 GPIO_ACTIVE_HIGH>;
-			label = "red:power";
+			label = "red:sys";
 			default-state = "on";
 		};
 


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

this will cause uboot to fail to load the sd card 
at startup, and uboot can recognize emmc...
```log
=> mmc list
mmc@fe320000: 1
mmc@fe330000: 0 (eMMC)
=> mmc info
Device: mmc@fe330000
Manufacturer ID: 15
OEM: 0
Name: BJTD4R
Bus Speed: 52000000
Mode: MMC High Speed (52MHz)
Rd Block Len: 512
MMC version 5.1
High Capacity: Yes
Capacity: 29.1 GiB
Bus Width: 8-bit
Erase Group Size: 512 KiB
HC WP Group Size: 8 MiB
User Capacity: 29.1 GiB WRREL
Boot Capacity: 4 MiB ENH
RPMB Capacity: 4 MiB ENH
Boot area 0 is not write protected
Boot area 1 is not write protected
=> mmc dev 0
switch to partitions #0, OK
mmc0(part 0) is current device
=> mmc dev 1
switch to partitions #0, OK
mmc1 is current device
=> mmc dev 2
MMC Device 2 not found
no mmc device at slot 2
=>
```