### PR TITLE
toolchain: glibc: Fix build with autoconf 2.71

### DIFF
--- a/toolchain/glibc/common.mk
+++ b/toolchain/glibc/common.mk
@@ -80,11 +80,6 @@ define Host/SetToolchainInfo
 endef
 
 define Host/Configure
-	[ -f $(HOST_BUILD_DIR)/.autoconf ] || { \
-		cd $(HOST_BUILD_DIR)/; \
-		autoconf --force && \
-		touch $(HOST_BUILD_DIR)/.autoconf; \
-	}
 	mkdir -p $(CUR_BUILD_DIR)
 	( cd $(CUR_BUILD_DIR); rm -f config.cache; \
 		$(GLIBC_CONFIGURE) \


### PR DESCRIPTION
The glibc build was failing with this error message:
  aclocal.m4:6: error: Exactly version 2.69 of Autoconf is required but you have 2.71
  aclocal.m4:6: the top level

The autoconf run on glibc is not needed, just remove it.

Fixes: #13308 