### PR TITLE
qca: change the source repo URL of the qca package

### DIFF
--- a/package/lean/shortcut-fe/simulated-driver/Makefile
+++ b/package/lean/shortcut-fe/simulated-driver/Makefile
@@ -18,7 +18,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=shortcut-fe-simulated-driver
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=https://source.codeaurora.org/quic/qsdk/oss/lklm/shortcut-fe
+PKG_SOURCE_URL:=https://git.codelinaro.org/clo/qsdk/oss/lklm/shortcut-fe.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_DATE:=2021-03-17
 PKG_SOURCE_VERSION:=697977d8d0ccf0ab596e5692d08608a75dd7f33d

--- a/package/qca/nss/qca-nss-cfi/Makefile
+++ b/package/qca/nss/qca-nss-cfi/Makefile
@@ -4,7 +4,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=qca-nss-cfi
 PKG_RELEASE:=2
 
-PKG_SOURCE_URL:=https://source.codeaurora.org/quic/qsdk/oss/lklm/nss-cfi
+PKG_SOURCE_URL:=https://git.codelinaro.org/clo/qsdk/oss/lklm/nss-cfi.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=8035a8ddefdcc8a2f06c96b2a82618ca6ce6406d
 PKG_MIRROR_HASH:=23316395d1346994d069eb41ef73a5505853687f8beab14f83545b3a05e52429

--- a/package/qca/nss/qca-nss-clients-64/Makefile
+++ b/package/qca/nss/qca-nss-clients-64/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=qca-nss-clients-64
 PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE_URL:=https://source.codeaurora.org/quic/cc-qrdk/oss/lklm/nss-clients
+PKG_SOURCE_URL:=https://git.codelinaro.org/clo/qsdk/oss/lklm/nss-clients.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_DATE:=2021-04-29
 PKG_SOURCE_VERSION:=b93c72c1b72c591c2ddc2f0b24f0e2b457720118

--- a/package/qca/nss/qca-nss-clients/Makefile
+++ b/package/qca/nss/qca-nss-clients/Makefile
@@ -4,7 +4,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=qca-nss-clients
 PKG_RELEASE:=2
 
-PKG_SOURCE_URL:=https://source.codeaurora.org/quic/qsdk/oss/lklm/nss-clients
+PKG_SOURCE_URL:=https://git.codelinaro.org/clo/qsdk/oss/lklm/nss-clients.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=740d0102c518cd49f30c5580982b218b480006b1
 PKG_MIRROR_HASH:=2f427d01dba69b1b89d3a081daf08b36fb345d55b9c9462eb358e5b071e2a171

--- a/package/qca/nss/qca-nss-crypto/Makefile
+++ b/package/qca/nss/qca-nss-crypto/Makefile
@@ -4,7 +4,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=qca-nss-crypto
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=https://source.codeaurora.org/quic/qsdk/oss/lklm/nss-crypto
+PKG_SOURCE_URL:=https://git.codelinaro.org/clo/qsdk/oss/lklm/nss-crypto.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=e7651c2986d30b5e8ca5ad6b9a72c47febdf3cca
 PKG_MIRROR_HASH:=381ba448ccd9e0ff69fa52b3e10687b72260b7d0bf865cac10be7f159573b6c8

--- a/package/qca/nss/qca-nss-drv-64/Makefile
+++ b/package/qca/nss/qca-nss-drv-64/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=qca-nss-drv-64
 PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE_URL:=https://source.codeaurora.org/quic/qsdk/oss/lklm/nss-drv
+PKG_SOURCE_URL:=https://git.codelinaro.org/clo/qsdk/oss/lklm/nss-drv.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_DATE:=2022-01-24
 PKG_SOURCE_VERSION:=4f1b8e51105bb71ebd0bb07c1ec0d8b6e5d0913e

--- a/package/qca/nss/qca-nss-drv/Makefile
+++ b/package/qca/nss/qca-nss-drv/Makefile
@@ -4,7 +4,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=qca-nss-drv
 PKG_RELEASE:=2
 
-PKG_SOURCE_URL:=https://source.codeaurora.org/quic/qsdk/oss/lklm/nss-drv
+PKG_SOURCE_URL:=https://git.codelinaro.org/clo/qsdk/oss/lklm/nss-drv.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=809a00deffe9f3d4ecd15965790a152757073437
 PKG_MIRROR_HASH:=9c4340561fe9d6ccaa094bbfc5c7f98c27867d2d9a3f1a3f9a7483bca9bbedf8

