### PR TITLE
tools/dosfstools: fix PKG_SOURCE

### DIFF
--- a/tools/dosfstools/Makefile
+++ b/tools/dosfstools/Makefile
@@ -11,10 +11,10 @@ PKG_NAME:=dosfstools
 PKG_CPE_ID:=cpe:/a:dosfstools_project:dosfstools
 PKG_VERSION:=4.2
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/dosfstools/dosfstools/releases/download/v$(PKG_VERSION)/ \
 		http://fossies.org/linux/misc
-PKG_HASH:=ba7c716ff9b8208a3bba5094a77584a7dc814141de09ab4ce1ae9b84bbcd7844
+PKG_HASH:=64926eebf90092dca21b14259a5301b7b98e7b1943e8a201c7d726084809b527
 
 HOST_FIXUP:=autoreconf
 


### PR DESCRIPTION
Both mirrors provided in the Makefile only serve gzipped tarballs.

Fixes: #10871
Fixes: 9edfe7dd13d9 ("source: Switch to xz for packages and tools where possible")
Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
