### PR TITLE
qca-ssdk: refresh patches

### DIFF
--- a/package/qca/qca-ssdk/patches/0001-SSDK-config-add-kernel-5.10-5.15.patch
+++ b/package/qca/qca-ssdk/patches/0001-SSDK-config-add-kernel-5.10-5.15.patch
@@ -1,5 +1,3 @@
-diff --git a/config b/config
-index a8b97908..37b6ecd0 100755
 --- a/config
 +++ b/config
 @@ -24,6 +24,14 @@ ifeq ($(KVER),$(filter 5.4%,$(KVER)))
@@ -17,7 +15,6 @@ index a8b97908..37b6ecd0 100755
  ifeq ($(KVER), 3.4.0)
  	OS_VER=3_4
  endif
-
 @@ -132,7 +140,7 @@ ifeq ($(ARCH), arm)
  endif
  
@@ -27,8 +24,6 @@ index a8b97908..37b6ecd0 100755
  		CPU_CFLAG=  -DMODULE -Os -pipe -march=armv8-a -mcpu=cortex-a53+crypto -fno-caller-saves -fno-strict-aliasing -Werror -fno-common -Wno-format-security -Wno-pointer-sign -Wno-unused-but-set-variable -Wno-error=unused-result -mcmodel=large
  	endif
  endif
-diff --git a/make/linux_opt.mk b/make/linux_opt.mk
-index 21cb7c51..16122868 100755
 --- a/make/linux_opt.mk
 +++ b/make/linux_opt.mk
 @@ -422,7 +422,7 @@ ifeq (KSLIB, $(MODULE_TYPE))

--- a/package/qca/qca-ssdk/patches/0002-SSDK-replace-ioremap_nocache-with-ioremap.patch
+++ b/package/qca/qca-ssdk/patches/0002-SSDK-replace-ioremap_nocache-with-ioremap.patch
@@ -1,8 +1,6 @@
-diff --git a/src/init/ssdk_clk.c b/src/init/ssdk_clk.c
-index ee9fbdda..486b3590 100755
 --- a/src/init/ssdk_clk.c
 +++ b/src/init/ssdk_clk.c
