### PR TITLE
mediatek: add support for OpenEmbed SOM7981

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -48,6 +48,10 @@ glinet,gl-mt6000)
 glinet,gl-mt3000)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x20000"
 	;;
+openembed,som7981)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x80000"
+	ubootenv_add_uci_sys_config "/dev/mtd3" "0x0" "0x100000" "0x100000"
+	;;
 xiaomi,mi-router-wr30u|\
 xiaomi,mi-router-ax3000t|\
 xiaomi,redmi-router-ax6000)

--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -349,6 +349,26 @@ endef
 $(eval $(call KernelPackage,crypto-hmac))
 
 
+define KernelPackage/crypto-hw-atmel
+  TITLE:=Microchip / Atmel ECC/SHA/RNG hw accelerator
+  DEPENDS:=+kmod-i2c-core +kmod-crypto-ecdh +kmod-crypto-sha1 \
+	+kmod-crypto-sha256 +kmod-lib-crc16 +kmod-random-core
+  KCONFIG:= \
+	CONFIG_CRYPTO_HW=y \
+	CONFIG_CRYPTO_DEV_ATMEL_I2C \
+	CONFIG_CRYPTO_DEV_ATMEL_ECC \
+	CONFIG_CRYPTO_DEV_ATMEL_SHA204A
+  FILES:= \
+	$(LINUX_DIR)/drivers/crypto/atmel-i2c.ko \
+	$(LINUX_DIR)/drivers/crypto/atmel-ecc.ko \
+	$(LINUX_DIR)/drivers/crypto/atmel-sha204a.ko
+  AUTOLOAD:=$(call AutoLoad,09,atmel-i2c atmel-ecc atmel-sha204a)
+  $(call AddDepends/crypto)
+endef
+
+$(eval $(call KernelPackage,crypto-hw-atmel))
+
+
 define KernelPackage/crypto-hw-ccp
   TITLE:=AMD Cryptographic Coprocessor
   DEPENDS:= \

