### PR TITLE
mediatek:filogic: add support for cmcc-xr30-nand

### DIFF
--- a/cp.sh
+++ b/cp.sh
@@ -1,1 +1,0 @@
-cp -r bin/targets/mediatek/filogic/openwrt-mediatek-filogic-cmcc_xr30-nand-ubootmod-squashfs-* /mnt/d/image/openwrt/xr-30/build/lede/0118

--- a/cp.sh
+++ b/cp.sh
@@ -1,0 +1,1 @@
+cp -r bin/targets/mediatek/filogic/openwrt-mediatek-filogic-cmcc_xr30-nand-ubootmod-squashfs-* /mnt/d/image/openwrt/xr-30/build/lede/0118

--- a/target/linux/mediatek/dts/mt7981b-cmcc-xr30-nand-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-xr30-nand-ubootmod.dts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include "mt7981b-cmcc-xr30.dts"
+
+/ {
+	model = "CMCC RAX3000M (NAND version)";
+	compatible = "cmcc,rax3000m-nand", "mediatek,mt7981";
+
+	aliases {
+		label-mac-device = &gmac1;
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand: flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+					compatible = "fixed-partitions";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					partition@0 {
+						label = "bl2";
+						reg = <0x00000 0x0100000>;
+						read-only;
+					};
+
+					partition@100000 {
+						label = "u-boot-env";
+						reg = <0x100000 0x80000>;
+					};
+
+					factory: partition@180000 {
+						label = "factory";
+						reg = <0x180000 0x200000>;
+						read-only;
+					};
+
+					partition@380000 {
+						label = "fip";
+						reg = <0x380000 0x200000>;
+						read-only;
+					};
+
+					partition@580000 {
+						label = "ubi";
+						reg = <0x580000 0x7200000>;
+					};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+				mux {
+					function = "spi";
+					groups = "spi0", "spi0_wp_hold";
+				};
+
+				conf-pu {
+					pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+					drive-strength = <8>;
+					mediatek,pull-up-adv = <0>; /* bias-disable */
+				};
+
+				conf-pd {
+					pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+					drive-strength = <8>;
+					mediatek,pull-up-adv = <0>; /* bias-disable */
+				};
+	};
+};
+
+&wifi {
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};

