### PR TITLE
K2P支持WIFI客户端模式（无线中继/桥接）

### DIFF
--- a/package/lean/mt/drivers/mt7615d/Makefile
+++ b/package/lean/mt/drivers/mt7615d/Makefile
@@ -201,7 +201,7 @@ endef
 define KernelPackage/mt7615d_dbdc
   CATEGORY:=Kernel modules
   TITLE:=MTK wifi AP driver
-  DEPENDS:=@TARGET_ramips +kmod-mt7615d +maccalc
+  DEPENDS:=@TARGET_ramips +kmod-mt7615d +maccalc +PACKAGE_firewall:kmod-br-netfilter
   SUBMENU:=Wireless Drivers
   MENU:=1
 endef
@@ -234,7 +234,7 @@ define Build/Compile
 endef
 
 define Build/Install
-        :
+	:
 endef
 
 define KernelPackage/mt7615d/install

--- a/package/lean/mt/drivers/mt7615d/files/lib/netifd/wireless/mt_dbdc.sh
+++ b/package/lean/mt/drivers/mt7615d/files/lib/netifd/wireless/mt_dbdc.sh
@@ -310,13 +310,18 @@ mt_dbdc_sta_vif_pre_config() {
 		;;
 	esac
 
+	# mt_cmd iwpriv $APCLI_IF set MACRepeaterEn=1
 	mt_cmd iwpriv $APCLI_IF set ApCliAuthMode=$ApCliAuthMode
 	mt_cmd iwpriv $APCLI_IF set ApCliEncrypType=$ApCliEncrypType
 	if [[ "$ApCliEncrypType" = "WEP" ]]; then
 		mt_cmd iwpriv $APCLI_IF set ApCliDefaultKeyID=$key
+		# mt_cmd iwpriv $APCLI_IF set ApCliKey1Type=1 # 0:hex, 1:ascii
 		mt_cmd iwpriv $APCLI_IF set "\"ApCliKey1=${key1##*:}\""
+		# mt_cmd iwpriv $APCLI_IF set ApCliKey2Type=1
 		mt_cmd iwpriv $APCLI_IF set "\"ApCliKey2=${key2##*:}\""
+		# mt_cmd iwpriv $APCLI_IF set ApCliKey3Type=1
 		mt_cmd iwpriv $APCLI_IF set "\"ApCliKey3=${key3##*:}\""
+		# mt_cmd iwpriv $APCLI_IF set ApCliKey4Type=1
 		mt_cmd iwpriv $APCLI_IF set "\"ApCliKey4=${key4##*:}\""
 	elif ! [[ "$ApCliEncrypType" = "NONE" ]]; then
 		mt_cmd iwpriv $APCLI_IF set "\"ApCliWPAPSK=$key\""

--- a/package/lean/mt/drivers/mt7615d/files/lib/netifd/wireless/mt_dbdc.sh
+++ b/package/lean/mt/drivers/mt7615d/files/lib/netifd/wireless/mt_dbdc.sh
@@ -4,7 +4,7 @@
 # Copyright (c) 2005-2015, lintel <lintel.huang@gmail.com>
 # Copyright (c) 2013, Hoowa <hoowa.sun@gmail.com>
 # Copyright (c) 2015-2017, GuoGuo <gch981213@gmail.com>
-# Copyright (c) 2020, jjm2473 <jjm2473@gmail.com>
+# Copyright (c) 2020,2023, jjm2473 <jjm2473@gmail.com>
 # Copyright (c) 2022, nanchuci <nanchuci023@gmail.com>
 #
 # 	netifd config script for MT7615/MT7915 DBDC mode.
@@ -104,9 +104,14 @@ mt_dbdc_ap_vif_pre_config() {
 	json_get_vars disabled encryption key key1 key2 key3 key4 ssid mode wps pin isolate doth hidden disassoc_low_ack rssiassoc ieee80211k ieee80211v ieee80211r ieee80211w macfilter
 	json_get_values maclist maclist
 	json_select ..
-	[ "$disabled" == "1" ] && return
+
+	[[ "$disabled" = "1" ]] && return
 	echo "Generating ap config for interface ra${RTWIFI_IFPREFIX}${ApBssidNum}"
 	ifname="ra${RTWIFI_IFPREFIX}${ApBssidNum}"
+
+	json_add_object data
+	json_add_string ifname "$ifname"
+	json_close_object
 
 	#MAC过滤方式相关设定 由于编号问题......我扔在这了......
 	ra_maclist="${maclist// /;};"
@@ -196,7 +201,7 @@ mt_dbdc_ap_vif_pre_config() {
 	mt_cmd echo "Interface $ifname now up."
 	mt_cmd iwpriv $ifname set NoForwarding=${isolate:-0}
 	mt_cmd iwpriv $ifname set IEEE80211H=${doth:-0}
-	if [ "$wps" == "pbc" ] || [ "$wps" == "pin" ]  && [ "$encryption" != "none" ]; then
+	if [ "$wps" = "pbc" -o \( "$wps" = "pin" -a "$encryption" != "none" \) ]; then
 		echo "Enable WPS for ${ifname}."
 		mt_cmd iwpriv $ifname set WscConfMode=4
 		mt_cmd iwpriv $ifname set WscConfStatus=2
@@ -222,9 +227,14 @@ mt_dbdc_wds_vif_pre_config() {
 	set_default wdstxmcs 33
 	set_default wdsphymode "GREENFIELD"
 	json_select ..
-	[ "$disabled" == "1" ] && return
+	[[ "$disabled" = "1" ]] && return
 	[ $WDSBssidNum -gt 3 ] && return
 	ifname="wds${RTWIFI_IFPREFIX}${WDSBssidNum}"
+
+	json_add_object data
+	json_add_string ifname "$ifname"
+	json_close_object
+
 	echo "Generating WDS config for interface $ifname"
 	WDSEN=1
 	WDSList="${WDSList}${bssid};"
@@ -250,82 +260,100 @@ mt_dbdc_sta_vif_pre_config() {
 		return
 	}
 
-	[ "$disabled" == "1" ] && return
+	[[ "$disabled" = "1" ]] && return
 	let stacount+=1
 
+	json_add_object data
+	json_add_string ifname "$APCLI_IF"
+	json_close_object
+
+	local ApCliAuthMode=OPEN ApCliEncrypType=NONE
+	case "$encryption" in #加密方式
+	wpa*|psk*|WPA*|Mixed|mixed)
+		local enc
+		local crypto
+		case "$encryption" in
+			Mixed|mixed|psk+psk2|psk-mixed*)
+				enc=WPAPSKWPA2PSK
+			;;
+			WPA2*|wpa2*|psk2*)
+				enc=WPA2PSK
+			;;
+			WPA*|WPA1*|wpa*|wpa1*|psk*)
+				enc=WPAPSK
+			;;
+		esac
+		crypto="AES"
+		case "$encryption" in
+			*tkip+aes*|*tkip+ccmp*|*aes+tkip*|*ccmp+tkip*)
+				crypto="TKIPAES"
+			;;
+			*aes*|*ccmp*)
+				crypto="AES"
+			;;
+			*tkip*)
+				crypto="TKIP"
+			;;
+		esac
+		ApCliAuthMode="${enc}"
+		ApCliEncrypType="${crypto}"
+	;;
+	WEP|wep|wep-open|wep-shared)
+		if [[ "$encryption" = "wep-shared" ]]; then
+			ApCliAuthMode="SHARED"
+		else
+			ApCliAuthMode="OPEN"
+		fi
+		ApCliEncrypType="WEP"
+		;;
+	none|open)
+		;;
+	esac
+
+	mt_cmd iwpriv $APCLI_IF set ApCliAuthMode=$ApCliAuthMode
+	mt_cmd iwpriv $APCLI_IF set ApCliEncrypType=$ApCliEncrypType
+	if [[ "$ApCliEncrypType" = "WEP" ]]; then
+		mt_cmd iwpriv $APCLI_IF set ApCliDefaultKeyID=$key
+		mt_cmd iwpriv $APCLI_IF set "\"ApCliKey1=${key1##*:}\""
+		mt_cmd iwpriv $APCLI_IF set "\"ApCliKey2=${key2##*:}\""
+		mt_cmd iwpriv $APCLI_IF set "\"ApCliKey3=${key3##*:}\""
+		mt_cmd iwpriv $APCLI_IF set "\"ApCliKey4=${key4##*:}\""
+	elif ! [[ "$ApCliEncrypType" = "NONE" ]]; then
+		mt_cmd iwpriv $APCLI_IF set "\"ApCliWPAPSK=$key\""
+	fi
+	[ -z "$bssid" ] || mt_cmd iwpriv $APCLI_IF set "ApCliBssid=$(echo $bssid | tr 'A-Z' 'a-z')"
+	mt_cmd iwpriv $APCLI_IF set "\"ApCliSsid=$ssid\""
+
+	mt_cmd iwpriv $APCLI_IF set ApCliEnable=1
 	mt_cmd ifconfig $APCLI_IF up
