### PR TITLE
ipq40xx: improve support for Alibaba AP4220

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -58,8 +58,8 @@ case "$FIRMWARE" in
 	qcom,ap-dk01.1-c1)
 		caldata_extract "ART" 0x1000 0x2f20
 		;;
-	alibaba,ap4220|\
-	alibaba,ap4220-48m)
+	alibaba,ap4220-48m|\
+	alibaba,ap4220-128m)
 		caldata_extract "ART" 0x1000 0x2f20
 		ath10k_patch_mac $(macaddr_add "$(mtd_get_mac_text product_info 0x40)" 2)
 		;;
@@ -148,8 +148,8 @@ case "$FIRMWARE" in
 	qcom,ap-dk01.1-c1)
 		caldata_extract "ART" 0x5000 0x2f20
 		;;
-	alibaba,ap4220|\
-	alibaba,ap4220-48m)
+	alibaba,ap4220-48m|\
+	alibaba,ap4220-128m)
 		caldata_extract "ART" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add "$(mtd_get_mac_text product_info 0x40)" 3)
 		;;

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-ap4220-128m.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-ap4220-128m.dts
@@ -7,6 +7,6 @@
 	compatible = "alibaba,ap4220-128m";
 };
 
-&nand_rootfs {
+&ubi_rootfs {
 	reg = <0x0 0x08000000>;
 };

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-ap4220-48m.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-ap4220-48m.dts
@@ -7,6 +7,6 @@
 	compatible = "alibaba,ap4220-48m";
 };
 
-&nand_rootfs {
+&ubi_rootfs {
 	reg = <0x0 0x03000000>;
 };

--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-ap4220.dtsi
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-ap4220.dtsi
@@ -15,7 +15,7 @@
 	};
 
 	chosen {
-		bootargs-append = " root=/dev/ubiblock0_1";
+		bootargs-append = " ubi.mtd=rootfs root=/dev/ubiblock0_1";
 	};
 
 	soc {
@@ -164,7 +164,6 @@
 			partition@e0000 {
 				label = "APPSBLENV";
 				reg = <0xe0000 0x10000>;
-				read-only;
 			};
 
 			partition@f0000 {
@@ -177,17 +176,6 @@
 				label = "ART";
 				reg = <0x170000 0x10000>;
 				read-only;
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				precal_art_1000: precal@1000 {
-					reg = <0x1000 0x2f20>;
-				};
-
-				precal_art_5000: precal@5000 {
-					reg = <0x5000 0x2f20>;
-				};
 			};
 
 			partition@180000 {
@@ -199,7 +187,6 @@
 			partition@190000 {
 				label = "mtdoops";
 				reg = <0x00190000 0x00020000>;
-				read-only;
 			};
 
 			partition@1b0000 {
@@ -232,7 +219,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			nand_rootfs: partition@0 {
+			ubi_rootfs: partition@0 {
 				label = "rootfs";
 				/* reg defined in 48M/128M variant dts. */
 			};
@@ -330,20 +317,14 @@
 	status = "okay";
 };
 
-&vqmmc {
-	status = "okay";
-};
-
 &wifi0 {
 	status = "okay";
-	nvmem-cell-names = "pre-calibration";
-	nvmem-cells = <&precal_art_1000>;
+
 	qcom,ath10k-calibration-variant = "Alibaba-AP4220";
 };
 
 &wifi1 {
 	status = "okay";
-	nvmem-cell-names = "pre-calibration";
-	nvmem-cells = <&precal_art_5000>;
+
 	qcom,ath10k-calibration-variant = "Alibaba-AP4220";
 };


### PR DESCRIPTION
1. Add "ubi.mtd=rootfs" to dts for better compatibility with stock uboot and uboot_mod.
2. Remove wifi related nvmem nodes in dts to improve 2g and 5g mac addresses randomization issue.
3. Fixed wrong device name in "11-ath10k-caldata".


Tested-by: Willem Lee <1980490718@qq.com>