--- a/target/linux/mediatek/dts/mt7981b-cmcc-xr30-nand-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-xr30-nand-ubootmod.dts
@@ -4,86 +4,114 @@
 #include "mt7981b-cmcc-xr30.dts"
 
 / {
-	model = "CMCC RAX3000M (NAND version)";
-	compatible = "cmcc,rax3000m-nand", "mediatek,mt7981";
-
+	model = "CMCC XR30 NAND version (custom U-Boot layout)";
+	compatible = "cmcc,xr30-nand-ubootmod", "mediatek,mt7981";
+	
 	aliases {
 		label-mac-device = &gmac1;
 	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_2a 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	nvmem-cells = <&macaddr_factory_24 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &spi0 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi0_flash_pins>;
 	status = "okay";
-
+	
 	spi_nand: flash@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
-
+		
 		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;
 		mediatek,bmt-max-reserved-blocks = <64>;
-
+		
 		partitions {
-					compatible = "fixed-partitions";
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			
+			partition@0 {
+				label = "bl2";
+				reg = <0x00000 0x0100000>;
+				read-only;
+			};
+			
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+			
+			factory: partition@180000 {
+				label = "factory";
+				reg = <0x180000 0x200000>;
+				
+				compatible = "nvmem-cells";
+				nvmem-layout {
+					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;
-
-					partition@0 {
-						label = "bl2";
-						reg = <0x00000 0x0100000>;
-						read-only;
+					
+					macaddr_factory_24: macaddr@24 {
+						compatible = "mac-base";
+						reg = <0x24 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
-
-					partition@100000 {
-						label = "u-boot-env";
-						reg = <0x100000 0x80000>;
+					
+					macaddr_factory_2a: macaddr@2a {
+						compatible = "mac-base";
+						reg = <0x2a 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
-
-					factory: partition@180000 {
-						label = "factory";
-						reg = <0x180000 0x200000>;
-						read-only;
-					};
-
-					partition@380000 {
-						label = "fip";
-						reg = <0x380000 0x200000>;
-						read-only;
-					};
-
-					partition@580000 {
-						label = "ubi";
-						reg = <0x580000 0x7200000>;
-					};
+				};
+			};
+			
+			partition@380000 {
+				label = "fip";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+			
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x7200000>;
+			};
 		};
 	};
 };
 
 &pio {
 	spi0_flash_pins: spi0-pins {
-				mux {
-					function = "spi";
-					groups = "spi0", "spi0_wp_hold";
-				};
-
-				conf-pu {
-					pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
-					drive-strength = <8>;
-					mediatek,pull-up-adv = <0>; /* bias-disable */
-				};
-
-				conf-pd {
-					pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
-					drive-strength = <8>;
-					mediatek,pull-up-adv = <0>; /* bias-disable */
-				};
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <0>; /* bias-disable */
+		};
+		
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <0>; /* bias-disable */
+		};
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7981b-cmcc-xr30.dts
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-xr30.dts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+ * Copyright (C) 2023 Tianling Shen <cnsztl@immortalwrt.org>
+ */
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "mt7981.dtsi"
+
+/ {
+	model = "CMCC RAX3000M";
+	compatible = "cmcc,rax3000m", "mediatek,mt7981";
+
+	aliases {
+		led-boot = &red_led;
+		led-failsafe = &red_led;
+		led-running = &green_led;
+		led-upgrade = &green_led;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x20000000>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		button-mesh {
+			label = "mesh";
+			linux,code = <BTN_9>;
+			linux,input-type = <EV_SW>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		green_led: led-0 {
+			label = "green:status";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			label = "blue:status";
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		red_led: led-2 {
+			label = "red:status";
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan3";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan1";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+};

--- a/target/linux/mediatek/dts/mt7981b-cmcc-xr30.dts
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-xr30.dts
@@ -10,18 +10,18 @@
 #include "mt7981.dtsi"
 
 / {
-	model = "CMCC RAX3000M";
-	compatible = "cmcc,rax3000m", "mediatek,mt7981";
+	model = "CMCC XR30";
+	compatible = "cmcc,xr30", "mediatek,mt7981";
 
 	aliases {
 		led-boot = &red_led;
 		led-failsafe = &red_led;
-		led-running = &green_led;
-		led-upgrade = &green_led;
+		led-running = &white_led;
+		led-upgrade = &red_led;
 		serial0 = &uart0;
 	};
 
-	chosen {
+	chosen: chosen {
 		stdout-path = "serial0:115200n8";
 	};
 
@@ -46,22 +46,17 @@
 		};
 	};
 
-	gpio-leds {
+	leds {
 		compatible = "gpio-leds";
 
-		green_led: led-0 {
-			label = "green:status";
-			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
-		};
-
-		led-1 {
-			label = "blue:status";
-			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
-		};
-
-		red_led: led-2 {
-			label = "red:status";
+		red_led: red {
+			label = "xr30:red";
 			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+		};
+
+		white_led: white {
+			label = "xr30:white";
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -10,6 +10,7 @@ mediatek_setup_interfaces()
 	case $board in
 	abt,asr3000|\
 	cmcc,rax3000m*|\
+	cmcc,xr30*|\
 	h3c,magic-nx30-pro|\
 	imou,lc-hx3001|\
 	nokia,ea0326gmp)
@@ -103,6 +104,7 @@ mediatek_setup_macs()
 		lan_mac=$(mmc_get_mac_binary factory 0x24)
 		label_mac=$wan_mac
 		;;
+	cmcc,xr30*| \
 	cmcc,rax3000m-nand)
 		wan_mac=$(mtd_get_mac_binary factory 0x2a)
 		lan_mac=$(mtd_get_mac_binary factory 0x24)

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -316,6 +316,26 @@ define Device/cmcc_rax3000m-nand
 endef
 TARGET_DEVICES += cmcc_rax3000m-nand
 
+define Device/cmcc_xr30-nand-ubootmod
+  DEVICE_VENDOR := CMCC
+  DEVICE_MODEL := XR30 NAND version
+  DEVICE_VARIANT := (custom U-Boot layout)
+  DEVICE_DTS := mt7981b-cmcc-xr30-nand-ubootmod
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7981-firmware mt7981-wo-firmware \
+	kmod-usb3 automount
+  SUPPORTED_DEVICES := cmcc,xr30-nand-ubootmod
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 116736k
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += cmcc_xr30-nand-ubootmod
+
 define Device/cudy_tr3000-mod
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := TR3000


### PR DESCRIPTION
【添加】增加CMCC-XR30 nand的设备树及配置，初步适配CMCC-XR30，目前可正常使用
