### PR TITLE
ramips: MT7620 add support for Bolt BL201 board

### DIFF
--- a/target/linux/ramips/dts/mt7620a_bolt_bl201.dts
+++ b/target/linux/ramips/dts/mt7620a_bolt_bl201.dts
@@ -1,0 +1,159 @@
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "bolt,bl201", "ralink,mt7620a-soc";
+	model = "Bolt BL201";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wan {
+			label = "blue:wan";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+
+		power_red: power_red {
+			label = "red:power";
+			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		};
+
+		power_blue: power_blue {
+			label = "blue:power";
+			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
+		};
+
+		lte_s1_blue {
+			label = "blue:lte_s1";
+			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		};
+
+		lte_s2_blue {
+			label = "blue:lte_s2";
+			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+		};
+
+		lte_s3_blue {
+			label = "blue:lte_s3";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		};
+
+		lte_s4_blue {
+			label = "blue:lte_s4";
+			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wps_blue {
+			label = "blue:wps";
+			gpios = <&gpio2 22 GPIO_ACTIVE_LOW>;
+		};
+
+		lte_s1s2_red {
+			label = "red:lte_s1s2";
+			gpios = <&gpio2 24 GPIO_ACTIVE_LOW>;
+		};
+
+		lte_s3s4_red {
+			label = "red:lte_s3s4";
+			gpios = <&gpio2 25 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan_blue {
+			label = "blue:wlan";
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf80000>;
+			};
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&ephy_pins>;
+
+	mtd-mac-address = <&factory 0x4>;
+
+	mediatek,portmap = "llllw";
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pa_pins>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wled", "i2c", "uartf", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -130,6 +130,16 @@ define Device/bdcom_wap2100-sk
 endef
 TARGET_DEVICES += bdcom_wap2100-sk
 
+define Device/bolt_bl201
+  SOC := mt7620a
+  IMAGE_SIZE := 15872k
+  DEVICE_VENDOR := Bolt
+  DEVICE_MODEL := BL201
+  DEVICE_PACKAGES := kmod-mt76x2
+  SUPPORTED_DEVICES += bolt_bl201
+endef
+TARGET_DEVICES += bolt_bl201
+
 define Device/buffalo_whr-1166d
   SOC := mt7620a
   IMAGE_SIZE := 16064k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -40,6 +40,10 @@ asus,rt-n14u)
 bdcom,wap2100-sk)
 	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan2g" "wlan0"
 	;;
+bolt,bl201)
+	ucidef_set_led_netdev "wlan0" "wlan0-link" "blue:wlan" "wlan0"
+	ucidef_set_led_netdev "wan" "eth0.2-link" "blue:wan" "eth0.2" "link"
+	;;
 comfast,cf-wr800n)
 	ucidef_set_led_netdev "lan" "lan" "white:ethernet" eth0.1
 	ucidef_set_led_netdev "wifi_led" "wifi" "white:wifi" "wlan0"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -11,6 +11,7 @@ ramips_setup_interfaces()
 	aigale,ai-br100|\
 	alfa-network,ac1200rm|\
 	asus,rt-n12p|\
+	bolt,bl201|\
 	dlink,dwr-116-a1|\
 	dlink,dwr-921-c1|\
 	dlink,dwr-922-e2|\


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

Manufacturer: Bolt
Model: BL201
CPU: MT7620A
RAM: DDR2 64MB
ROM: NAND 16MB
Switch: MT7620
WIFI 5G: MT7612E