-	killall  $APCLI_APCTRL
-	[ ! -z "$key" ] && APCTRL_KEY_ARG="-k"
-	[ ! -z "$bssid" ] && APCTRL_BSS_ARG="-b $(echo $bssid | tr 'A-Z' 'a-z')"
-	mt_cmd $APCLI_APCTRL ra${RTWIFI_IFPREFIX}0 connect -s "$ssid" $APCTRL_BSS_ARG $APCTRL_KEY_ARG "$key"
 }
 
-mt_dbdc_wds_vif_post_config() {
+mt_dbdc_vif_post_config() {
 	local name="$1"
 	json_select config
 	json_get_vars disabled
 	json_select ..
 
-	[ "$disabled" == "1" ] && return
-	[ $WDSBssidNum -gt 3 ] && return
-
-	ifname="wds${RTWIFI_IFPREFIX}${WDSBssidNum}"
-	let WDSBssidNum+=1
-
-	wireless_add_vif "$name" "$ifname"
-}
-
-mt_dbdc_ap_vif_post_config() {
-	local name="$1"
-
-	json_select config
-	json_get_vars disabled encryption key key1 key2 key3 key4 ssid mode wps pin isolate doth hidden disassoc_low_ack rssiassoc ieee80211k ieee80211v ieee80211r ieee80211w
+	json_select data
+	json_get_vars ifname
 	json_select ..
 
-	[ "$disabled" == "1" ] && return
-
-	[ $ApIfCNT -gt $RTWIFI_DEF_MAX_BSSID ] && return 
-
-	ifname="ra${RTWIFI_IFPREFIX}${ApIfCNT}"
-	let ApIfCNT+=1
-
+	[ "$disabled" = "1" -o -z "$ifname" ] && return
+	logger -t "mt_dbdc" "wireless_add_vif $name $ifname"
 	wireless_add_vif "$name" "$ifname"
-}
-
-mt_dbdc_sta_vif_post_config() {
-	local name="$1"
-
-	json_select config
-	json_get_vars disabled
-	json_select ..
-
-	[ $stacount -gt 1 ] && {
-		return
-	}
-
-	[ "$disabled" == "1" ] && return
-	let stacount+=1
-
-	wireless_add_vif "$name" "$APCLI_IF"
-}
-
-get_if_stat() {
-	[ ! -z "$1" ] && [ -d "/sys/class/net/$1" ] && cat /sys/class/net/$1/operstate
 }
 
 mt_dbdc_vif_down() {
 	phy_name=${1}
-	killall -9 -q apcli_2g
-	killall -9 -q apcli_5g
 	case "$phy_name" in
 		rax0)
 			for vif in ra0 ra1 ra2 ra3 ra4 ra5 ra6 ra7 wds0 wds1 wds2 wds3 apcli0; do
-				[ "$(get_if_stat $vif)" != "down" ] && ifconfig $vif down && echo $vif
+				[ -d "/sys/class/net/$vif" ] && ifconfig $vif down
 			done
 		;;
 		ra0)
 			for vif in rax0 rax1 rax2 rax3 rax4 rax5 rax6 rax7 wdsx0 wdsx1 wdsx2 wdsx3 apclix0; do
