### PR TITLE
kernel: resolved: missing usb-audio dependency issue for kernel 6.6

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -576,7 +576,7 @@ define KernelPackage/usb-audio
 	CONFIG_SND_USB_AUDIO
   $(call AddDepends/usb)
   $(call AddDepends/sound)
-  DEPENDS += +LINUX_6_1:kmod-media-core
+  DEPENDS += +LINUX_6_1||LINUX_6_6:kmod-media-core
   FILES:= \
 	$(LINUX_DIR)/sound/usb/snd-usbmidi-lib.ko \
 	$(LINUX_DIR)/sound/usb/snd-usb-audio.ko


### PR DESCRIPTION
# Pull Request 规则，创建时请删除

- 禁止有关 "GitHub Actions" 的提交
- 禁止使用 users.noreply.github.com 提交
