### PR TITLE
修复K2P的WIFI频道不生效问题

### DIFF
--- a/package/lean/mt/drivers/mt7615d/files/lib/netifd/wireless/mt_dbdc.sh
+++ b/package/lean/mt/drivers/mt7615d/files/lib/netifd/wireless/mt_dbdc.sh
@@ -856,7 +856,10 @@ EOF
 
 	for_each_interface "ap" mt_dbdc_ap_vif_pre_config
 
-	[[ "$phy_name" = "ra0" ]] && [[ "$ApBssidNum" = "0" ]] && mt_cmd ifconfig ra0 down
+# 设置频道，每个PHY只有一个频道
+	[[ "${AutoChannelSelect:-0}" = "0" ]] && mt_cmd iwpriv $phy_name set Channel=${channel}
+
+	[[ "$phy_name" = "ra0" && "$ApBssidNum" = "0" ]] && mt_cmd ifconfig ra0 down
 #For DBDC profile merging......
 	while [ $ApBssidNum -lt $RTWIFI_DEF_MAX_BSSID ]
 	do


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

之前测试一直用默认频道，改成非默认频道以后发现并未生效，甚至重启系统都不会生效。由于客户端模式必须要使用正确的频道才能连接，所以修复下。