### PR TITLE
autocore: fix missing CPU frequency info for rockchip

### DIFF
--- a/package/lean/autocore/files/arm/sbin/cpuinfo
+++ b/package/lean/autocore/files/arm/sbin/cpuinfo
@@ -13,6 +13,7 @@ elif grep -q "mvebu" "/etc/openwrt_release"; then
 elif grep -q "filogic" "/etc/openwrt_release"; then
 	[ -f "/sys/devices/system/cpu/cpufreq/policy0/cpuinfo_cur_freq" ] && big_cpu_freq="$(expr $(cat /sys/devices/system/cpu/cpufreq/policy0/cpuinfo_cur_freq) / 1000)MHz"
 elif grep -q "rockchip" "/etc/openwrt_release"; then
+	cpu_freq="$(expr $(cat /sys/devices/system/cpu/cpufreq/policy0/cpuinfo_cur_freq) / 1000)MHz"
 	big_cpu_freq="$(expr $(cat /sys/devices/system/cpu/cpufreq/policy4/cpuinfo_cur_freq 2>"/dev/null") / 1000 2>"/dev/null")"
 	[ -n "${big_cpu_freq}" ] && big_cpu_freq="${big_cpu_freq}MHz "
 else
@@ -34,11 +35,11 @@ else
 	fi
 	if grep -q "filogic" "/etc/openwrt_release"; then
 		if [ -n "${big_cpu_freq}" ] ; then
-      echo -n "${cpu_arch} x ${cpu_cores} (${big_cpu_freq}, ${cpu_temp})"
-    else
-      echo -n "${cpu_arch} x ${cpu_cores} (${cpu_temp})"
-    fi
-  else
-    echo -n "${cpu_arch} x ${cpu_cores} (${big_cpu_freq}${cpu_freq}, ${cpu_temp})"
+			echo -n "${cpu_arch} x ${cpu_cores} (${big_cpu_freq}, ${cpu_temp})"
+		else
+			echo -n "${cpu_arch} x ${cpu_cores} (${cpu_temp})"
+		fi
+	else
+		echo -n "${cpu_arch} x ${cpu_cores} (${big_cpu_freq}${cpu_freq}, ${cpu_temp})"
 	fi
 fi


### PR DESCRIPTION
1. fix missing CPU frequency info for rockchip
2. adjust indent