### PR TITLE
Update:netcore n60 pro support

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-netcore-n60-pro.dts
+++ b/target/linux/mediatek/dts/mt7986a-netcore-n60-pro.dts
@@ -13,10 +13,10 @@
 	aliases {
 		serial0 = &uart0;
 		label-mac-device = &gmac0;
-		led-boot = &led_status_red;
-		led-failsafe = &led_status_red;
-		led-running = &led_status_blue;
-		led-upgrade = &led_status_blue;
+		led-boot = &sys_status_blue;
+		led-failsafe = &sys_status_blue;
+		led-running = &sys_status_blue;
+		led-upgrade = &sys_status_blue;
 	};
 
 	chosen {
@@ -46,13 +46,27 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_status_red: status_red {
-			label = "red:status";
+		sys_status_blue: status_blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
 			gpios = <&pio 29 GPIO_ACTIVE_LOW>;
 		};
 
-		led_status_blue: status_blue {
-			label = "blue:status";
+		usb_status_blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_USB;
+			gpios = <&pio 30 GPIO_ACTIVE_LOW>;
+		};
+
+		mesh_status_blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 31 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_status_blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WAN;
 			gpios = <&pio 32 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/mediatek/dts/mt7986a-netcore-n60-pro.dts
+++ b/target/linux/mediatek/dts/mt7986a-netcore-n60-pro.dts
@@ -3,6 +3,7 @@
 /dts-v1/;
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
 
 #include "mt7986a.dtsi"
 
@@ -13,10 +14,10 @@
 	aliases {
 		serial0 = &uart0;
 		label-mac-device = &gmac0;
-		led-boot = &sys_status_blue;
-		led-failsafe = &sys_status_blue;
-		led-running = &sys_status_blue;
-		led-upgrade = &sys_status_blue;
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
 	};
 
 	chosen {
@@ -46,31 +47,31 @@
 	leds {
 		compatible = "gpio-leds";
 
-		sys_status_blue: status_blue {
+		led_status: status {
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_POWER;
 			gpios = <&pio 29 GPIO_ACTIVE_LOW>;
 		};
 
-		usb_status_blue {
+		usb {
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_USB;
 			gpios = <&pio 30 GPIO_ACTIVE_LOW>;
 		};
 
-		mesh_status_blue {
+		mesh {
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_STATUS;
 			gpios = <&pio 31 GPIO_ACTIVE_LOW>;
 		};
 
-		wan_status_blue {
+		wan {
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WAN;
 			gpios = <&pio 32 GPIO_ACTIVE_LOW>;
 		};
 	};
-	
+
 	reg_3p3v: regulator-3p3v {
 		compatible = "regulator-fixed";
 		regulator-name = "fixed-3.3V";
@@ -136,13 +137,11 @@
 	phy5: phy@5 {
 		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <5>;
-		mxl,led-config = <0x0 0x0 0x0 0x3f0>;
 	};
 
 	phy6: phy@6 {
 		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <6>;
-		mxl,led-config = <0x0 0x0 0x0 0x3f0>;
 	};
 
 	switch: switch@0 {

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -45,6 +45,9 @@ nokia,ea0326gmp)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "br-lan"
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	;;
+netcore,n60-pro)
+	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1" "link"
+	;;
 openembed,som7981)
 	ucidef_set_led_netdev "lanact" "LANACT" "amber:lan" "eth1" "rx tx"
 	ucidef_set_led_netdev "lanlink" "LANLINK" "green:lan" "eth1" "link"


### PR DESCRIPTION
Hardware specification:
SoC: MediaTek MT7986A 4x A53
Flash: ESMT F50L1G41LB 128MB
RAM: M16U4G16256A DDR4 512MB
Ethernet: 2x 2.5G + 3x 1G
USB: 1x USB 3.0
WiFi1: MT7975N 2.4GHz 4T4R
WiFi2: MT7975PN 5GHz 4T4R
Button: Reset, WPS
Power: DC 12V 2A