### PR TITLE
generic: add DUAL_READ flag to EON EN25Q128

### DIFF
--- a/target/linux/generic/pending-5.10/476-mtd-spi-nor-add-eon-en25q128.patch
+++ b/target/linux/generic/pending-5.10/476-mtd-spi-nor-add-eon-en25q128.patch
@@ -1,18 +1,23 @@
 From: Piotr Dymacz <pepe2k@gmail.com>
 Subject: kernel/mtd: add support for EON EN25Q128
 
+Add support for EON EN25Q128 with flags SECT_4K and
+from documentation supports QUAD_READ
+
 Signed-off-by: Piotr Dymacz <pepe2k@gmail.com>
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 ---
  drivers/mtd/spi-nor/spi-nor.c | 1 +
  1 file changed, 1 insertion(+)
 
 --- a/drivers/mtd/spi-nor/eon.c
 +++ b/drivers/mtd/spi-nor/eon.c
-@@ -15,6 +15,8 @@ static const struct flash_info eon_parts
+@@ -15,6 +15,9 @@ static const struct flash_info eon_parts
  	{ "en25q32b",   INFO(0x1c3016, 0, 64 * 1024,   64, 0) },
  	{ "en25p64",    INFO(0x1c2017, 0, 64 * 1024,  128, 0) },
  	{ "en25q64",    INFO(0x1c3017, 0, 64 * 1024,  128, SECT_4K) },
-+	{ "en25q128",   INFO(0x1c3018, 0, 64 * 1024,  256, SECT_4K) },
++	{ "en25q128",   INFO(0x1c3018, 0, 64 * 1024,  256,
++			     SECT_4K | SPI_NOR_DUAL_READ) },
 +	{ "en25qx128a",	INFO(0x1c7118, 0, 64 * 1024,  256, SECT_4K) },
  	{ "en25q80a",   INFO(0x1c3014, 0, 64 * 1024,   16,
  			     SECT_4K | SPI_NOR_DUAL_READ) },

--- a/target/linux/generic/pending-5.15/476-mtd-spi-nor-add-eon-en25q128.patch
+++ b/target/linux/generic/pending-5.15/476-mtd-spi-nor-add-eon-en25q128.patch
@@ -1,18 +1,23 @@
 From: Piotr Dymacz <pepe2k@gmail.com>
 Subject: kernel/mtd: add support for EON EN25Q128
 
+Add support for EON EN25Q128 with flags SECT_4K and
+from documentation supports QUAD_READ
+
 Signed-off-by: Piotr Dymacz <pepe2k@gmail.com>
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 ---
  drivers/mtd/spi-nor/spi-nor.c | 1 +
  1 file changed, 1 insertion(+)
 
 --- a/drivers/mtd/spi-nor/eon.c
 +++ b/drivers/mtd/spi-nor/eon.c
-@@ -15,6 +15,8 @@ static const struct flash_info eon_parts
+@@ -15,6 +15,9 @@ static const struct flash_info eon_parts
  	{ "en25q32b",   INFO(0x1c3016, 0, 64 * 1024,   64, 0) },
  	{ "en25p64",    INFO(0x1c2017, 0, 64 * 1024,  128, 0) },
  	{ "en25q64",    INFO(0x1c3017, 0, 64 * 1024,  128, SECT_4K) },
-+	{ "en25q128",   INFO(0x1c3018, 0, 64 * 1024,  256, SECT_4K) },
++	{ "en25q128",   INFO(0x1c3018, 0, 64 * 1024,  256,
++			     SECT_4K | SPI_NOR_DUAL_READ) },
 +	{ "en25qx128a",	INFO(0x1c7118, 0, 64 * 1024,  256, SECT_4K) },
  	{ "en25q80a",   INFO(0x1c3014, 0, 64 * 1024,   16,
  			     SECT_4K | SPI_NOR_DUAL_READ) },


### PR DESCRIPTION
Add DUAL_READ flag to EON EN25Q128 as from documentation it's supported. While at it also rework the patch and add a commit description.

Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
