### PR TITLE
packages: libusb: add package 'fxload' (from libusb examples)

### DIFF
--- a/package/libs/libusb/Makefile
+++ b/package/libs/libusb/Makefile
@@ -40,10 +40,26 @@ define Package/libusb-1.0/description
   many different operating systems.
 endef
 
+define Package/fxload
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=fxload firmware loader
+  URL:=http://linux-hotplug.sourceforge.net
+  DEPENDS:=+libusb-1.0
+endef
+
+define Package/fxload/description
+This program is conveniently able to download firmware into FX, FX2,
+and FX2LP EZ-USB devices, as well as the original AnchorChips EZ-USB.
+It is intended to be invoked by hotplug scripts when the unprogrammed
+device appears on the bus.
+endef
+
 TARGET_CFLAGS += $(FPIC)
 CONFIGURE_ARGS += \
-	--disable-udev \
-	--disable-log
+	--enable-examples-build \
+	--disable-log \
+	--disable-udev
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include/libusb-1.0
@@ -59,4 +75,10 @@ define Package/libusb-1.0/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libusb-1.0.so.* $(1)/usr/lib/
 endef
 
+define Package/fxload/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/examples/.libs/fxload $(1)/usr/sbin
+endef
+
 $(eval $(call BuildPackage,libusb-1.0))
+$(eval $(call BuildPackage,fxload))


### PR DESCRIPTION
The 'fxload' tool contained in the examples provided with libusb is actually useful and turns out to be the only way to load firmware into some rather ancient EZ-USB microcontrollers made by Cypress (formerly Anchor Chips).
The original 'fxload' tool from hotplug-linux has been abandonned long ago and requires usbfs to be mounted in /proc/bus/usb/ (like it was in Linux 2.4...).
Hence the best option is to package the modern 'fxload' from the libusb examples which (unsurprisingly) uses libusb and works on modern systems.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
