### PR TITLE
x86: fix  hyper-v poweroff support for 5.15+

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -684,6 +684,22 @@ endef
 $(eval $(call KernelPackage,e1000e))
 
 
+define KernelPackage/hv_utils
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Microsoft Hyper-V Utilities driver
+  DEPENDS:=@PCIE_SUPPORT +kmod-ptp
+  KCONFIG:=CONFIG_HYPERV_UTILS
+  FILES:=$(LINUX_DIR)/drivers/hv/hv_utils.ko
+  AUTOLOAD:=$(call AutoLoad,35,hv_utils,1)
+endef
+
+define KernelPackage/hv_utils/description
+ Microsoft Hyper-V Utilities driver.
+endef
+
+$(eval $(call KernelPackage,hv_utils))
+
+
 define KernelPackage/igb
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Intel(R) 82575/82576 PCI-Express Gigabit Ethernet support

--- a/target/linux/x86/Makefile
+++ b/target/linux/x86/Makefile
@@ -18,7 +18,7 @@ KERNELNAME:=bzImage
 include $(INCLUDE_DIR)/target.mk
 
 DEFAULT_PACKAGES += partx-utils mkf2fs e2fsprogs kmod-button-hotplug kmod-usb-hid kmod-mmc kmod-sdhci kmod-fs-f2fs cfdisk usbutils pciutils \
-kmod-alx kmod-e1000e kmod-igb kmod-igc kmod-igbvf kmod-iavf kmod-bnx2x kmod-pcnet32 kmod-tulip kmod-via-velocity kmod-vmxnet3 kmod-i40e kmod-i40evf kmod-r8125 kmod-8139cp kmod-8139too kmod-tg3 \
+kmod-alx kmod-e1000e kmod-hv_utils kmod-igb kmod-igc kmod-igbvf kmod-iavf kmod-bnx2x kmod-pcnet32 kmod-tulip kmod-via-velocity kmod-vmxnet3 kmod-i40e kmod-i40evf kmod-r8125 kmod-8139cp kmod-8139too kmod-tg3 \
 htop lm-sensors iperf3 autocore-x86 automount autosamba luci-app-adbyby-plus luci-app-ipsec-vpnd luci-proto-bonding luci-app-diskman \
 luci-app-unblockmusic luci-app-zerotier luci-app-xlnetacc ddns-scripts_aliyun ddns-scripts_dnspod ca-bundle luci-app-wireguard luci-app-ttyd \
 kmod-sound-hda-core kmod-sound-hda-codec-realtek kmod-sound-hda-codec-via kmod-sound-via82xx kmod-sound-hda-intel kmod-sound-hda-codec-hdmi kmod-sound-i8x0 kmod-usb-audio \

--- a/target/linux/x86/image/64.mk
+++ b/target/linux/x86/image/64.mk
@@ -1,7 +1,7 @@
 define Device/generic
   DEVICE_VENDOR := Generic
   DEVICE_MODEL := x86/64
-  DEVICE_PACKAGES += kmod-amazon-ena kmod-bnx2 kmod-e1000e kmod-e1000 \
+  DEVICE_PACKAGES += kmod-amazon-ena kmod-bnx2 kmod-e1000e kmod-hv_utils kmod-e1000 \
 	kmod-forcedeth kmod-ixgbe kmod-amd-xgbe kmod-r8168 kmod-fs-vfat
   GRUB2_VARIANT := generic
 endef


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ x] 我知道

修复5.15 之后默认编译不带hv_utils，导致hyper-v的正常关机失效问题。