### PR TITLE
mtwifi: Mt7612E disable set_fs get_fs by default

### DIFF
--- a/package/lean/mt/drivers/mt7612e/src/mt76x2/os/linux/rt_linux.c
+++ b/package/lean/mt/drivers/mt7612e/src/mt76x2/os/linux/rt_linux.c
@@ -914,10 +914,14 @@ static inline void __RtmpOSFSInfoChange(OS_FS_INFO * pOSFSInfo, BOOLEAN bSet)
 		pOSFSInfo->fsuid = current_fsuid();
 		pOSFSInfo->fsgid = current_fsgid();
 #endif
+#if 0
 		pOSFSInfo->fs = get_fs();
 		set_fs(KERNEL_DS);
+#endif
 	} else {
+#if 0
 		set_fs(pOSFSInfo->fs);
+#endif
 #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,29)
 		current->fsuid = pOSFSInfo->fsuid;
 		current->fsgid = pOSFSInfo->fsgid;
@@ -1936,8 +1940,10 @@ VOID RtmpDrvAllMacPrint(
 	if (!msg)
 		return;
 	
+#if 0
 	orig_fs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 
 	/* open file */
 	file_w = filp_open(fileName, O_WRONLY | O_CREAT, 0);
@@ -1965,7 +1971,9 @@ VOID RtmpDrvAllMacPrint(
 		}
 		filp_close(file_w, NULL);
 	}
+#if 0
 	set_fs(orig_fs);
+#endif
 	os_free_mem(NULL, msg);
 }
 
@@ -1987,8 +1995,10 @@ VOID RtmpDrvAllE2PPrint(
 	if (!msg)
 		return;
 	
+#if 0
 	orig_fs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 	
 	/* open file */
 	file_w = filp_open(fileName, O_WRONLY | O_CREAT, 0);
@@ -2017,7 +2027,9 @@ VOID RtmpDrvAllE2PPrint(
 		}
 		filp_close(file_w, NULL);
 	}
+#if 0
 	set_fs(orig_fs);
+#endif
 	os_free_mem(NULL, msg);
 }
 
@@ -2031,8 +2043,10 @@ VOID RtmpDrvAllRFPrint(
 	PSTRING fileName = "RFDump.txt";
 	mm_segment_t orig_fs;
 	
+#if 0
 	orig_fs = get_fs();
 	set_fs(KERNEL_DS);
+#endif
 
 	/* open file */
 	file_w = filp_open(fileName, O_WRONLY | O_CREAT, 0);
@@ -2048,7 +2062,9 @@ VOID RtmpDrvAllRFPrint(
 		}
 		filp_close(file_w, NULL);
 	}
+#if 0
 	set_fs(orig_fs);
+#endif
 }
 
 


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

注意到MT7621E驱动默认没有禁用get_fs set_fs 为了兼容新内核，暂时禁用，或者修改为5.10内核以下启用