### PR TITLE
Update dnsmasq.init

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -205,8 +205,12 @@ ismounted() {
 	return 1
 }
 
-append_addnhosts() {
+append_extramount() {
 	ismounted "$1" || append EXTRA_MOUNT "$1"
+}
+
+append_addnhosts() {
+	append_extramount "$1"
 	xappend "--addn-hosts=$1"
 }
 
@@ -1157,6 +1161,8 @@ dnsmasq_start()
 			echo "nameserver $DNS_SERVER" >> /tmp/resolv.conf
 		done
 	}
+
+	config_list_foreach "$cfg" addnmount append_extramount
 
 	procd_open_instance $cfg
 	procd_set_param command $PROG -C $CONFIGFILE -k -x /var/run/dnsmasq/dnsmasq."${cfg}".pid


### PR DESCRIPTION
dnsmasq: add option to expose additional paths to jail
Add new UCI list 'addn_mount' allowing the expose additional filesystem
paths to the jailed dnsmasq process. This is useful e.g. in case of
manually configured includes to the configuration file or symlinks
pointing outside of the exposed paths as used by e.g. the safe-search
package in the packages feed.

(https://github.com/openwrt/openwrt/commit/aa12a0fdd1c5a004281633c5b0758da1781bb41c)
