### PR TITLE
update dropbear version

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -8,14 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dropbear
-PKG_VERSION:=2022.82
+PKG_VERSION:=2022.83
 PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \
 	https://matt.ucc.asn.au/dropbear/releases/ \
 	https://dropbear.nl/mirror/releases/
-PKG_HASH:=3a038d2bbc02bf28bbdd20c012091f741a3ec5cbe460691811d714876aad75d1
+#PKG_HASH:=3a038d2bbc02bf28bbdd20c012091f741a3ec5cbe460691811d714876aad75d1
+PKG_HASH:=bc5a121ffbc94b5171ad5ebe01be42746d50aa797c9549a4639894a16749443b
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE libtomcrypt/LICENSE libtommath/LICENSE

--- a/package/network/services/dropbear/files/dropbear.init
+++ b/package/network/services/dropbear/files/dropbear.init
@@ -156,7 +156,7 @@ dropbear_instance()
 	local pid_file="/var/run/${NAME}.${PIDCOUNT}.pid"
 
 	procd_open_instance
-	procd_set_param command "$PROG" -F -P "$pid_file"
+	procd_set_param command "$PROG" -F -P "$pid_file" -z
 	[ "${PasswordAuth}" -eq 0 ] && procd_append_param command -s
 	[ "${GatewayPorts}" -eq 1 ] && procd_append_param command -a
 	[ "${RootPasswordAuth}" -eq 0 ] && procd_append_param command -g


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [X ] 我知道
* release note：https://github.com/mkj/dropbear/releases/tag/DROPBEAR_2022.83
* solve problem ：
Add '-z' flag to disable setting QoS traffic class. This may be necessary
to work with broken networks or network drivers, exposed after changes to use
AF21 in 2022.82

descrip:
when openwrt route  8.X in Network A ,Network B through ipsecvpn to Network B ,  Network B is 10.X, when we use dropbear whitch version is 2022.82  , 10.X client  ssh to 8.X 's  openwrt must be  failed ! 
issue like :
https://github.com/coolsnowwolf/lede/issues/10569
