### PR TITLE
Fix: Addressing Vulnerability in Cloned Function

### DIFF
--- a/package/lean/mt/drivers/mt7615d/src/mt_wifi/embedded/security/bn_lib.c
+++ b/package/lean/mt/drivers/mt7615d/src/mt_wifi/embedded/security/bn_lib.c
@@ -6557,7 +6557,8 @@ BIGNUM *BN_mod_sqrt(BIGNUM *in, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
 /*
  * Returns 'ret' such that ret^2 == a (mod p), using the Tonelli/Shanks
  * algorithm (cf. Henri Cohen, "A Course in Algebraic Computational Number
- * Theory", algorithm 1.5.1). 'p' must be prime!
+ * Theory", algorithm 1.5.1). 'p' must be prime, otherwise an error or
+ * an incorrect "result" will be returned.
  */
 {
 	BIGNUM *ret = in;
@@ -6873,22 +6874,23 @@ BIGNUM *BN_mod_sqrt(BIGNUM *in, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
 			goto vrfy;
 		}
 
-		/* find smallest  i  such that  b^(2^i) = 1 */
-		i = 1;
-
-		if (!BN_mod_sqr(t, b, p, ctx))
-			goto end;
-
-		while (!BN_is_one(t)) {
-			i++;
-
-			if (i == e) {
-				BNerr(BN_F_BN_MOD_SQRT, BN_R_NOT_A_SQUARE);
-				goto end;
+		/* Find the smallest i, 0 < i < e, such that b^(2^i) = 1. */
+        for (i = 1; i < e; i++) {
+            if (i == 1) {
+                if (!BN_mod_sqr(t, b, p, ctx))
+                    goto end;
+            } else {
+                if (!BN_mod_mul(t, t, t, p, ctx))
+                    goto end;
 			}
 
-			if (!BN_mod_mul(t, t, t, p, ctx))
-				goto end;
+			if (BN_is_one(t))
+                break;
+        }
+        /* If not found, a is not a square or p is not prime. */
+        if (i >= e) {
+            BNerr(BN_F_BN_MOD_SQRT, BN_R_NOT_A_SQUARE);
+            goto end;
 		}
 
 		/* t := y^2^(e - i - 1) */


### PR DESCRIPTION
## Summary
This PR fixes a security vulnerability in BN_mod_sqrt() that was cloned from OpenSSL but did not receive the security patch applied in OpenSSL. The original issue was reported and fixed under CVE-2022-0778.

## Issue Details
The function BN_mod_sqrt() in this repository is nearly identical to BN_mod_sqrt() from OpenSSL.
The original function was patched due to a vulnerability identified in CVE-2022-0778.
The same issue exists in this repository's function but remains unpatched.

## Proposed Fix
This PR applies the same patch as the one in OpenSSL to eliminate the vulnerability.

## References
CVE: [CVE-2022-0778](https://nvd.nist.gov/vuln/detail/CVE-2022-0778)
Original Fix: [Original Fix](https://github.com/openssl/openssl/commit/3118eb64934499d93db3230748a452351d1d9a65)