### PR TITLE
Rockchip: fix motorcomm unavailability

### DIFF
--- a/target/linux/rockchip/patches-5.15/203-rockchip-rk3328-Add-support-for-OrangePi-R1-Plus-LTS.patch
+++ b/target/linux/rockchip/patches-5.15/203-rockchip-rk3328-Add-support-for-OrangePi-R1-Plus-LTS.patch
@@ -10,7 +10,7 @@
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-roc-cc.dtb
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus-lts.dts
-@@ -0,0 +1,66 @@
+@@ -0,0 +1,71 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2016 Xunlong Software. Co., Ltd.
@@ -53,6 +53,11 @@
 +			compatible = "ethernet-phy-id4f51.e91b",
 +				     "ethernet-phy-ieee802.3-c22";
 +			reg = <0>;
++
++ 			motorcomm,clk-out-frequency-hz = <125000000>;
++			motorcomm,keep-pll-enabled;
++			motorcomm,auto-sleep-disabled;
++
 +			pinctrl-0 = <&eth_phy_reset_pin>;
 +			pinctrl-names = "default";
 +			reset-assert-us = <15000>;

--- a/target/linux/rockchip/patches-5.15/204-rockchip-rk3328-Add-support-for-FriendlyARM-NanoPi-R.patch
+++ b/target/linux/rockchip/patches-5.15/204-rockchip-rk3328-Add-support-for-FriendlyARM-NanoPi-R.patch
@@ -10,7 +10,7 @@
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-orangepi-r1-plus-lts.dtb
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2c.dts
-@@ -0,0 +1,55 @@
+@@ -0,0 +1,60 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2021 FriendlyElec Computer Tech. Co., Ltd.
@@ -40,6 +40,11 @@
 +			compatible = "ethernet-phy-id0000.011a",
 +				     "ethernet-phy-ieee802.3-c22";
 +			reg = <3>;
++
++			motorcomm,clk-out-frequency-hz = <125000000>;
++			motorcomm,keep-pll-enabled;
++			motorcomm,auto-sleep-disabled;
++
 +			interrupt-parent = <&gpio2>;
 +			interrupts = <RK_PC4 IRQ_TYPE_EDGE_FALLING>;
 +			pinctrl-0 = <&eth_phy_reset_pin>;

--- a/target/linux/rockchip/patches-6.1/203-rockchip-rk3328-Add-support-for-OrangePi-R1-Plus-LTS.patch
+++ b/target/linux/rockchip/patches-6.1/203-rockchip-rk3328-Add-support-for-OrangePi-R1-Plus-LTS.patch
@@ -10,7 +10,7 @@
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-roc-cc.dtb
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus-lts.dts
-@@ -0,0 +1,66 @@
+@@ -0,0 +1,71 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2016 Xunlong Software. Co., Ltd.
@@ -53,6 +53,11 @@
 +			compatible = "ethernet-phy-id4f51.e91b",
 +				     "ethernet-phy-ieee802.3-c22";
 +			reg = <0>;
++
++ 			motorcomm,clk-out-frequency-hz = <125000000>;
++			motorcomm,keep-pll-enabled;
++			motorcomm,auto-sleep-disabled;
++
 +			pinctrl-0 = <&eth_phy_reset_pin>;
 +			pinctrl-names = "default";
 +			reset-assert-us = <15000>;

--- a/target/linux/rockchip/patches-6.1/204-rockchip-rk3328-Add-support-for-FriendlyARM-NanoPi-R.patch
+++ b/target/linux/rockchip/patches-6.1/204-rockchip-rk3328-Add-support-for-FriendlyARM-NanoPi-R.patch
@@ -10,7 +10,7 @@
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-orangepi-r1-plus-lts.dtb
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-nanopi-r2c.dts
-@@ -0,0 +1,55 @@
+@@ -0,0 +1,60 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2021 FriendlyElec Computer Tech. Co., Ltd.
@@ -40,6 +40,11 @@
 +			compatible = "ethernet-phy-id0000.011a",
 +				     "ethernet-phy-ieee802.3-c22";
 +			reg = <3>;
++
++ 			motorcomm,clk-out-frequency-hz = <125000000>;
++			motorcomm,keep-pll-enabled;
++			motorcomm,auto-sleep-disabled;
++
 +			interrupt-parent = <&gpio2>;
 +			interrupts = <RK_PC4 IRQ_TYPE_EDGE_FALLING>;
 +			pinctrl-0 = <&eth_phy_reset_pin>;


### PR DESCRIPTION
修复 NanoPi R2C 和 OrangePi R1 Plus LTS 裕太微网口无法使用问题

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
#11074
#10980