### PR TITLE
rockchip: fix cannot stat dtb file

### DIFF
--- a/target/linux/rockchip/patches-5.15/210-rockchip-rk356x-add-support-for-new-boards.patch
+++ b/target/linux/rockchip/patches-5.15/210-rockchip-rk356x-add-support-for-new-boards.patch
@@ -1,6 +1,6 @@
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -59,3 +59,13 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-sa
+@@ -59,3 +59,14 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-sa
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-sapphire-excavator.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399pro-rock-pi-n10.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-evb1-v10.dtb

--- a/target/linux/rockchip/patches-6.1/210-rockchip-rk356x-add-support-for-new-boards.patch
+++ b/target/linux/rockchip/patches-6.1/210-rockchip-rk356x-add-support-for-new-boards.patch
@@ -1,6 +1,6 @@
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -79,3 +79,12 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-so
+@@ -79,3 +79,13 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-so
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-bpi-r2-pro.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-evb1-v10.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-rock-3a.dtb


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
```
mkdir -p /home/superb/lede/build_dir/target-aarch64_generic_musl/linux-rockchip_armv8/tmp/openwrt-rockchip-armv8-fastrhino_r68s-squashfs-sysupgrade.img.gz.boot
cp -fpR /home/superb/lede/build_dir/target-aarch64_generic_musl/linux-rockchip_armv8/linux-5.15.91/arch/arm64/boot/dts/rockchip/rk3568-r68s.dtb /home/superb/lede/build_dir/target-aarch64_generic_musl/linux-rockchip_armv8/tmp/openwrt-rockchip-armv8-fastrhino_r68s-squashfs-sysupgrade.img.gz.boot/rockchip.dtb
cp: cannot stat '/home/superb/lede/build_dir/target-aarch64_generic_musl/linux-rockchip_armv8/linux-5.15.91/arch/arm64/boot/dts/rockchip/rk3568-r68s.dtb': No such file or directory
make[5]: *** [Makefile:84: /home/superb/lede/build_dir/target-aarch64_generic_musl/linux-rockchip_armv8/tmp/openwrt-rockchip-armv8-fastrhino_r68s-squashfs-sysupgrade.img.gz] Error 1
```
