### PR TITLE
rockchip: add kmod-usb-net-rtl8152 to device packages for rumu3f_fine-3399

### DIFF
--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -458,7 +458,7 @@ define Device/rumu3f_fine-3399
   SOC := rk3399
   UBOOT_DEVICE_NAME := fine3399-rk3399
   IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
-  DEVICE_PACKAGES := kmod-gpio-button-hotplug kmod-r8168
+  DEVICE_PACKAGES := kmod-gpio-button-hotplug kmod-r8168 kmod-usb-net-rtl8152
 endef
 TARGET_DEVICES += rumu3f_fine-3399
 


### PR DESCRIPTION
Because the WAN port of fine3399 uses the Realtek RTL8153 USB to ethernet adapter, this package is not compiled by default.