--- a/package/qca/nss/qca-nss-ecm-64/Makefile
+++ b/package/qca/nss/qca-nss-ecm-64/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=qca-nss-ecm-64
 PKG_RELEASE:=$(AUTORELEASE)
 
-PKG_SOURCE_URL:=https://source.codeaurora.org/quic/cc-qrdk/oss/lklm/qca-nss-ecm
+PKG_SOURCE_URL:=https://git.codelinaro.org/clo/qsdk/oss/lklm/qca-nss-ecm.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_DATE:=2021-04-29
 PKG_SOURCE_VERSION:=c115aec34867b582e2e5ea79fc5315971e0e953c

--- a/package/qca/nss/qca-nss-ecm/Makefile
+++ b/package/qca/nss/qca-nss-ecm/Makefile
@@ -4,7 +4,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=qca-nss-ecm
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=https://source.codeaurora.org/quic/qsdk/oss/lklm/qca-nss-ecm
+PKG_SOURCE_URL:=https://git.codelinaro.org/clo/qsdk/oss/lklm/qca-nss-ecm.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=9228212b4238c0d8c296f795948ede8f2ca0242e
 PKG_MIRROR_HASH:=02fe4c86c8c88fb15704b1b253ab756a2658f24ce5db64a7909cb60bf9c1cdff

--- a/package/qca/nss/qca-nss-gmac/Makefile
+++ b/package/qca/nss/qca-nss-gmac/Makefile
@@ -5,7 +5,7 @@ PKG_NAME:=qca-nss-gmac
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://source.codeaurora.org/quic/qsdk/oss/lklm/nss-gmac
+PKG_SOURCE_URL:=https://git.codelinaro.org/clo/qsdk/oss/lklm/nss-gmac.git
 PKG_SOURCE_VERSION:=9b74deef2816d91e58926e6fab7a6ff931eb3b22
 PKG_MIRROR_HASH:=a1939caa638414323e60f7d29f797ea831c6036e424b8e7bd6cf2d3d874de064
 

--- a/package/qca/qca-mcs/Makefile
+++ b/package/qca/qca-mcs/Makefile
@@ -5,7 +5,7 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_DATE:=2021-10-28
-PKG_SOURCE_URL:=https://source.codeaurora.org/quic/qsdk/oss/lklm/qca-mcs
+PKG_SOURCE_URL:=https://git.codelinaro.org/clo/qsdk/oss/lklm/qca-mcs.git
 PKG_SOURCE_VERSION:=31f5cd4b83da5a7c0fdca240b4e72677e4523b6e
 PKG_MIRROR_HASH:=3e2e25025dc2e771aafe7d8b12f26ac831d123b34bdd7b7e84bd39c1e933491d
 

--- a/package/qca/qca-rfs/Makefile
+++ b/package/qca/qca-rfs/Makefile
@@ -4,7 +4,7 @@ PKG_NAME:=qca-rfs
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://source.codeaurora.org/quic/qsdk/oss/lklm/qca-rfs
+PKG_SOURCE_URL:=https://git.codelinaro.org/clo/qsdk/oss/lklm/qca-rfs.git
 PKG_SOURCE_DATE:=2021-03-17
 PKG_SOURCE_VERSION:=75197c386f477c7b3a6f02489d9903a9409fd5cc
 PKG_MIRROR_HASH:=90f1c3ec2e984cf8efa79c85d715ebd8a21e347ab57adbd9695de23e64eea1ec

--- a/package/qca/qca-ssdk-shell/Makefile
+++ b/package/qca/qca-ssdk-shell/Makefile
@@ -5,7 +5,7 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_DATE:=2022-01-24
-PKG_SOURCE_URL:=https://source.codeaurora.org/quic/qsdk/oss/ssdk-shell
+PKG_SOURCE_URL:=https://git.codelinaro.org/clo/qsdk/oss/ssdk-shell.git
 PKG_SOURCE_VERSION:=01a60b45ac3498a40bbb011d0c3b7d5d3a1cc9cb
 PKG_MIRROR_HASH:=6233c02c296af241eb2e1c25e49dfc8d9c6cf1095cb82f1862b125dd125c758e
 


### PR DESCRIPTION
The original URL has been deprecated:
https://bye.codeaurora.org/

fixes: #11048

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