--- a/target/linux/generic/backport-5.15/750-v6.5-20-net-ethernet-mtk_eth_soc-fix-uninitialized-variable.patch
+++ b/target/linux/generic/backport-5.15/750-v6.5-20-net-ethernet-mtk_eth_soc-fix-uninitialized-variable.patch
@@ -19,7 +19,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -1941,11 +1941,11 @@ static int mtk_poll_rx(struct napi_struc
+@@ -1940,11 +1940,11 @@ static int mtk_poll_rx(struct napi_struc
  	u8 *data, *new_data;
  	struct mtk_rx_dma_v2 *rxd, trxd;
  	int done = 0, bytes = 0;
@@ -32,7 +32,7 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
  		u32 hash, reason;
  		int mac = 0;
  
-@@ -2122,7 +2122,8 @@ release_desc:
+@@ -2121,7 +2121,8 @@ release_desc:
  		else
  			rxd->rxd2 = RX_DMA_PREP_PLEN0(ring->buf_size);
  

--- a/target/linux/generic/hack-5.15/767-net-phy-realtek-add-led-link-select-for-RTL8221.patch
+++ b/target/linux/generic/hack-5.15/767-net-phy-realtek-add-led-link-select-for-RTL8221.patch
@@ -18,36 +18,55 @@ Signed-off-by: Yangyu Chen <cyy@cyyself.name>
 
 --- a/drivers/net/phy/realtek.c
 +++ b/drivers/net/phy/realtek.c
-@@ -66,6 +66,10 @@
+@@ -66,6 +66,12 @@
  #define RTL8221B_PHYCR1_ALDPS_EN		BIT(2)
  #define RTL8221B_PHYCR1_ALDPS_XTAL_OFF_EN	BIT(12)
  
 +#define RTL8221B_NR_LEDS				3
 +#define RTL8221B_LED_LINK_SELECT		0xd032
 +#define RTL8221B_LED_LINK_SELECT_OFFSET	0x2
++#define RTL8221B_LED_ACT_SELECT		0xd040
++#define RTL8221B_LED_POLARITY_SELECT		0xd044
 +
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
  
-@@ -921,6 +925,28 @@ static irqreturn_t rtl9000a_handle_inter
+@@ -921,6 +927,45 @@ static irqreturn_t rtl9000a_handle_inter
  	return IRQ_HANDLED;
  }
  
 +static int rtl8221b_config_led(struct phy_device *phydev) {
 +	struct device_node *node = phydev->mdio.dev.of_node;
 +	u32 link_select[RTL8221B_NR_LEDS];
++	u32 act_select, polarity_select;
 +	int i, val;
 +
-+	val = of_property_read_u32_array(node, "realtek,led-link-select", 
++	val = of_property_read_u32_array(node, "realtek,led-link-select",
 +					 link_select, RTL8221B_NR_LEDS);
++	if (!val) {
++		for (i = 0; i < RTL8221B_NR_LEDS; i++) {
++			val = phy_write_mmd(phydev, RTL8221B_MMD_PHY_CTRL,
++				RTL8221B_LED_LINK_SELECT + i * RTL8221B_LED_LINK_SELECT_OFFSET,
++				link_select[i]);
++			if (val < 0)
++				return val;
++		}
++	}
 +
-+	if (val)
-+		return 0;
++	val = of_property_read_u32(node, "realtek,led-act-select",
++				   &act_select);
++	if (!val) {
++		val = phy_write_mmd(phydev, RTL8221B_MMD_PHY_CTRL,
++				RTL8221B_LED_ACT_SELECT, act_select);
++		if (val < 0)
++			return val;
++	}
 +
-+	for (i = 0; i < RTL8221B_NR_LEDS; i++) {
-+		val = phy_write_mmd(phydev, RTL8221B_MMD_PHY_CTRL, 
-+			RTL8221B_LED_LINK_SELECT + i * RTL8221B_LED_LINK_SELECT_OFFSET, 
-+			link_select[i]);
++	val = of_property_read_u32(node, "realtek,led-polarity-select",
++				   &polarity_select);
++	if (!val) {
++		val = phy_write_mmd(phydev, RTL8221B_MMD_PHY_CTRL,
++				RTL8221B_LED_POLARITY_SELECT, polarity_select);
 +		if (val < 0)
 +			return val;
 +	}
@@ -58,7 +77,7 @@ Signed-off-by: Yangyu Chen <cyy@cyyself.name>
  static int rtl8221b_config_init(struct phy_device *phydev)
  {
  	u16 option_mode;
-@@ -968,7 +994,7 @@ static int rtl8221b_config_init(struct p
+@@ -968,7 +1013,7 @@ static int rtl8221b_config_init(struct p
  	phy_read_mmd_poll_timeout(phydev, RTL8221B_MMD_SERDES_CTRL, 0x7587,
  				  val, !(val & BIT(0)), 500, 100000, false);
  

--- a/target/linux/generic/hack-6.1/767-net-phy-realtek-add-led-link-select-for-RTL8221.patch
+++ b/target/linux/generic/hack-6.1/767-net-phy-realtek-add-led-link-select-for-RTL8221.patch
@@ -18,36 +18,55 @@ Signed-off-by: Yangyu Chen <cyy@cyyself.name>
 
 --- a/drivers/net/phy/realtek.c
 +++ b/drivers/net/phy/realtek.c
-@@ -66,6 +66,10 @@
+@@ -66,6 +66,12 @@
  #define RTL8221B_PHYCR1_ALDPS_EN		BIT(2)
  #define RTL8221B_PHYCR1_ALDPS_XTAL_OFF_EN	BIT(12)
  
 +#define RTL8221B_NR_LEDS				3
 +#define RTL8221B_LED_LINK_SELECT		0xd032
 +#define RTL8221B_LED_LINK_SELECT_OFFSET	0x2
++#define RTL8221B_LED_ACT_SELECT		0xd040
++#define RTL8221B_LED_POLARITY_SELECT		0xd044
 +
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
  
-@@ -932,6 +936,28 @@ static irqreturn_t rtl9000a_handle_inter
+@@ -932,6 +938,45 @@ static irqreturn_t rtl9000a_handle_inter
  	return IRQ_HANDLED;
  }
  
 +static int rtl8221b_config_led(struct phy_device *phydev) {
 +	struct device_node *node = phydev->mdio.dev.of_node;
 +	u32 link_select[RTL8221B_NR_LEDS];
++	u32 act_select, polarity_select;
 +	int i, val;
 +
-+	val = of_property_read_u32_array(node, "realtek,led-link-select", 
++	val = of_property_read_u32_array(node, "realtek,led-link-select",
 +					 link_select, RTL8221B_NR_LEDS);
++	if (!val) {
++		for (i = 0; i < RTL8221B_NR_LEDS; i++) {
++			val = phy_write_mmd(phydev, RTL8221B_MMD_PHY_CTRL,
++				RTL8221B_LED_LINK_SELECT + i * RTL8221B_LED_LINK_SELECT_OFFSET,
++				link_select[i]);
++			if (val < 0)
++				return val;
++		}
++	}
 +
-+	if (val)
-+		return 0;
++	val = of_property_read_u32(node, "realtek,led-act-select",
++				   &act_select);
++	if (!val) {
++		val = phy_write_mmd(phydev, RTL8221B_MMD_PHY_CTRL,
++				RTL8221B_LED_ACT_SELECT, act_select);
++		if (val < 0)
++			return val;
++	}
 +
-+	for (i = 0; i < RTL8221B_NR_LEDS; i++) {
-+		val = phy_write_mmd(phydev, RTL8221B_MMD_PHY_CTRL, 
-+			RTL8221B_LED_LINK_SELECT + i * RTL8221B_LED_LINK_SELECT_OFFSET, 
-+			link_select[i]);
++	val = of_property_read_u32(node, "realtek,led-polarity-select",
++				   &polarity_select);
++	if (!val) {
++		val = phy_write_mmd(phydev, RTL8221B_MMD_PHY_CTRL,
++				RTL8221B_LED_POLARITY_SELECT, polarity_select);
 +		if (val < 0)
 +			return val;
 +	}
@@ -58,7 +77,7 @@ Signed-off-by: Yangyu Chen <cyy@cyyself.name>
  static int rtl8221b_config_init(struct phy_device *phydev)
  {
  	u16 option_mode;
-@@ -979,7 +1005,7 @@ static int rtl8221b_config_init(struct p
+@@ -979,7 +1024,7 @@ static int rtl8221b_config_init(struct p
  	phy_read_mmd_poll_timeout(phydev, RTL8221B_MMD_SERDES_CTRL, 0x7587,
  				  val, !(val & BIT(0)), 500, 100000, false);
  

--- a/target/linux/generic/hack-6.6/767-net-phy-realtek-add-led-link-select-for-RTL8221.patch
+++ b/target/linux/generic/hack-6.6/767-net-phy-realtek-add-led-link-select-for-RTL8221.patch
@@ -18,36 +18,55 @@ Signed-off-by: Yangyu Chen <cyy@cyyself.name>
 
 --- a/drivers/net/phy/realtek.c
 +++ b/drivers/net/phy/realtek.c
-@@ -86,6 +86,10 @@
+@@ -86,6 +86,12 @@
  #define RTL8221B_PHYCR1_ALDPS_EN		BIT(2)
  #define RTL8221B_PHYCR1_ALDPS_XTAL_OFF_EN	BIT(12)
  
 +#define RTL8221B_NR_LEDS				3
 +#define RTL8221B_LED_LINK_SELECT		0xd032
 +#define RTL8221B_LED_LINK_SELECT_OFFSET	0x2
++#define RTL8221B_LED_ACT_SELECT		0xd040
++#define RTL8221B_LED_POLARITY_SELECT		0xd044
 +
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
  
-@@ -787,6 +791,28 @@ static int rtl822x_write_mmd(struct phy_
+@@ -787,6 +793,45 @@ static int rtl822x_write_mmd(struct phy_
  	return ret;
  }
  
 +static int rtl822xb_config_led(struct phy_device *phydev) {
 +	struct device_node *node = phydev->mdio.dev.of_node;
 +	u32 link_select[RTL8221B_NR_LEDS];
++	u32 act_select, polarity_select;
 +	int i, val;
 +
-+	val = of_property_read_u32_array(node, "realtek,led-link-select", 
++	val = of_property_read_u32_array(node, "realtek,led-link-select",
 +					 link_select, RTL8221B_NR_LEDS);
++	if (!val) {
++		for (i = 0; i < RTL8221B_NR_LEDS; i++) {
++			val = phy_write_mmd(phydev, MDIO_MMD_VEND2,
++				RTL8221B_LED_LINK_SELECT + i * RTL8221B_LED_LINK_SELECT_OFFSET,
++				link_select[i]);
++			if (val < 0)
++				return val;
++		}
++	}
 +
-+	if (val)
-+		return 0;
++	val = of_property_read_u32(node, "realtek,led-act-select",
++				   &act_select);
++	if (!val) {
++		val = phy_write_mmd(phydev, MDIO_MMD_VEND2,
++				RTL8221B_LED_ACT_SELECT, act_select);
++		if (val < 0)
++			return val;
++	}
 +
-+	for (i = 0; i < RTL8221B_NR_LEDS; i++) {
-+		val = phy_write_mmd(phydev, MDIO_MMD_VEND2, 
-+			RTL8221B_LED_LINK_SELECT + i * RTL8221B_LED_LINK_SELECT_OFFSET, 
-+			link_select[i]);
++	val = of_property_read_u32(node, "realtek,led-polarity-select",
++				   &polarity_select);
++	if (!val) {
++		val = phy_write_mmd(phydev, MDIO_MMD_VEND2,
++				RTL8221B_LED_POLARITY_SELECT, polarity_select);
 +		if (val < 0)
 +			return val;
 +	}
@@ -58,7 +77,7 @@ Signed-off-by: Yangyu Chen <cyy@cyyself.name>
  static int rtl822xb_config_init(struct phy_device *phydev)
  {
  	bool has_2500, has_sgmii;
-@@ -863,7 +889,7 @@ static int rtl822xb_config_init(struct p
+@@ -863,7 +908,7 @@ static int rtl822xb_config_init(struct p
  	if (ret < 0)
  		return ret;
  

--- a/target/linux/generic/pending-5.15/700-net-ethernet-mtk_eth_soc-avoid-creating-duplicate-of.patch
+++ b/target/linux/generic/pending-5.15/700-net-ethernet-mtk_eth_soc-avoid-creating-duplicate-of.patch
@@ -14,7 +14,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/net/ethernet/mediatek/mtk_ppe_offload.c
 +++ b/drivers/net/ethernet/mediatek/mtk_ppe_offload.c
-@@ -253,6 +253,9 @@ mtk_flow_offload_replace(struct mtk_eth
+@@ -255,6 +255,9 @@ mtk_flow_offload_replace(struct mtk_eth
  	if (rhashtable_lookup(&eth->flow_table, &f->cookie, mtk_flow_ht_params))
  		return -EEXIST;
  

--- a/target/linux/generic/pending-5.15/702-net-ethernet-mtk_eth_soc-enable-threaded-NAPI.patch
+++ b/target/linux/generic/pending-5.15/702-net-ethernet-mtk_eth_soc-enable-threaded-NAPI.patch
@@ -10,7 +10,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -3097,8 +3097,8 @@ static irqreturn_t mtk_handle_irq_rx(int
+@@ -3098,8 +3098,8 @@ static irqreturn_t mtk_handle_irq_rx(int
  
  	eth->rx_events++;
  	if (likely(napi_schedule_prep(&eth->rx_napi))) {
@@ -20,7 +20,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	}
  
  	return IRQ_HANDLED;
-@@ -3110,8 +3110,8 @@ static irqreturn_t mtk_handle_irq_tx(int
+@@ -3111,8 +3111,8 @@ static irqreturn_t mtk_handle_irq_tx(int
  
  	eth->tx_events++;
  	if (likely(napi_schedule_prep(&eth->tx_napi))) {
@@ -30,7 +30,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	}
  
  	return IRQ_HANDLED;
-@@ -4885,6 +4885,8 @@ static int mtk_probe(struct platform_dev
+@@ -4886,6 +4886,8 @@ static int mtk_probe(struct platform_dev
  	 * for NAPI to work
  	 */
  	init_dummy_netdev(&eth->dummy_dev);

--- a/target/linux/generic/pending-5.15/732-03-net-ethernet-mtk_eth_soc-fix-remaining-throughput-re.patch
+++ b/target/linux/generic/pending-5.15/732-03-net-ethernet-mtk_eth_soc-fix-remaining-throughput-re.patch
@@ -30,7 +30,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	switch (speed) {
  	case SPEED_2500:
  	case SPEED_1000:
-@@ -3290,6 +3291,9 @@ found:
+@@ -3291,6 +3292,9 @@ found:
  	if (dp->index >= MTK_QDMA_NUM_QUEUES)
  		return NOTIFY_DONE;
  

--- a/target/linux/generic/pending-5.15/736-01-net-ethernet-mtk_eth_soc-add-code-for-offloading-flo.patch
+++ b/target/linux/generic/pending-5.15/736-01-net-ethernet-mtk_eth_soc-add-code-for-offloading-flo.patch
@@ -26,7 +26,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
 --- a/drivers/net/ethernet/mediatek/mtk_ppe_offload.c
 +++ b/drivers/net/ethernet/mediatek/mtk_ppe_offload.c
-@@ -235,7 +235,8 @@ out:
+@@ -237,7 +237,8 @@ out:
  }
  
  static int
@@ -36,7 +36,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  {
  	struct flow_rule *rule = flow_cls_offload_flow_rule(f);
  	struct flow_action_entry *act;
-@@ -455,6 +456,7 @@ mtk_flow_offload_replace(struct mtk_eth
+@@ -457,6 +458,7 @@ mtk_flow_offload_replace(struct mtk_eth
  	entry->cookie = f->cookie;
  	memcpy(&entry->data, &foe, sizeof(entry->data));
  	entry->wed_index = wed_index;
@@ -44,7 +44,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  	err = mtk_foe_entry_commit(eth->ppe[entry->ppe_index], entry);
  	if (err < 0)
-@@ -523,25 +525,15 @@ mtk_flow_offload_stats(struct mtk_eth *e
+@@ -525,25 +527,15 @@ mtk_flow_offload_stats(struct mtk_eth *e
  
  static DEFINE_MUTEX(mtk_flow_offload_mutex);
  
@@ -73,7 +73,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		break;
  	case FLOW_CLS_DESTROY:
  		err = mtk_flow_offload_destroy(eth, cls);
-@@ -559,6 +551,23 @@ mtk_eth_setup_tc_block_cb(enum tc_setup_
+@@ -561,6 +553,23 @@ mtk_eth_setup_tc_block_cb(enum tc_setup_
  }
  
  static int

--- a/target/linux/generic/pending-5.15/736-04-net-ethernet-mediatek-fix-ppe-flow-accounting-for-L2.patch
+++ b/target/linux/generic/pending-5.15/736-04-net-ethernet-mediatek-fix-ppe-flow-accounting-for-L2.patch
@@ -308,7 +308,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		seq_printf(m, "%05x %s %7s", i,
 --- a/drivers/net/ethernet/mediatek/mtk_ppe_offload.c
 +++ b/drivers/net/ethernet/mediatek/mtk_ppe_offload.c
-@@ -502,24 +502,21 @@ static int
+@@ -504,24 +504,21 @@ static int
  mtk_flow_offload_stats(struct mtk_eth *eth, struct flow_cls_offload *f)
  {
  	struct mtk_flow_entry *entry;

--- a/target/linux/generic/pending-5.15/737-net-ethernet-mtk_eth_soc-add-paths-and-SerDes-modes-.patch
+++ b/target/linux/generic/pending-5.15/737-net-ethernet-mtk_eth_soc-add-paths-and-SerDes-modes-.patch
@@ -478,7 +478,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  static const struct phylink_mac_ops mtk_phylink_ops = {
  	.validate = phylink_generic_validate,
  	.mac_select_pcs = mtk_mac_select_pcs,
-@@ -4560,8 +4674,21 @@ static int mtk_add_mac(struct mtk_eth *e
+@@ -4561,8 +4675,21 @@ static int mtk_add_mac(struct mtk_eth *e
  		phy_interface_zero(mac->phylink_config.supported_interfaces);
  		__set_bit(PHY_INTERFACE_MODE_INTERNAL,
  			  mac->phylink_config.supported_interfaces);
@@ -500,7 +500,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	phylink = phylink_create(&mac->phylink_config,
  				 of_fwnode_handle(mac->of_node),
  				 phy_mode, &mtk_phylink_ops);
-@@ -4754,6 +4881,13 @@ static int mtk_probe(struct platform_dev
+@@ -4755,6 +4882,13 @@ static int mtk_probe(struct platform_dev
  
  		if (err)
  			return err;

--- a/target/linux/mediatek/dts/mt7981b-openembed-som7981.dts
+++ b/target/linux/mediatek/dts/mt7981b-openembed-som7981.dts
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include "mt7981.dtsi"
+
+/ {
+	model = "OpenEmbed SOM7981";
+	compatible = "openembed,som7981", "mediatek,mt7981";
+
+	aliases {
+		led-boot = &wlan5g_led;
+		led-failsafe = &wlan5g_led;
+		led-upgrade = &wlan5g_led;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x40000000>;
+	};
+
+	beeper {
+		compatible = "gpio-beeper";
+		gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			label = "amber:lan";
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			label = "green:lan";
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			label = "green:wlan2g";
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g_led: led-3 {
+			label = "red:wlan5g";
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		phy-handle = <&phy0>;
+		nvmem-cells = <&macaddr_factory_a 0>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+		nvmem-cells = <&macaddr_factory_a 1>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&i2c0 {
+	clock-frequency = <400000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+	status = "okay";
+
+	eeprom@50 {
+		compatible = "atmel,24c64";
+		reg = <0x50>;
+		page-size = <32>;
+	};
+
+	rtc@51 {
+		compatible = "nxp,pcf8563";
+		reg = <0x51>;
+		#clock-cells = <0>;
+	};
+
+	crypto@60 {
+		compatible = "atmel,atecc508a";
+		reg = <0x60>;
+	};
+};
+
+&mdio_bus {
+	phy0: ethernet-phy@5 {
+		reg = <5>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		phy-mode = "2500base-x";
+		reset-gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <10000>;
+		reset-deassert-us = <50000>;
+		realtek,aldps-enable;
+		realtek,led-link-select = <0x0 0xa7 0xa7>;
+		realtek,led-act-select = <0x2612>;
+		realtek,led-polarity-select = <0x63>;
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand: flash@0 {
+		compatible = "spi-nand";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bl2";
+				reg = <0x000000 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "factory";
+				reg = <0x180000 0x100000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_a: macaddr@a {
+						compatible = "mac-base";
+						reg = <0xa 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@280000 {
+				label = "config";
+				reg = <0x280000 0x100000>;
+				read-only;
+			};
+
+			partition@380000 {
+				label = "fip";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0xf880000>;
+			};
+		};
+	};
+};
+
+&pio {
+	i2c0_pins: i2c0-pins {
+		mux {
+			function = "i2c";
+			groups = "i2c0_1";
+		};
+	};
+
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <0>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <8>;
+			mediatek,pull-down-adv = <0>;
+		};
+	};
+
+	uart1_pins: uart1-pins {
+		mux {
+			function = "uart1";
+			groups = "uart1_1_tx_rx";
+		};
+	};
+
+	uart2_pins: uart2-pins {
+		mux {
+			function = "uart2";
+			groups = "uart2_0_tx_rx";
+		};
+	};
+
+	wwan_rst_h: wwan-rst-h {
+		pins = "GPIO_WPS";
+		drive-strength = <8>;
+		mediatek,pull-down-adv = <0>;
+		output-low;
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&uart1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart1_pins>;
+	status = "okay";
+};
+
+&uart2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart2_pins>;
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	status = "okay";
+};
+
+&xhci {
+	pinctrl-names = "default";
+	pinctrl-0 = <&wwan_rst_h>;
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -28,6 +28,12 @@ nokia,ea0326gmp)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "br-lan"
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	;;
+openembed,som7981)
+	ucidef_set_led_netdev "lanact" "LANACT" "green:lan" "eth1" "rx tx"
+	ucidef_set_led_netdev "lanlink" "LANLINK" "amber:lan" "eth1" "link"
+	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wlan2g" "wlan0"
+	ucidef_set_led_netdev "wlan5g" "WLAN5G" "red:wlan5g" "wlan1"
+	;;
 xiaomi,mi-router-wr30u)
 	ucidef_set_led_netdev "wan" "wan" "blue:internet" "wan"
 	;;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -35,7 +35,8 @@ mediatek_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" wan
 		;;
 	glinet,gl-mt2500|\
-	glinet,gl-mt3000)
+	glinet,gl-mt3000|\
+	openembed,som7981)
 		ucidef_set_interfaces_lan_wan eth1 eth0
 		;;
 	hf,m7986r1*)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -66,6 +66,9 @@ case "$board" in
 		addr=$(mtd_get_mac_binary Factory 0x28)
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		;;
+	openembed,som7981)
+		[ "$PHYNBR" = "1" ] && cat /sys/class/net/eth0/address > /sys${DEVPATH}/macaddress
+		;;
 	qihoo,360t7)
 		addr=$(mtd_get_mac_ascii factory lanMac)
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -535,6 +535,26 @@ define Device/nokia_ea0326gmp
 endef
 TARGET_DEVICES += nokia_ea0326gmp
 
+
+define Device/openembed_som7981
+  DEVICE_VENDOR := OpenEmbed
+  DEVICE_MODEL := SOM7981
+  DEVICE_DTS := mt7981b-openembed-som7981
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 \
+	kmod-crypto-hw-atmel kmod-eeprom-at24 kmod-gpio-beeper kmod-rtc-pcf8563 \
+	kmod-usb-net-cdc-mbim kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 244224k
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += openembed_som7981
+
 define Device/qihoo_360t7
   DEVICE_VENDOR := Qihoo
   DEVICE_MODEL := 360T7


### PR DESCRIPTION
```
Hardware specification:
  SoC: MediaTek MT7981B 2x A53
  Flash: 256 MiB SPI-NAND
  RAM: 0.5/1 GB DDR4
  Ethernet: 1x 1GbE, 1x 2.5GbE (RTL8221B)
  WiFi: MediaTek MT7976C
  USB: 1x M.2 B-Key
  GPIO: 26-Pin header
  UART: 6 GND, 8 TX, 10 RX (in Pin header)
  Button: Reset

Installation:
The board comes with a third-party custom OpenWrt image, you can upload
sysupgrade image via LuCI directly WITHOUT keeping configurations.

Or power on the board with pressing reset button for 5 second, then visit
http://192.168.1.1/ and upload -factory.bin firmware.
```