### PR TITLE
doc: added a workaround for WSL/WSL2 non-sensitive FS errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,23 @@ make V=s -j$(nproc)
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ```
 
+由于默认情况下，装载到 WSL 发行版的 NTFS 格式的驱动器将不区分大小写，因此大概率在 WSL/WSL2 的编译检查中会返回以下错误：
+
+```txt
+Build dependency: OpenWrt can only be built on a case-sensitive filesystem 
+```
+
+一个比较简洁的解决方法是，在 `git clone` 前先创建 Repository 目录，并为其启用大小写敏感：
+
+```powershell
+# 以管理员身份打开终端
+PS > fsutil.exe file setCaseSensitiveInfo <your_local_lede_path> enable
+# 将本项目 git clone 到开启了大小写敏感的目录 <your_local_lede_path> 中
+PS > git clone git@github.com:coolsnowwolf/lede.git <your_local_lede_path>
+```
+
+> 对已经 `git clone` 完成的项目目录执行 `fsutil.exe` 命令无法生效，大小写敏感只对新增的文件变更有效。
+
 ### macOS 原生系统进行编译
 
 1. 在 AppStore 中安装 Xcode


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
- [x] 我知道

### PR 描述

在 `README.md` 的  `如果你使用 WSL/WSL2 进行编译` 小节中，添加了对一个高概率出现的错误的解决方法。

### 详细说明

由于默认情况下，装载到 WSL 发行版的 NTFS 格式的驱动器将不区分大小写，因此在 WSL/WSL2 中进行首次编译检查的时候，几乎必然会发生以下报错：
```
Build dependency: OpenWrt can only be built on a case-sensitive filesystem 
```
关于这一点，在  Windows 的[官方文档](https://learn.microsoft.com/zh-cn/windows/wsl/case-sensitivity#changing-the-case-sensitivity-on-a-drive-mounted-to-a-wsl-distribution)中提供了描述：
> 默认情况下，装载到 WSL 发行版的 NTFS 格式的驱动器将不区分大小写。 若要更改装载到 WSL 分发版的驱动器上的目录的区分大小写， (ie。Ubuntu) ，请遵循上面针对 Windows 文件系统列出的相同步骤。 （默认情况下，EXT4 驱动器区分大小写）。

以及对应的解决方案：
- 若要在目录上启用区分大小写 (FOO ≠ foo)，请使用以下命令：
```bash
fsutil.exe file setCaseSensitiveInfo <path> enable
```
- 若要在目录上禁用区分大小写并返回到默认设置不区分大小写 (FOO = foo)，请使用以下命令：
```bash
fsutil.exe file setCaseSensitiveInfo <path> disable
```

由于这个报错对于绝大多数第一次执行 `lede.git` 项目编译的用户来说，复现率极高，因此本 PR 高度建议将这段 Workaround 加入到 `README.md` 中。

感谢大佬的项目

Best Regards,

