### PR TITLE
fibocom_qmi: fixes build error

### DIFF
--- a/package/wwan/driver/fibocom_QMI_WWAN/src/qmi_wwan_f.c
+++ b/package/wwan/driver/fibocom_QMI_WWAN/src/qmi_wwan_f.c
@@ -2096,9 +2096,8 @@ static int qmi_wwan_reset_resume(struct usb_interface *intf)
 
 static int rmnet_usb_bind(struct usbnet *dev, struct usb_interface *intf)
 {
-    int status;
+    int status = qmi_wwan_bind(dev, intf);
     dev_err(&intf->dev, "rmnet_usb_bind\n");
-    status = qmi_wwan_bind(dev, intf);
 
     if (!status) {
         struct qmi_wwan_state *info = (void *)&dev->data;

--- a/package/wwan/driver/fibocom_QMI_WWAN/src/qmi_wwan_f.c
+++ b/package/wwan/driver/fibocom_QMI_WWAN/src/qmi_wwan_f.c
@@ -2096,8 +2096,9 @@ static int qmi_wwan_reset_resume(struct usb_interface *intf)
 
 static int rmnet_usb_bind(struct usbnet *dev, struct usb_interface *intf)
 {
+    int status;
     dev_err(&intf->dev, "rmnet_usb_bind\n");
-    int status = qmi_wwan_bind(dev, intf);
+    status = qmi_wwan_bind(dev, intf);
 
     if (!status) {
         struct qmi_wwan_state *info = (void *)&dev->data;


### PR DESCRIPTION
qmi_wwan_f.c:2100:5: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
 2100 |     int status = qmi_wwan_bind(dev, intf);
      |     ^~~

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [ x] 我知道
