### PR TITLE
Update package-defaults.mk

### DIFF
--- a/include/package-defaults.mk
+++ b/include/package-defaults.mk
@@ -64,6 +64,7 @@ ifneq ($(strip $(PKG_UNPACK)),)
   define Build/Prepare/Default
 	$(PKG_UNPACK)
 	[ ! -d ./src/ ] || $(CP) ./src/. $(PKG_BUILD_DIR)
+	[ "$(shell uname | tr '[:upper:]' '[:lower:]')" = "linux" ] && find $(PKG_BUILD_DIR) -type f -exec dos2unix {} \;
 	$(Build/Patch)
   endef
 endif


### PR DESCRIPTION
make package/shadowsocksr-libev/compile V=s -j17 编译时出现错误:
Applying ./patches/101-Fix-Werror-sizeof-pointer-memaccess.patch using plaintext: 
patching file src/local.c
Hunk #1 FAILED at 718 (different line endings).
1 out of 1 hunk FAILED -- saving rejects to file src/local.c.rej
Patch failed!  Please fix ./patches/101-Fix-Werror-sizeof-pointer-memaccess.patch!
make[2]: *** [Makefile:72: /home/lin/Downloads/lede/build_dir/target-aarch64_generic_musl/shadowsocksr-libev-2.5.6/.prepared_d0e680ab2943487cbfd92c161f28c49a_6664517399ebbbc92a37c5bb081b5c53] Error 1
make[2]: Leaving directory '/home/lin/Downloads/lede/feeds/my/helloworld/shadowsocksr-libev'
time: package/feeds/my/shadowsocksr-libev/compile#0.24#0.04#0.26
    ERROR: package/feeds/my/shadowsocksr-libev failed to build.
make[1]: *** [package/Makefile:116: package/feeds/my/shadowsocksr-libev/compile] Error 1
make[1]: Leaving directory '/home/lin/Downloads/lede'
make: *** [/home/lin/Downloads/lede/include/toplevel.mk:231：package/shadowsocksr-libev/compile] 错误 2

原因是：
windows 和 uinix 的文件 line ending 不同导致的无法打上 patch

修复方法：
只要将 $(PKG_BUILD_DIR) 目录下的文件内容使用 dos2unix 转换为 uinix 格式，为了防止不同系统的 line ending，我添加了 [ "$(shell uname | tr '[:upper:]' '[:lower:]')" = "linux" ] 只让在 linux 系统下进行转换为 uinix 格式

