### PR TITLE
config: add missing KERNEL_XDP_SOCKETS symbol

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1151,6 +1151,13 @@ config KERNEL_NET_L3_MASTER_DEV
 	  This module provides glue between core networking code and device
 	  drivers to support L3 master devices like VRF.
 
+config KERNEL_XDP_SOCKETS
+	bool "XDP sockets support"
+	default y if KERNEL_DEBUG_INFO_BTF
+	help
+	  XDP sockets allows a channel between XDP programs and
+	  userspace applications.
+
 config KERNEL_PAGE_POOL
 	def_bool n
 


### PR DESCRIPTION
It's a missing symbol that required by package `kmod-xdp-sockets-diag`.
https://github.com/coolsnowwolf/lede/blob/e725c6198c74d8e86aaebf7af74112c91c1da3b2/package/kernel/linux/modules/netsupport.mk#L1480-L1493

And the code in this PR is copied from upstream.

https://github.com/openwrt/openwrt/blob/9d8d0509bf2a630464e050de21e21110748e4f27/config/Config-kernel.in#L1190-L1194