### PR TITLE
bcm53xx: add support for ASUS RT-AC3100

### DIFF
--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -168,6 +168,14 @@ define Device/asus_rt-ac87u
 endef
 TARGET_DEVICES += asus_rt-ac87u
 
+define Device/asus_rt-ac3100
+  $(call Device/asus)
+  DEVICE_MODEL := RT-AC3100
+  DEVICE_PACKAGES := $(BRCMFMAC_4366B1) $(BRCMFMAC_4366C0) $(USB3_PACKAGES)
+  ASUS_PRODUCTID := RT-AC3100
+endef
+TARGET_DEVICES += asus_rt-ac3100
+
 define Device/asus_rt-n18u
   $(call Device/asus)
   DEVICE_MODEL := RT-N18U


### PR DESCRIPTION
bcm53xx: add support for ASUS RT-AC3100
ASUS RT-AC3100 is ASUS RT-AC88U without the external switch.

OpenWrt forum users effortless and ktmakwana have confirmed that there are
revisions with either 4366b1 or 4366c0 wireless chips.

Therefore, include firmware for 4366b1 along with 4366c0. This way, all
hardware revisions of the router will be supported by having brcmfmac use
the firmware file for the wireless chip it detects.

Signed-off-by: Arınç ÜNAL <arinc.unal@arinc9.com>