### PR TITLE
Fix OpenWrt with Docker will cause NAT loopback

### DIFF
--- a/package/base-files/files/etc/sysctl.conf
+++ b/package/base-files/files/etc/sysctl.conf
@@ -1,1 +1,6 @@
 # Defaults are configured in /etc/sysctl.d/* and can be customized in this file
+
+# disable bridge firewalling.(Fixed the problem that even if br-netfilter is disabled in package/kernel/linux/files/sysctl-br-netfilter.conf, NAT loopback will still fail. This applies to OpenWrt with Docker)
+net.bridge.bridge-nf-call-arptables = 0
+net.bridge.bridge-nf-call-ip6tables = 0
+net.bridge.bridge-nf-call-iptables = 0


### PR DESCRIPTION
Fixed the problem that even if br-netfilter is disabled in package/kernel/linux/files/sysctl-br-netfilter.conf, NAT loopback will still fail. This applies to OpenWrt with Docker

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ x] 我知道
