### PR TITLE
Update ipq6018-cmiot.dtsi

### DIFF
--- a/target/linux/ipq60xx/files/arch/arm64/boot/dts/qcom/ipq6018-cmiot.dtsi
+++ b/target/linux/ipq60xx/files/arch/arm64/boot/dts/qcom/ipq6018-cmiot.dtsi
@@ -198,3 +198,18 @@
 &wifi {
 	status = "okay";
 };
+
+&ssphy_0 {
+	status = "ok";
+};
+
+&qusb_phy_0 {
+	status = "ok";
+};
+
+&usb3 {
+	status = "ok";
+};
+&wifi {
+	status = "okay";
+};


### PR DESCRIPTION
add usb3 support for ax18/zn-m2