-@@ -696,7 +696,7 @@ ssdk_mp_tcsr_get(a_uint32_t tcsr_offset, a_uint32_t *tcsr_val)
+@@ -696,7 +696,7 @@ ssdk_mp_tcsr_get(a_uint32_t tcsr_offset,
  {
  	void __iomem *tcsr_base = NULL;
  
@@ -11,7 +9,7 @@ index ee9fbdda..486b3590 100755
  	if (!tcsr_base)
  	{
  		SSDK_ERROR("Failed to map tcsr eth address!\n");
-@@ -713,7 +713,7 @@ ssdk_mp_tcsr_set(a_uint32_t tcsr_offset, a_uint32_t tcsr_val)
+@@ -713,7 +713,7 @@ ssdk_mp_tcsr_set(a_uint32_t tcsr_offset,
  {
  	void __iomem *tcsr_base = NULL;
  
@@ -29,7 +27,7 @@ index ee9fbdda..486b3590 100755
  	if (!pll_lock) {
  		SSDK_ERROR("Failed to map CMN PLL LOCK register!\n");
  		return A_FALSE;
-@@ -818,7 +818,7 @@ static void ssdk_cmnblk_pll_src_set(enum cmnblk_pll_src_type pll_source)
+@@ -818,7 +818,7 @@ static void ssdk_cmnblk_pll_src_set(enum
  	void __iomem *cmn_pll_src_base = NULL;
  	a_uint32_t reg_val;
  
@@ -38,7 +36,7 @@ index ee9fbdda..486b3590 100755
  	if (!cmn_pll_src_base) {
  		SSDK_ERROR("Failed to map cmn pll source address!\n");
  		return;
-@@ -839,7 +839,7 @@ static void ssdk_cmnblk_init(enum cmnblk_clk_type mode)
+@@ -839,7 +839,7 @@ static void ssdk_cmnblk_init(enum cmnblk
  	void __iomem *gcc_pll_base = NULL;
  	a_uint32_t reg_val;
  
@@ -47,11 +45,9 @@ index ee9fbdda..486b3590 100755
  	if (!gcc_pll_base) {
  		SSDK_ERROR("Failed to map gcc pll address!\n");
  		return;
-diff --git a/src/init/ssdk_init.c b/src/init/ssdk_init.c
-index 0d7cac41..bc4486fe 100755
 --- a/src/init/ssdk_init.c
 +++ b/src/init/ssdk_init.c
-@@ -2945,7 +2945,7 @@ static int ssdk_dess_mac_mode_init(a_uint32_t dev_id, a_uint32_t mac_mode)
+@@ -2945,7 +2945,7 @@ static int ssdk_dess_mac_mode_init(a_uin
  							(a_uint8_t *)&reg_value, 4);
  			mdelay(10);
  			/*softreset psgmii, fixme*/
@@ -60,11 +56,9 @@ index 0d7cac41..bc4486fe 100755
  			if (!gcc_addr) {
  				SSDK_ERROR("gcc map fail!\n");
  				return 0;
-diff --git a/src/init/ssdk_plat.c b/src/init/ssdk_plat.c
-index 1d97f81c..dbb186fa 100755
 --- a/src/init/ssdk_plat.c
 +++ b/src/init/ssdk_plat.c
-@@ -1361,7 +1361,7 @@ ssdk_plat_init(ssdk_init_cfg *cfg, a_uint32_t dev_id)
+@@ -1361,7 +1361,7 @@ ssdk_plat_init(ssdk_init_cfg *cfg, a_uin
  	reg_mode = ssdk_uniphy_reg_access_mode_get(dev_id);
  	if(reg_mode == HSL_REG_LOCAL_BUS) {
  		ssdk_uniphy_reg_map_info_get(dev_id, &map);
@@ -73,7 +67,7 @@ index 1d97f81c..dbb186fa 100755
  									map.size);
  		if (!qca_phy_priv_global[dev_id]->uniphy_hw_addr) {
  			SSDK_ERROR("%s ioremap fail.", __func__);
-@@ -1376,7 +1376,7 @@ ssdk_plat_init(ssdk_init_cfg *cfg, a_uint32_t dev_id)
+@@ -1376,7 +1376,7 @@ ssdk_plat_init(ssdk_init_cfg *cfg, a_uin
  	reg_mode = ssdk_switch_reg_access_mode_get(dev_id);
  	if(reg_mode == HSL_REG_LOCAL_BUS) {
  		ssdk_switch_reg_map_info_get(dev_id, &map);
@@ -82,7 +76,7 @@ index 1d97f81c..dbb186fa 100755
  								map.size);
  		if (!qca_phy_priv_global[dev_id]->hw_addr) {
  			SSDK_ERROR("%s ioremap fail.", __func__);
-@@ -1409,7 +1409,7 @@ ssdk_plat_init(ssdk_init_cfg *cfg, a_uint32_t dev_id)
+@@ -1409,7 +1409,7 @@ ssdk_plat_init(ssdk_init_cfg *cfg, a_uin
  			return -1;
  		}
  

--- a/package/qca/qca-ssdk/patches/0004-platform-use-of_mdio_find_bus-to-get-MDIO-bus.patch
+++ b/package/qca/qca-ssdk/patches/0004-platform-use-of_mdio_find_bus-to-get-MDIO-bus.patch
@@ -1,5 +1,3 @@
-diff --git a/src/init/ssdk_plat.c b/src/init/ssdk_plat.c
-index dbb186fa..4b44d218 100755
 --- a/src/init/ssdk_plat.c
 +++ b/src/init/ssdk_plat.c
 @@ -561,7 +561,6 @@ static int miibus_get(a_uint32_t dev_id)

--- a/package/qca/qca-ssdk/patches/0005-add-kernel-5.4-support.patch
+++ b/package/qca/qca-ssdk/patches/0005-add-kernel-5.4-support.patch
@@ -1,8 +1,6 @@
-diff --git a/app/nathelper/linux/lib/nat_helper_dt.c b/app/nathelper/linux/lib/nat_helper_dt.c
-index 85941881..921c81fa 100755
 --- a/app/nathelper/linux/lib/nat_helper_dt.c
 +++ b/app/nathelper/linux/lib/nat_helper_dt.c
-@@ -726,7 +726,7 @@ napt_ct_counter_sync(a_uint32_t hw_index)
+@@ -726,7 +726,7 @@ napt_ct_counter_sync(a_uint32_t hw_index
  	}
  	
  	if (!test_bit(IPS_FIXED_TIMEOUT_BIT, &ct->status)) {
@@ -11,7 +9,7 @@ index 85941881..921c81fa 100755
  	}
  
  	if((cct != NULL) && (napt_hw_get_by_index(&napt, hw_index) == 0))
-@@ -775,7 +775,7 @@ napt_ct_timer_update(a_uint32_t hw_index)
+@@ -775,7 +775,7 @@ napt_ct_timer_update(a_uint32_t hw_index
  	}
  
  	if (!test_bit(IPS_FIXED_TIMEOUT_BIT, &ct->status)) {
@@ -20,8 +18,6 @@ index 85941881..921c81fa 100755
  	}
  
  	return 0;
-diff --git a/app/nathelper/linux/napt_helper.c b/app/nathelper/linux/napt_helper.c
-index e6efbbf8..8cd8b9d9 100755
 --- a/app/nathelper/linux/napt_helper.c
 +++ b/app/nathelper/linux/napt_helper.c
 @@ -64,11 +64,6 @@ napt_ct_aging_disable(uintptr_t ct_addr)
@@ -36,7 +32,7 @@ index e6efbbf8..8cd8b9d9 100755
  }
  
  int
-@@ -85,7 +80,7 @@ napt_ct_aging_is_enable(uintptr_t ct_addr)
+@@ -85,7 +80,7 @@ napt_ct_aging_is_enable(uintptr_t ct_add
  
  	ct = (struct nf_conn *)ct_addr;
  
@@ -74,7 +70,7 @@ index e6efbbf8..8cd8b9d9 100755
  	struct nf_conntrack_tuple_hash *h = NULL;
  	struct nf_conn *ct = NULL;
  	struct hlist_nulls_node *pos = (struct hlist_nulls_node *) (*iterate);
-@@ -349,7 +342,7 @@ napt_ct_list_iterate(uint32_t *hash, uintptr_t *iterate)
+@@ -349,7 +342,7 @@ napt_ct_list_iterate(uint32_t *hash, uin
  		if(pos == 0)
  		{
  			/*get head for list*/
@@ -83,8 +79,6 @@ index e6efbbf8..8cd8b9d9 100755
  		}
  
  		hlist_nulls_for_each_entry_from(h, pos, hnnode)
-diff --git a/app/nathelper/linux/nat_ipt_helper.c b/app/nathelper/linux/nat_ipt_helper.c
-index d48c26ef..2304ad5a 100755
 --- a/app/nathelper/linux/nat_ipt_helper.c
 +++ b/app/nathelper/linux/nat_ipt_helper.c
 @@ -534,10 +534,10 @@ nat_ipt_data_init(void)
@@ -100,8 +94,6 @@ index d48c26ef..2304ad5a 100755
  }
  
  static void
-diff --git a/make/linux_opt.mk b/make/linux_opt.mk
-index 16122868..23f50ea4 100755
 --- a/make/linux_opt.mk
 +++ b/make/linux_opt.mk
 @@ -483,9 +483,6 @@ ifeq (KSLIB, $(MODULE_TYPE))

--- a/package/qca/qca-ssdk/patches/0007-SSDK-dts-fix-of_get_mac_address.patch
+++ b/package/qca/qca-ssdk/patches/0007-SSDK-dts-fix-of_get_mac_address.patch
@@ -1,5 +1,3 @@
-diff --git a/src/init/ssdk_dts.c b/src/init/ssdk_dts.c
-index e7152987..5ef813c9 100755
 --- a/src/init/ssdk_dts.c
 +++ b/src/init/ssdk_dts.c
 @@ -824,8 +824,9 @@ static void ssdk_dt_parse_intf_mac(void)

--- a/package/qca/qca-ssdk/patches/0009-qca8081-convert-to-5.11-IRQ-model.patch
+++ b/package/qca/qca-ssdk/patches/0009-qca8081-convert-to-5.11-IRQ-model.patch
@@ -1,8 +1,6 @@
-diff --git a/src/hsl/phy/qca808x.c b/src/hsl/phy/qca808x.c
-index 0f0ebb57..f370e39e 100755
 --- a/src/hsl/phy/qca808x.c
 +++ b/src/hsl/phy/qca808x.c
-@@ -238,6 +238,7 @@ static int qca808x_config_intr(struct phy_device *phydev)
+@@ -238,6 +238,7 @@ static int qca808x_config_intr(struct ph
  	return err;
  }
  
@@ -10,7 +8,7 @@ index 0f0ebb57..f370e39e 100755
  static int qca808x_ack_interrupt(struct phy_device *phydev)
  {
  	int err;
-@@ -257,6 +258,47 @@ static int qca808x_ack_interrupt(struct phy_device *phydev)
+@@ -257,6 +258,47 @@ static int qca808x_ack_interrupt(struct
  
  	return (err < 0) ? err : 0;
  }

--- a/package/qca/qca-ssdk/patches/0010-QSDK-config-Avoid-Werror-heroics.patch
+++ b/package/qca/qca-ssdk/patches/0010-QSDK-config-Avoid-Werror-heroics.patch
@@ -19,12 +19,12 @@ Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>
 
 --- a/config
 +++ b/config
-@@ -132,7 +132,7 @@ endif
+@@ -141,7 +141,7 @@ endif
  
  ifeq ($(ARCH), arm64)
- ifeq ($(KVER),$(filter 4.1% 4.4% 4.9% 5.4% 5.10% 5.15%,$(KVER)))
--  CPU_CFLAG=  -DMODULE -Os -pipe -march=armv8-a -mcpu=cortex-a53+crypto -fno-caller-saves -fno-strict-aliasing -Werror -fno-common -Wno-format-security -Wno-pointer-sign -Wno-unused-but-set-variable -Wno-error=unused-result -mcmodel=large
-+  CPU_CFLAG=  -DMODULE -Os -pipe -march=armv8-a -mcpu=cortex-a53+crypto -fno-caller-saves -fno-strict-aliasing -fno-common -Wno-format-security -Wno-pointer-sign -Wno-unused-but-set-variable -Wno-error=unused-result -Wno-error=maybe-uninitialized -Wno-error=array-bounds -mcmodel=large
- endif
+ 	ifeq ($(KVER),$(filter 4.1% 4.4% 4.9% 5.4% 5.10% 5.15%,$(KVER)))
+-		CPU_CFLAG=  -DMODULE -Os -pipe -march=armv8-a -mcpu=cortex-a53+crypto -fno-caller-saves -fno-strict-aliasing -Werror -fno-common -Wno-format-security -Wno-pointer-sign -Wno-unused-but-set-variable -Wno-error=unused-result -mcmodel=large
++		CPU_CFLAG=  -DMODULE -Os -pipe -march=armv8-a -mcpu=cortex-a53+crypto -fno-caller-saves -fno-strict-aliasing -fno-common -Wno-format-security -Wno-pointer-sign -Wno-unused-but-set-variable -Wno-error=unused-result -Wno-error=maybe-uninitialized -Wno-error=array-bounds -mcmodel=large
+ 	endif
  endif
  


### PR DESCRIPTION
Fixed patch application failure.

Fixes: 89200af ("bump qca-ssdk nss-dp and ssdk-shell, Add tplink-tl-er2260t basic support (#10777)")
Fixes: #10844

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
