### PR TITLE
ipq807x: add tl-er2260t dts for other device builds in 5.15

### DIFF
--- a/target/linux/ipq807x/files-5.15/arch/arm64/boot/dts/qcom/ipq8070-tl-er2260t.dts
+++ b/target/linux/ipq807x/files-5.15/arch/arm64/boot/dts/qcom/ipq8070-tl-er2260t.dts
@@ -1,0 +1,666 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/* Copyright (c) 2020 The Linux Foundation. All rights reserved.
+ */
+
+/dts-v1/;
+
+#include "ipq8074.dtsi"
+#include "ipq8074-ess.dtsi"
+#include "ipq8074-hk-cpu.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+/ {
+	#address-cells = <0x2>;
+	#size-cells = <0x2>;
+	model = "TP-Link TL-ER2260T";
+	compatible = "tplink,tl-er2260t", "qcom,ipq8074";
+	qcom,msm-id = <0x143 0x0>;
+	interrupt-parent = <&intc>;
+
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+		serial0 = &blsp1_uart5;
+
+		ethernet0 = "/soc/dp1";
+		ethernet1 = "/soc/dp2";
+		ethernet2 = "/soc/dp3";
+		ethernet3 = "/soc/dp4";
+		ethernet4 = "/soc/dp5";
+		ethernet5 = "/soc/dp6";
+	};
+
+	chosen {
+		stdout-path = "serial0";
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
+			linux,input-type = <1>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&leds_pins>;
+		pinctrl-names = "default";
+
+		led_sys: sys {
+			label = "green:sys";
+			gpios = <&tlmm 21 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb {
+			label = "green:usb";
+			gpios = <&tlmm 22 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "usbport";
+		};
+
+		sfp1-green {
+			label = "green:sfp1";
+			gpios = <&tlmm 51 GPIO_ACTIVE_HIGH>;
+		};
+
+		sfp2-green {
+			label = "green:sfp2";
+			gpios = <&tlmm 55 GPIO_ACTIVE_HIGH>;
+		};
+	};
+	
+	spi@78b5000 {
+		status = "ok";
+		pinctrl-0 = <&spi_0_pins>;
+		pinctrl-names = "default";
+		cs-select = <0>;
+
+		m25p80@0 {
+			  compatible = "n25q128a11";
+			  #address-cells = <1>;
+			  #size-cells = <1>;
+			  reg = <0>;
+			  spi-max-frequency = <50000000>;
+		};
+	};
+};
+
+&tlmm {
+	mdio_pins: mdio_pinmux {
+		mux_0 {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+		mux_1 {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+		mux_2 {
+			pins = "gpio44";
+			function = "gpio";
+			bias-pull-up;
+		};
+	};
+
+	i2c_1_pins: i2c_1_pins {
+		pins = "gpio46", "gpio47";
+		function = "blsp2_i2c";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	button_pins: button_pins {
+		reset {
+			pins = "gpio50";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	uniphy_pins: uniphy_pinmux {
+		mux {
+			pins = "gpio60";
+			function = "rx2";
+			bias-disable;
+		};
+		sfp_tx {
+			pins = "gpio59";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+			output-high;
+		};
+	};
+
+	leds_pins: leds_pinmux {
+		mux {
+			pins = "gpio21", "gpio22", "gpio65";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+		led_sfp1_active {
+			pins = "gpio51";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+		led_sfp2_active {
+			pins = "gpio55";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
+
+	phy0:ethernet-phy@0 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <0>;
+	};
+	phy1:ethernet-phy@1 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <1>;
+	};
+	phy2:ethernet-phy@2 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <2>;
+	};
+	phy3:ethernet-phy@3 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <3>;
+	};
+	phy4: ethernet-phy@29 {
+		reg = <29>;
+	};
+	phy5: ethernet-phy@30 {
+		reg = <30>;
+	};
+};
+
+&switch {
+	status = "okay";
+	switch_cpu_bmp = <0x1>;  /* cpu port bitmap */
+	switch_lan_bmp = <0x3e>; /* lan port bitmap */
+	switch_wan_bmp = <0x40>; /* wan port bitmap */
+	switch_mac_mode = <0xb>; /* mac mode for uniphy instance0*/
+	switch_mac_mode1 = <0xe>; /* mac mode for uniphy instance1*/ //use 10g_baser mode for default
+	switch_mac_mode2 = <0xe>; /* mac mode for uniphy instance2*/ //use 10g_baser mode for default
+	bm_tick_mode = <0>; /* bm tick mode */
+	tm_tick_mode = <0>; /* tm tick mode */
+	cmnblk_clk = "external_50MHz";
+
+	qcom,port_phyinfo {
+		port@0 {
+			port_id = <1>;
+			phy_address = <0>;
+		};
+		port@1 {
+			port_id = <2>;
+			phy_address = <1>;
+		};
+		port@2 {
+			port_id = <3>;
+			phy_address = <2>;
+		};
+		port@3 {
+			port_id = <4>;
+			phy_address = <3>;
+		};
+		port@4 {
+			port_id = <5>;
+			phy_address = <29>;//29
+			phy_i2c_address = <29>;//29
+			phy-i2c-mode; /*i2c access phy */
+			media-type = "sfp"; /* fiber mode */
+		};
+		port@5 {
+			port_id = <6>;
+			phy_address = <30>;//30
+			phy_i2c_address = <30>;//30
+			phy-i2c-mode; /*i2c access phy */
+			media-type = "sfp"; /* fiber mode */
+		};
+	};
+	port_scheduler_resource {
+		port@0 {
+			port_id = <0>;
+			ucast_queue = <0 143>;
+			mcast_queue = <256 271>;
+			l0sp = <0 35>;
+			l0cdrr = <0 47>;
+			l0edrr = <0 47>;
+			l1cdrr = <0 7>;
+			l1edrr = <0 7>;
+		};
+		port@1 {
+			port_id = <1>;
+			ucast_queue = <144 159>;
+			mcast_queue = <272 275>;
+			l0sp = <36 39>;
+			l0cdrr = <48 63>;
+			l0edrr = <48 63>;
+			l1cdrr = <8 11>;
+			l1edrr = <8 11>;
+		};
+		port@2 {
+			port_id = <2>;
+			ucast_queue = <160 175>;
+			mcast_queue = <276 279>;
+			l0sp = <40 43>;
+			l0cdrr = <64 79>;
+			l0edrr = <64 79>;
+			l1cdrr = <12 15>;
+			l1edrr = <12 15>;
+		};
+		port@3 {
+			port_id = <3>;
+			ucast_queue = <176 191>;
+			mcast_queue = <280 283>;
+			l0sp = <44 47>;
+			l0cdrr = <80 95>;
+			l0edrr = <80 95>;
+			l1cdrr = <16 19>;
+			l1edrr = <16 19>;
+		};
+		port@4 {
+			port_id = <4>;
+			ucast_queue = <192 207>;
+			mcast_queue = <284 287>;
+			l0sp = <48 51>;
+			l0cdrr = <96 111>;
+			l0edrr = <96 111>;
+			l1cdrr = <20 23>;
+			l1edrr = <20 23>;
+		};
+		port@5 {
+			port_id = <5>;
+			ucast_queue = <208 223>;
+			mcast_queue = <288 291>;
+			l0sp = <52 55>;
+			l0cdrr = <112 127>;
+			l0edrr = <112 127>;
+			l1cdrr = <24 27>;
+			l1edrr = <24 27>;
+		};
+		port@6 {
+			port_id = <6>;
+			ucast_queue = <224 239>;
+			mcast_queue = <292 295>;
+			l0sp = <56 59>;
+			l0cdrr = <128 143>;
+			l0edrr = <128 143>;
+			l1cdrr = <28 31>;
+			l1edrr = <28 31>;
+		};
+		port@7 {
+			port_id = <7>;
+			ucast_queue = <240 255>;
+			mcast_queue = <296 299>;
+			l0sp = <60 63>;
+			l0cdrr = <144 159>;
+			l0edrr = <144 159>;
+			l1cdrr = <32 35>;
+			l1edrr = <32 35>;
+		};
+	};
+	port_scheduler_config {
+		port@0 {
+			port_id = <0>;
+			l1scheduler {
+				group@0 {
+					sp = <0 1>; /*L0 SPs*/
+					/*cpri cdrr epri edrr*/
+					cfg = <0 0 0 0>;
+				};
+			};
+			l0scheduler {
+				group@0 {
+					/*unicast queues*/
+					ucast_queue = <0 4 8>;
+					/*multicast queues*/
+					mcast_queue = <256 260>;
+					/*sp cpri cdrr epri edrr*/
+					cfg = <0 0 0 0 0>;
+				};
+				group@1 {
+					ucast_queue = <1 5 9>;
+					mcast_queue = <257 261>;
+					cfg = <0 1 1 1 1>;
+				};
+				group@2 {
+					ucast_queue = <2 6 10>;
+					mcast_queue = <258 262>;
+					cfg = <0 2 2 2 2>;
+				};
+				group@3 {
+					ucast_queue = <3 7 11>;
+					mcast_queue = <259 263>;
+					cfg = <0 3 3 3 3>;
+				};
+			};
+		};
+		port@1 {
+			port_id = <1>;
+			l1scheduler {
+				group@0 {
+					sp = <36>;
+					cfg = <0 8 0 8>;
+				};
+				group@1 {
+					sp = <37>;
+					cfg = <1 9 1 9>;
+				};
+			};
+			l0scheduler {
+				group@0 {
+					ucast_queue = <144>;
+					ucast_loop_pri = <16>;
+					mcast_queue = <272>;
+					mcast_loop_pri = <4>;
+					cfg = <36 0 48 0 48>;
+				};
+			};
+		};
+		port@2 {
+			port_id = <2>;
+			l1scheduler {
+				group@0 {
+					sp = <40>;
+					cfg = <0 12 0 12>;
+				};
+				group@1 {
+					sp = <41>;
+					cfg = <1 13 1 13>;
+				};
+			};
+			l0scheduler {
+				group@0 {
+					ucast_queue = <160>;
+					ucast_loop_pri = <16>;
+					mcast_queue = <276>;
+					mcast_loop_pri = <4>;
+					cfg = <40 0 64 0 64>;
+				};
+			};
+		};
+		port@3 {
+			port_id = <3>;
+			l1scheduler {
+				group@0 {
+					sp = <44>;
+					cfg = <0 16 0 16>;
+				};
+				group@1 {
+					sp = <45>;
+					cfg = <1 17 1 17>;
+				};
+			};
+			l0scheduler {
+				group@0 {
+					ucast_queue = <176>;
+					ucast_loop_pri = <16>;
+					mcast_queue = <280>;
+					mcast_loop_pri = <4>;
+					cfg = <44 0 80 0 80>;
+				};
+			};
+		};
+		port@4 {
+			port_id = <4>;
+			l1scheduler {
+				group@0 {
+					sp = <48>;
+					cfg = <0 20 0 20>;
+				};
+				group@1 {
+					sp = <49>;
+					cfg = <1 21 1 21>;
+				};
+			};
+			l0scheduler {
+				group@0 {
+					ucast_queue = <192>;
+					ucast_loop_pri = <16>;
+					mcast_queue = <284>;
+					mcast_loop_pri = <4>;
+					cfg = <48 0 96 0 96>;
+				};
+			};
+		};
+		port@5 {
+			port_id = <5>;
+			l1scheduler {
+				group@0 {
+					sp = <52>;
+					cfg = <0 24 0 24>;
+				};
+				group@1 {
+					sp = <53>;
+					cfg = <1 25 1 25>;
+				};
+			};
+			l0scheduler {
+				group@0 {
+					ucast_queue = <208>;
+					ucast_loop_pri = <16>;
+					mcast_queue = <288>;
+					mcast_loop_pri = <4>;
+					cfg = <52 0 112 0 112>;
+				};
+			};
+		};
+		port@6 {
+			port_id = <6>;
+			l1scheduler {
+				group@0 {
+					sp = <56>;
+					cfg = <0 28 0 28>;
+				};
+				group@1 {
+					sp = <57>;
+					cfg = <1 29 1 29>;
+				};
+			};
+			l0scheduler {
+				group@0 {
+					ucast_queue = <224>;
+					ucast_loop_pri = <16>;
+					mcast_queue = <292>;
+					mcast_loop_pri = <4>;
+					cfg = <56 0 128 0 128>;
+				};
+			};
+		};
+		port@7 {
+			port_id = <7>;
+			l1scheduler {
+				group@0 {
+					sp = <60>;
+					cfg = <0 32 0 32>;
+				};
+				group@1 {
+					sp = <61>;
+					cfg = <1 33 1 33>;
+				};
+			};
+			l0scheduler {
+				group@0 {
+					ucast_queue = <240>;
+					ucast_loop_pri = <16>;
+					mcast_queue = <296>;
+					cfg = <60 0 144 0 144>;
+				};
+			};
+		};
+	};
+};
+
+&soc {
+	dp1: dp1 {
+		device_type = "network";
+		compatible = "qcom,nss-dp";
+		qcom,id = <1>;
+		reg = <0x3a001000 0x200>;
+		qcom,mactype = <0>;
+		local-mac-address = [000000000000];
+		qcom,link-poll = <1>;
+		qcom,phy-mdio-addr = <0>;
+		phy-mode = "sgmii";
+		mdio-bus = <&mdio>;
+	};
+	dp2: dp2 {
+		device_type = "network";
+		compatible = "qcom,nss-dp";
+		qcom,id = <2>;
+		reg = <0x3a001200 0x200>;
+		qcom,mactype = <0>;
+		local-mac-address = [000000000000];
+		qcom,link-poll = <1>;
+		qcom,phy-mdio-addr = <1>;
+		phy-mode = "sgmii";
+		mdio-bus = <&mdio>;
+	};
+	dp3: dp3 {
+		device_type = "network";
+		compatible = "qcom,nss-dp";
+		qcom,id = <3>;
+		reg = <0x3a001400 0x200>;
+		qcom,mactype = <0>;
+		local-mac-address = [000000000000];
+		qcom,link-poll = <1>;
+		qcom,phy-mdio-addr = <2>;
+		phy-mode = "sgmii";
+		mdio-bus = <&mdio>;
+	};
+	dp4: dp4 {
+		device_type = "network";
+		compatible = "qcom,nss-dp";
+		qcom,id = <4>;
+		reg = <0x3a001600 0x200>;
+		qcom,mactype = <0>;
+		local-mac-address = [000000000000];
+		qcom,link-poll = <1>;
+		qcom,phy-mdio-addr = <3>;
+		phy-mode = "sgmii";
+		mdio-bus = <&mdio>;
+	};
+	dp5: dp5 {
+		device_type = "network";
+		compatible = "qcom,nss-dp";
+		qcom,id = <5>;
+		reg = <0x3a001800 0x200>;
+		qcom,mactype = <1>;
+		local-mac-address = [000000000000];
+		qcom,link-poll = <1>;
+		qcom,phy-mdio-addr = <29>;
+		phy-mode = "sgmii";
+		mdio-bus = <&mdio>;
+	};
+	dp6: dp6 {
+		device_type = "network";
+		compatible = "qcom,nss-dp";
+		qcom,id = <6>;
+		reg = <0x3a007000 0x3fff>;
+		qcom,mactype = <1>;
+		local-mac-address = [000000000000];
+		qcom,link-poll = <1>;
+		qcom,phy-mdio-addr = <30>;
+		phy-mode = "sgmii";
+		mdio-bus = <&mdio>;
+	};
+	
+	nss-macsec1 {
+		compatible = "qcom,nss-macsec";
+		phy_addr = <0x1c>;
+		phy_access_mode = <0x00>;
+		mdiobus = <&mdio>;
+	};
+
+	watchdog@b017000 {
+		compatible = "qcom,kpss-wdt-ipq807x";
+		reg = <0xb017000 0x1000>;
+		reg-names = "kpss_wdt";
+		interrupt-names = "bark_irq";
+		interrupts = <0x00 0x03 0x00>;
+		clocks = <&sleep_clk>;
+		timeout-sec = <0x0a>;
+		wdt-max-timeout = <0x20>;
+	};
+};
+
+&blsp1_i2c2 {
+	status = "okay";
+};
+
+&blsp1_i2c3 {
+	pinctrl-0 = <&i2c_1_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+		};
+	};
+};
+
+&qusb_phy_0 {
+	status = "okay";
+};
+
+&ssphy_0 {
+	status = "okay";
+};
+
+&usb_0 {
+	status = "okay";
+};

--- a/target/linux/ipq807x/patches-5.15/0900-arm64-dts-add-OpenWrt-DTS-files.patch
+++ b/target/linux/ipq807x/patches-5.15/0900-arm64-dts-add-OpenWrt-DTS-files.patch
@@ -12,14 +12,15 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 
 --- a/arch/arm64/boot/dts/qcom/Makefile
 +++ b/arch/arm64/boot/dts/qcom/Makefile
-@@ -4,6 +4,11 @@ dtb-$(CONFIG_ARCH_QCOM)	+= apq8094-sony-
+@@ -4,6 +4,12 @@ dtb-$(CONFIG_ARCH_QCOM)	+= apq8094-sony-
  dtb-$(CONFIG_ARCH_QCOM)	+= apq8096-db820c.dtb
  dtb-$(CONFIG_ARCH_QCOM)	+= apq8096-ifc6640.dtb
  dtb-$(CONFIG_ARCH_QCOM)	+= ipq6018-cp01-c1.dtb
-+dtb-$(CONFIG_ARCH_QCOM)	+= ipq8072-301w.dtb
++dtb-$(CONFIG_ARCH_QCOM)	+= ipq8070-tl-er2260t.dtb
 +dtb-$(CONFIG_ARCH_QCOM)	+= ipq8071-ax6.dtb
 +dtb-$(CONFIG_ARCH_QCOM)	+= ipq8071-ax3600.dtb
 +dtb-$(CONFIG_ARCH_QCOM)	+= ipq8071-mf269.dtb
++dtb-$(CONFIG_ARCH_QCOM)	+= ipq8072-301w.dtb
 +dtb-$(CONFIG_ARCH_QCOM)	+= ipq8078-xtr10890.dtb
  dtb-$(CONFIG_ARCH_QCOM)	+= ipq8074-hk01.dtb
  dtb-$(CONFIG_ARCH_QCOM)	+= ipq8074-hk10-c1.dtb


### PR DESCRIPTION
Only solves other device builds, doesn't support tl-er2260t running.

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
