### PR TITLE
ksmbd: sync with official source to fix build error.

### DIFF
--- a/package/kernel/ksmbd/Makefile
+++ b/package/kernel/ksmbd/Makefile
@@ -14,6 +14,9 @@ PKG_LICENSE_FILES:=COPYING
 include $(INCLUDE_DIR)/kernel.mk
 include $(INCLUDE_DIR)/package.mk
 
+TAR_OPTIONS+= --strip-components 1
+TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
+
 define KernelPackage/fs-ksmbd
 	SUBMENU:=Filesystems
 	TITLE:=SMB kernel server support


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

最近的ksmbd更新编译出错，但是官方源的没问题。和官方源对比，makefile少2行内容，补上了