-				[ "$(get_if_stat $vif)" != "down" ] && ifconfig $vif down && echo $vif
+				[ -d "/sys/class/net/$vif" ] && ifconfig $vif down
 			done
 		;;
 	esac
@@ -339,14 +367,12 @@ drv_mt_dbdc_teardown() {
 	phy_name=${1}
 	case "$phy_name" in
 		ra0)
-			killall -9 -q apcli_2g
 			for vif in ra0 ra1 ra2 ra3 ra4 ra5 ra6 ra7 wds0 wds1 wds2 wds3 apcli0; do
 				# iwpriv $vif set DisConnectAllSta=1
 				[ -d "/sys/class/net/$vif" ] && ifconfig $vif down
 			done
 		;;
 		rax0)
-			killall -9 -q apcli_5g
 			for vif in rax0 rax1 rax2 rax3 rax4 rax5 rax6 rax7 wdsx0 wdsx1 wdsx2 wdsx3 apclix0; do
 				# iwpriv $vif set DisConnectAllSta=1
 				[ -d "/sys/class/net/$vif" ] && ifconfig $vif down
@@ -442,7 +468,7 @@ drv_mt_dbdc_setup() {
 			hwmode=${RTWIFI_DEF_BAND}
 		;;
 	esac
-	
+
 #HT默认模式设定
 	HT_BW=1  #允许HT40
 	HT_CE=1  #允许HT20/40共存
@@ -451,14 +477,14 @@ drv_mt_dbdc_setup() {
 	VHT_SGI=1 #VHT_SHORT_GI
 	#HT_MIMOPSMode用于省电模式设置
 	#HT_MIMOPSMode=3
-	
+
 #VHT默认模式设定
 	VHT_BW=1 #允许VHT
 	VHT_DisallowNonVHT=0 #是否禁止非VHT客户端连接，VHT80 only
-	
+
 	[ "$short_gi_20" == "0" -o "$short_gi_40" == "0" ] && HT_GI=0
 	[ "$short_gi_80" == "0" -o "$short_gi_160" == "0" ] && VHT_SGI=0
-	
+
 	case "$htmode" in
 		HT20 |\
 		VHT20) 
@@ -490,9 +516,9 @@ drv_mt_dbdc_setup() {
 #仅HT20以外才需要设置的参数
      [ "$htmode" != "HT20" ] && {
 #强制HT40/VHT80
-		[ "$noscan" == "1" ] && HT_CE=0 && RTWIFI_FORCE_HT=1
+		[[ "$noscan" = "1" ]] && HT_CE=0 && RTWIFI_FORCE_HT=1
 #HT HTC
-		[ "$ht_htc" == "1" ] && HT_HTC=1
+		[[ "$ht_htc" = "1" ]] && HT_HTC=1
     }
 
 #自动处理CountryRegion:指定信道的时候支持全频段
@@ -507,7 +533,7 @@ drv_mt_dbdc_setup() {
 		a)
 			EXTCHA=1
 			[ "$channel" != "auto" ] && [ "$channel" != "0" ] && [ "$(( ($channel / 4) % 2 ))" == "0" ] && EXTCHA=0
-			[ "$channel" == "165" ] && EXTCHA=0
+			[[ "$channel" = "165" ]] && EXTCHA=0
 			[ "$channel" == "auto" -o "$channel" == "0" ] && {
 				#CountryRegion CN
 				countryregion=1
@@ -806,6 +832,8 @@ EOF
 
 #接口配置生成
 #	STA模式
+	mt_cmd ifconfig $APCLI_IF down
+	mt_cmd iwpriv $APCLI_IF set ApCliEnable=0
 	stacount=0
 	for_each_interface "sta" mt_dbdc_sta_vif_pre_config
 
@@ -823,7 +851,7 @@ EOF
 
 	for_each_interface "ap" mt_dbdc_ap_vif_pre_config
 
-	[ "$phy_name" == "ra0" ] && [ "$ApBssidNum" == "0" ] && mt_cmd ifconfig ra0 down
+	[[ "$phy_name" = "ra0" ]] && [[ "$ApBssidNum" = "0" ]] && mt_cmd ifconfig ra0 down
 #For DBDC profile merging......
 	while [ $ApBssidNum -lt $RTWIFI_DEF_MAX_BSSID ]
 	do
@@ -867,36 +895,34 @@ EOF
 #加锁
 	echo "Pending..."
 	if lock -n $WIFI_OP_LOCK; then
-		sleep 3
-		RA_MAIN_UP=$(get_if_stat ra0)
+		sleep 2
 		drv_mt_dbdc_teardown $phy_name
-		RESET_IF=$(mt_dbdc_vif_down $phy_name)
-		echo "MT_DBDC:ra0:$RA_MAIN_UP.Later we'll restart $(echo ${RESET_IF} | tr '\n' ' ')"
-		sleep 1
+		mt_dbdc_vif_down $phy_name
 
 #Start root device
 		ifconfig ra0 up
 #restore interfaces
-		sh $RTWIFI_CMD_OPATH
-
-		sh $RTWIFI_CMD_PATH
+		if [[ "$phy_name" = "ra0" ]]; then
+			sh $RTWIFI_CMD_OPATH
+			sh $RTWIFI_CMD_PATH
+		else
+			sh $RTWIFI_CMD_PATH
+			sh $RTWIFI_CMD_OPATH
+		fi
 #重启HWNAT
 		[ -d /sys/module/hw_nat ] && {
 			/etc/init.d/hwacc restart
 		}
 	else
-		echo "Wait other process"
+		echo "Wait other process reload wifi"
 		lock $WIFI_OP_LOCK
 	fi
-#AP模式
-	ApIfCNT=0
-	for_each_interface "ap" mt_dbdc_ap_vif_post_config
 #WDS接口
-	WDSBssidNum=0
-	for_each_interface "wds" mt_dbdc_wds_vif_post_config
+	for_each_interface "wds" mt_dbdc_vif_post_config
 #STA模式
-	stacount=0
-	for_each_interface "sta" mt_dbdc_sta_vif_post_config
+	for_each_interface "sta" mt_dbdc_vif_post_config
+#AP模式
+	for_each_interface "ap" mt_dbdc_vif_post_config
 
 #设置无线上线
 	wireless_set_up

--- a/package/lean/mt/luci-app-mtwifi/Makefile
+++ b/package/lean/mt/luci-app-mtwifi/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE:=GPLv2
 PKG_MAINTAINER:=Hua Shao <nossiac@163.com>
 
 LUCI_TITLE:=LuCI support for mt wifi driver
-LUCI_DEPENDS:=@TARGET_ramips +mt_wifi
+LUCI_DEPENDS:=@TARGET_ramips @!PACKAGE_kmod-mt7615d_dbdc +mt_wifi
 LUCI_PKGARCH:=all
 PKG_VERSION:=1
 PKG_RELEASE:=8


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

主要用于支持K2P的Client模式。

前几年给K2P适配的 mt7615d_dbdc 脚本，一直没支持Client模式，最近又买了个K2P，想作为无线中继，所以这个PR就是加上Client模式的支持：
1. 支持Client模式
2. 支持Client和有线网口的桥接
3. 重启网络或WIFI会自动重连


“无线”页面，将Client模式的WIFI关联到WAN口，增加一个AP也关联到WAN口
<img width="958" alt="image" src="https://user-images.githubusercontent.com/3896703/229339945-663d84d4-4243-4822-aaf1-53017ac50dc1.png">


“接口”页面，WAN口桥接了两个WIFI
<img width="957" alt="image" src="https://user-images.githubusercontent.com/3896703/229340072-636cf0b1-b755-4087-a4c1-14a62c6ed282.png">
