### PR TITLE
Leigod-Acc: Add Scheduled Pause

### DIFF
--- a/package/lean/leigod-acc/files/leigod-helper.sh
+++ b/package/lean/leigod-acc/files/leigod-helper.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# https://github.com/isecret/leigod-helper/blob/main/leigod-helper.sh
+
+USERNAME="${USERNAME:-phone}"
+PASSWORD="${PASSWORD:-password}"
+
+if ! command -v "jq" > /dev/null; then
+    echo "缺失 jq 依赖";
+    exit;
+fi
+
+if command -v md5sum > /dev/null; then
+    password_hash=$(echo -n "$PASSWORD" | md5sum | awk '{print $1}')
+elif command -v md5 > /dev/null; then
+    password_hash=$(echo -n "$PASSWORD" | md5)
+else
+    echo "缺失 md5 或 md5sum 依赖，请手动安装"
+    exit 1
+fi
+
+login=$(curl -Lks -X POST https://webapi.leigod.com/api/auth/login \
+    -H 'content-type: application/json' \
+    -d "{
+        \"account_token\": null,
+        \"country_code\": 86,
+        \"lang\": \"zh_CN\",
+        \"password\": \"$password_hash\",
+        \"region_code\": 1,
+        \"src_channel\": \"guanwang\",
+        \"user_type\": \"0\",
+        \"username\": \"$USERNAME\"
+    }")
+
+login_code=$(echo $login | jq -r ".code" 2>&1)
+login_msg=$(echo $login | jq -r ".msg" 2>&1)
+
+if [ "$login_code" -eq 0 ]; then
+    account_token=$(echo $login | jq -r ".data.login_info.account_token" 2>&1)
+    pause=$(curl -Lks -X POST https://webapi.leigod.com/api/user/pause \
+        -H 'content-type: application/json' \
+        -d "{
+                \"account_token\": \"$account_token\",
+                \"lang\": \"zh_CN\"
+            }")
+    pause_code=$(echo $pause | jq -r ".code" 2>&1)
+    pause_msg=$(echo $pause | jq -r ".msg" 2>&1)
+
+    echo "暂停结果: $pause_msg"
+else
+    echo "登录失败...原因: $login_msg"
+fi

--- a/package/lean/luci-app-leigod-acc/luasrc/controller/acc.lua
+++ b/package/lean/luci-app-leigod-acc/luasrc/controller/acc.lua
@@ -62,7 +62,7 @@ function start_acc_service()
   luci.http.write_json(resp)  
 end
 
--- start_acc_service
+-- stop_acc_service
 function stop_acc_service()
   -- util module
   local util      = require "luci.util"
@@ -72,4 +72,30 @@ function stop_acc_service()
   resp.result = "OK"
   luci.http.prepare_content("application/json")
   luci.http.write_json(resp)  
+end
+
+-- schedule_pause
+function schedule_pause()
+  local util = require "luci.util"
+  local uci = require "luci.model.uci".cursor()
+  local schedule_enabled = uci:get("accelerator", "system", "schedule_enabled") or "0"
+  local pause_time = uci:get("accelerator", "system", "pause_time") or "01:00"
+  local username = uci:get("accelerator", "system", "username") or ""
+  local password = uci:get("accelerator", "system", "password") or ""
+
+  -- Remove existing cron jobs related to leigod_helper.sh
+  util.exec("sed -i '/usr/sbin/leigod/leigod_helper.sh/d' /etc/crontabs/root")
+
+  if schedule_enabled == "1" then
+      -- Set the new cron job
+      local hour, minute = pause_time:match("(%d+):(%d+)")
+      local cron_time = string.format("%d %d * * * USERNAME=%s PASSWORD=%s /usr/sbin/leigod/leigod_helper.sh", tonumber(minute), tonumber(hour), username, password)
+      util.exec(string.format('echo "%s" >> /etc/crontabs/root', cron_time))
+      util.exec("/etc/init.d/cron restart")
+  end
+
+  local resp = {}
+  resp.result = "OK"
+  luci.http.prepare_content("application/json")
+  luci.http.write_json(resp)
 end

--- a/package/lean/luci-app-leigod-acc/luasrc/model/cbi/leigod/service.lua
+++ b/package/lean/luci-app-leigod-acc/luasrc/model/cbi/leigod/service.lua
@@ -16,6 +16,30 @@ enable.default = 0
 tun = s:option(Flag,"tun" ,translate("Tunnel Mode"))
 tun.rmempty = false
 tun.default = 0
+tun.description = translate("Turning Leigod into Tunnel mode can make some proxy plugins available")
+
+schedule_enabled = s:option(Flag, "schedule_enabled", translate("Scheduled Pause"))
+schedule_enabled.rmempty = false
+schedule_enabled.default = 0
+schedule_enabled.description = translate("夜猫子选项")
+
+pause_time = s:option(ListValue, "pause_time", translate("Pause Time"))
+pause_time:depends("schedule_enabled", 1)
+for i = 0, 23 do
+    pause_time:value(string.format("%02d:00", i), string.format("%02d:00", i))
+end
+pause_time.rmempty = false
+pause_time.description = translate("选择好时间雷神加速器会定时暂停，请避开你的游戏时间以免影响游戏体验")
+
+
+username = s:option(Value, "username", translate("Phone Number"))
+username:depends("schedule_enabled", 1)
+username.rmempty = false
+
+password = s:option(Value, "password", translate("Leigod Password"))
+password:depends("schedule_enabled", 1)
+password.password = true
+password.rmempty = false
 
 m:section(SimpleSection).template = "leigod/service"
 

--- a/package/lean/luci-app-leigod-acc/root/etc/config/accelerator
+++ b/package/lean/luci-app-leigod-acc/root/etc/config/accelerator
@@ -5,6 +5,10 @@ config system 'base'
 	option base_url 'https://opapi.nn.com/speed'
 	option enabled '0'
 	option tun '0'
+	option schedule_enabled '0'
+	option pause_time '01:00'
+	option username ''
+	option password ''
 
 config bind 'bind'
 


### PR DESCRIPTION
**其他人别合**

- 新增计划任务暂停时长

暂停时长是雷神特色，调用 API 接口实现并且使用 jq ，所以需要 Makefile 添加一个依赖 jq

BUG:
- crontabs 这里不能提交到计划任务，并且关闭了该选项会错误（一个或多个必选项值为空！）
- tunnel 这里我没搞，貌似是一个虚空选项

会的人来弄好了 Debug 一下

tunnel 这里 ${args} 就是默认的 Tproxy，把 ${args} 整掉改成 --mode tun 就是 TUN 模式了