### PR TITLE
Fixed the issue where CPU usage only shows a %

### DIFF
--- a/package/lean/autocore/files/x86/index.htm
+++ b/package/lean/autocore/files/x86/index.htm
@@ -52,7 +52,7 @@
 
 		local user_info = luci.sys.exec("cat /proc/net/arp | grep '0x2' | wc -l") or 0
 		
-		local cpu_usage = (luci.sys.exec("expr 100 - $(top -n 1 | grep 'CPU:' | awk -F '%' '{print$4}' | awk -F ' ' '{print$2}' | awk '{print int($1 + 0.5)}')") or "6") .. "%"
+		local cpu_usage = (luci.sys.exec("expr 100 - $(top -n 1 | grep -E '^CPU:' | awk -F '%' '{print$4}' | awk -F ' ' '{print$2}' | awk '{print int($1 + 0.5)}')") or "6") .. "%"
 
 		local rv = {
 			cpuusage    = cpu_usage,


### PR DESCRIPTION
Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道

之前提过 issues #11603 

经过不断尝试，发现在 `package/lean/autocore/files/x86/index.htm` 文件中匹配 CPU 使用率所在行的命令 `top -n 1 | grep 'CPU:'` 会获取到两行数据，而另一行是 `grep CPU:` 进程自身，最终导致 CPU 使用率计算报错，如下所示
```
root@OpenWrt:~# top -n 1 | grep 'CPU:' 
CPU:   0% usr   9% sys   0% nic  90% idle   0% io   0% irq   0% sirq
 2813  6672 root     S     1124   0%   0% grep CPU:
```
由于 x86 平台和 arm 平台使用的是不同的 index.htm 文件，获取 CPU 使用率的命令也不一样，再结合其他人的反馈，所以这个问题应该是只出现在 x86 平台上

虽然我也还是不知道为啥在编译时取消 autosamba 就会出现这个问题，但是修改匹配条件使用 `grep -E '^CPU:'`  匹配 CPU 使用率所在行可修复此问题