### PR TITLE
rockchip: configure pad driver strength for orangepi r1 plus lts

### DIFF
--- a/target/linux/rockchip/patches-6.1/203-rockchip-rk3328-Add-support-for-OrangePi-R1-Plus-LTS.patch
+++ b/target/linux/rockchip/patches-6.1/203-rockchip-rk3328-Add-support-for-OrangePi-R1-Plus-LTS.patch
@@ -10,7 +10,7 @@
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3328-roc-cc.dtb
 --- /dev/null
 +++ b/arch/arm64/boot/dts/rockchip/rk3328-orangepi-r1-plus-lts.dts
-@@ -0,0 +1,71 @@
+@@ -0,0 +1,73 @@
 +// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 +/*
 + * Copyright (c) 2016 Xunlong Software. Co., Ltd.
@@ -54,9 +54,11 @@
 +				     "ethernet-phy-ieee802.3-c22";
 +			reg = <0>;
 +
++			motorcomm,auto-sleep-disabled;
 + 			motorcomm,clk-out-frequency-hz = <125000000>;
 +			motorcomm,keep-pll-enabled;
-+			motorcomm,auto-sleep-disabled;
++			motorcomm,rx-clk-drv-microamp = <5020>;
++			motorcomm,rx-data-drv-microamp = <5020>;
 +
 +			pinctrl-0 = <&eth_phy_reset_pin>;
 +			pinctrl-names = "default";


### PR DESCRIPTION
The default strength is not enough to provide stable connection under 3.3v LDO voltage.