### PR TITLE
ramips: update Bolt BL201 to match stock bootloader

### DIFF
--- a/target/linux/ramips/dts/mt7620a_bolt_bl201.dts
+++ b/target/linux/ramips/dts/mt7620a_bolt_bl201.dts
@@ -2,89 +2,113 @@
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
 
 / {
 	compatible = "bolt,bl201", "ralink,mt7620a-soc";
 	model = "Bolt BL201";
 
 	aliases {
-		led-boot = &power_red;
-		led-failsafe = &power_red;
-		led-running = &power_blue;
-		led-upgrade = &power_red;
+		led-boot = &led_reset;
+		led-failsafe = &led_reset;
+		led-running = &led_power;
+		led-upgrade = &led_reset;
 		label-mac-device = &ethernet;
 	};
 
 	chosen {
-		bootargs = "console=ttyS0,115200";
+		bootargs = "console=ttyS0,57600";
 	};
 
 	leds {
 		compatible = "gpio-leds";
 
-		wan {
-			label = "blue:wan";
-			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
-		};
-
-		power_red: power_red {
-			label = "red:power";
+		led_reset: led-reset {
+			label = "red:reset";
 			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
 		};
 
-		power_blue: power_blue {
+		led_power: led-power {
 			label = "blue:power";
 			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
 		};
 
-		lte_s1_blue {
-			label = "blue:lte_s1";
+		led-lte1 {
+			label = "blue:lte1";
 			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 		};
 
-		lte_s2_blue {
-			label = "blue:lte_s2";
+		led-lte2 {
+			label = "blue:lte2";
 			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
 		};
 
-		lte_s3_blue {
-			label = "blue:lte_s3";
+		led-lte3 {
+			label = "blue:lte3";
 			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
 		};
 
-		lte_s4_blue {
-			label = "blue:lte_s4";
+		led-lte4 {
+			label = "blue:lte4";
 			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 		};
 
-		wps_blue {
+		led-lte5 {
+			label = "red:lte5";
+			gpios = <&gpio2 24 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lte6 {
+			label = "red:lte6";
+			gpios = <&gpio2 25 GPIO_ACTIVE_LOW>;
+		};
+
+		led-wps {
 			label = "blue:wps";
 			gpios = <&gpio2 22 GPIO_ACTIVE_LOW>;
 		};
 
-		lte_s1s2_red {
-			label = "red:lte_s1s2";
-			gpios = <&gpio2 24 GPIO_ACTIVE_LOW>;
+		led-voip {
+			label = "blue:voip";
+			gpios = <&gpio2 23 GPIO_ACTIVE_LOW>;
 		};
 
-		lte_s3s4_red {
-			label = "red:lte_s3s4";
-			gpios = <&gpio2 25 GPIO_ACTIVE_LOW>;
-		};
-
-		wlan_blue {
-			label = "blue:wlan";
+		led-wlan2 {
+			label = "blue:wlan2";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led-wlan5 {
+			label = "blue:wlan5";
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-lan {
+			label = "green:lan";
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led-wan {
+			label = "green:wan";
+			gpios = <&gpio2 4 GPIO_ACTIVE_LOW>;
 		};
 	};
 
 	keys {
 		compatible = "gpio-keys";
 
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
+		};
+
 		reset {
 			label = "reset";
-			gpios = <&gpio1 26 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
 		};
 	};
 };
@@ -111,8 +135,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <10000000>;
-		// m25p,fast-read;
+		spi-max-frequency = <50000000>;
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -137,9 +160,10 @@
 			};
 
 			partition@50000 {
-				compatible = "denx,uimage";
 				label = "firmware";
 				reg = <0x50000 0xf80000>;
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x26112015>;
 			};
 
 			partition@fd0000 {
@@ -161,11 +185,16 @@
 	};
 };
 
-&ethernet {
-	pinctrl-names = "default";
-	pinctrl-0 = <&ephy_pins>;
+&ehci {
+	status = "okay";
+};
 
-	mtd-mac-address = <&factory 0x4>;
+&ohci {
+	status = "okay";
+};
+
+&ethernet {
+	mtd-mac-address = <&factory 0x28>;
 
 	mediatek,portmap = "llllw";
 };

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -135,7 +135,8 @@ define Device/bolt_bl201
   IMAGE_SIZE := 15872k
   DEVICE_VENDOR := Bolt
   DEVICE_MODEL := BL201
-  DEVICE_PACKAGES := kmod-mt76x2
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb2 kmod-usb-ohci
+  UIMAGE_MAGIC := 0x26112015
 endef
 TARGET_DEVICES += bolt_bl201
 

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -41,9 +41,8 @@ bdcom,wap2100-sk)
 	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan2g" "wlan0"
 	;;
 bolt,bl201)
-	ucidef_set_led_netdev "phy0-ap0" "phy0-ap0" "blue:wlan" "phy0-ap0"
-	ucidef_set_led_netdev "wan" "eth0.2" "blue:wan" "eth0.2" 
-	ucidef_set_led_netdev "lan" "eth0.1" "blue:wps" "eth0.1" 
+	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0.1"
+	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth0.2"
 	;;
 comfast,cf-wr800n)
 	ucidef_set_led_netdev "lan" "lan" "white:ethernet" eth0.1

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -11,7 +11,6 @@ ramips_setup_interfaces()
 	aigale,ai-br100|\
 	alfa-network,ac1200rm|\
 	asus,rt-n12p|\
-	bolt,bl201|\
 	dlink,dwr-116-a1|\
 	dlink,dwr-921-c1|\
 	dlink,dwr-922-e2|\
@@ -34,6 +33,7 @@ ramips_setup_interfaces()
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
 	alfa-network,r36m-e4g|\
+	bolt,bl201|\
 	zbtlink,zbt-we1026-h-32m)
 		ucidef_add_switch "switch0" \
 			"3:lan" "4:wan" "6@eth0"
@@ -296,6 +296,7 @@ ramips_setup_macs()
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x28)" 1)
 		;;
 	alfa-network,r36m-e4g|\
+	bolt,bl201|\
 	zbtlink,zbt-we1026-h-32m)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		label_mac=$(mtd_get_mac_binary factory 0x4)


### PR DESCRIPTION
This update eliminates the need to change the bootloader using breedweb, though breedweb remains an option.

Changes:
1. Update device baud rate.
2. Modify LED and button GPIO values and names.
3. Adjust partition layout to match the stock configuration.
4. Add missing package dependencies for USB.
5. Include device UIMAGE Magic value.
6. Revise switch layout.
7. Assign different MAC addresses to eth0.1 and eth0.2, consistent with the stock firmware.

Tested: OK