### PR TITLE
 generic: fix swconfig_leds.c in 5.15

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/swconfig_leds.c
+++ b/target/linux/generic/files/drivers/net/phy/swconfig_leds.c
@@ -85,7 +85,7 @@ swconfig_trig_update_port_mask(struct led_trigger *trigger)
 	sw_trig = (void *) trigger;
 
 	port_mask = 0;
-#if LINUX_VERSION_CODE > KERNEL_VERSION(5, 15, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0)
 	spin_lock(&trigger->leddev_list_lock);
 #else
 	read_lock(&trigger->leddev_list_lock);
@@ -102,7 +102,7 @@ swconfig_trig_update_port_mask(struct led_trigger *trigger)
 			read_unlock(&trig_data->lock);
 		}
 	}
-#if LINUX_VERSION_CODE > KERNEL_VERSION(5, 15, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0)
 	spin_unlock(&trigger->leddev_list_lock);
 #else
 	read_unlock(&trigger->leddev_list_lock);
@@ -425,7 +425,7 @@ swconfig_trig_update_leds(struct switch_led_trigger *sw_trig)
 	struct led_trigger *trigger;
 
 	trigger = &sw_trig->trig;
-#if LINUX_VERSION_CODE > KERNEL_VERSION(5, 15, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0)
 	spin_lock(&trigger->leddev_list_lock);
 #else
 	read_lock(&trigger->leddev_list_lock);
@@ -436,7 +436,7 @@ swconfig_trig_update_leds(struct switch_led_trigger *sw_trig)
 		led_cdev = list_entry(entry, struct led_classdev, trig_list);
 		swconfig_trig_led_event(sw_trig, led_cdev);
 	}
-#if LINUX_VERSION_CODE > KERNEL_VERSION(5, 15, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0)
 	spin_unlock(&trigger->leddev_list_lock);
 #else
 	read_unlock(&trigger->leddev_list_lock);


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
修复[L大提交的:generic: fix swconfig_leds.c in 5.18](https://github.com/coolsnowwolf/lede/commit/ebfa1b93b76d5a2faacecbc8ed237ed44f5a7018) 导致的5.15内核编译失败，测试MT7620编译无法通过，报错指针不兼容，由KERNEL_VERSION(5, 15, 0)修改为>= KERNEL_VERSION(5, 18, 0)为5.15内核保留原有兼容性也保证5.18内核可以支持编译使用
