### PR TITLE
strace: bump to version 6.6

### DIFF
--- a/package/devel/strace/Makefile
+++ b/package/devel/strace/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=strace
-PKG_VERSION:=6.1
+PKG_VERSION:=6.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://strace.io/files/$(PKG_VERSION)
-PKG_HASH:=2579e9cec37dbb786f6ea0bebd15f40dd561ef2bde2a2a2ecdce5963b01859fd
+PKG_HASH:=421b4186c06b705163e64dc85f271ebdcf67660af8667283147d5e859fc8a96c
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
This bump will fix the following build failure with kernel >= 6.6 raised In file included from btrfs.c:51 #12011 :
xlat/btrfs_key_types.h:167:37: error: 'BTRFS_EXTENT_REF_V0_KEY' undeclared here (not in a function); did you mean 'BTRFS_EXTENT_DATA_KEY'?
  167 | static_assert((unsigned long long) (BTRFS_EXTENT_REF_V0_KEY)
      |                                     ^~~~~~~~~~~~~~~~~~~~~~~
      |                                     BTRFS_EXTENT_DATA_KEY

# Pull Request 规则，创建时请删除

- 禁止有关 "GitHub Actions" 的提交
- 禁止使用 users.noreply.github.com 提交
