### PR TITLE
Update netsupport.mk

### DIFF
--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -1137,6 +1137,12 @@ $(eval $(call KernelPackage,dnsresolver))
 define KernelPackage/rxrpc
   SUBMENU:=$(NETWORK_SUPPORT_MENU)
   TITLE:=AF_RXRPC support
+  DEPENDS:= \
+    +kmod-crypto-manager \
+    +kmod-crypto-pcbc \
+    +kmod-crypto-fcrypt \
+    +kmod-udptunnel4 \
+    +IPV6:kmod-udptunnel6
   HIDDEN:=1
   KCONFIG:= \
 	CONFIG_AF_RXRPC \
@@ -1145,7 +1151,6 @@ define KernelPackage/rxrpc
   FILES:= \
 	$(LINUX_DIR)/net/rxrpc/rxrpc.ko
   AUTOLOAD:=$(call AutoLoad,30,rxrpc.ko)
-  DEPENDS:= +kmod-crypto-manager +kmod-crypto-pcbc +kmod-crypto-fcrypt
 endef
 
 define KernelPackage/rxrpc/description


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ ] 我知道
编译某些需要udp的插件时会因为缺少依赖而报错
根据报错Package kmod-rxrpc is missing dependencies for the following libraries:
ip6_udp_tunnel.ko
udp_tunnel.ko
添加 +kmod-udptunnel4 +IPV6:kmod-udptunnel6后成功编译。