### PR TITLE
Fix build kernel with zram failure

### DIFF
--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -1000,10 +1000,7 @@ define KernelPackage/zram/config
   if PACKAGE_kmod-zram
     if !LINUX_6_6
         config KERNEL_ZRAM_BACKEND_LZO
-                bool "lzo and lzo-rle compression support" if KERNEL_ZRAM_BACKEND_LZ4 || \
-                    KERNEL_ZRAM_BACKEND_LZ4HC || KERNEL_ZRAM_BACKEND_ZSTD
-                default !KERNEL_ZRAM_BACKEND_LZ4 && \
-                    !KERNEL_ZRAM_BACKEND_LZ4HC && !KERNEL_ZRAM_BACKEND_ZSTD
+                bool "lzo and lzo-rle compression support"
 
         config KERNEL_ZRAM_BACKEND_LZ4
                 bool "lz4 compression support"
@@ -1013,6 +1010,12 @@ define KernelPackage/zram/config
 
         config KERNEL_ZRAM_BACKEND_ZSTD
                 bool "zstd compression support"
+
+        config KERNEL_ZRAM_BACKEND_FORCE_LZO
+                def_bool !KERNEL_ZRAM_BACKEND_LZ4 && \
+                         !KERNEL_ZRAM_BACKEND_LZ4HC && \
+                         !KERNEL_ZRAM_BACKEND_ZSTD
+                select KERNEL_ZRAM_BACKEND_LZO
 
     endif
     choice

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -974,6 +974,11 @@ $(eval $(call KernelPackage,ikconfig))
 
 define KernelPackage/zram
   SUBMENU:=$(OTHER_MENU)
+  DEPENDS:= \
+	+(KERNEL_ZRAM_BACKEND_LZO||KERNEL_ZRAM_DEF_COMP_LZORLE||KERNEL_ZRAM_DEF_COMP_LZO):kmod-lib-lzo \
+	+(KERNEL_ZRAM_BACKEND_LZ4||KERNEL_ZRAM_DEF_COMP_LZ4):kmod-lib-lz4 \
+	+(KERNEL_ZRAM_BACKEND_LZ4HC||KERNEL_ZRAM_DEF_COMP_LZ4HC):kmod-lib-lz4hc \
+	+(KERNEL_ZRAM_BACKEND_ZSTD||KERNEL_ZRAM_DEF_COMP_ZSTD):kmod-lib-zstd
   TITLE:=ZRAM
   KCONFIG:= \
 	CONFIG_ZSMALLOC \
@@ -993,29 +998,46 @@ endef
 
 define KernelPackage/zram/config
   if PACKAGE_kmod-zram
+    if !LINUX_6_6
+        config KERNEL_ZRAM_BACKEND_LZO
+                bool "lzo and lzo-rle compression support" if KERNEL_ZRAM_BACKEND_LZ4 || \
+                    KERNEL_ZRAM_BACKEND_LZ4HC || KERNEL_ZRAM_BACKEND_ZSTD
+                default !KERNEL_ZRAM_BACKEND_LZ4 && \
+                    !KERNEL_ZRAM_BACKEND_LZ4HC && !KERNEL_ZRAM_BACKEND_ZSTD
+
+        config KERNEL_ZRAM_BACKEND_LZ4
+                bool "lz4 compression support"
+
+        config KERNEL_ZRAM_BACKEND_LZ4HC
+                bool "lz4hc compression support"
+
+        config KERNEL_ZRAM_BACKEND_ZSTD
+                bool "zstd compression support"
+
+    endif
     choice
       prompt "ZRAM Default compressor"
-      default ZRAM_DEF_COMP_LZORLE
+      default KERNEL_ZRAM_DEF_COMP_LZORLE
 
-    config ZRAM_DEF_COMP_LZORLE
+    config KERNEL_ZRAM_DEF_COMP_LZORLE
             bool "lzo-rle"
-            select PACKAGE_kmod-lib-lzo
+            depends on KERNEL_ZRAM_BACKEND_LZO || LINUX_6_6
 
-    config ZRAM_DEF_COMP_LZO
+    config KERNEL_ZRAM_DEF_COMP_LZO
             bool "lzo"
-            select PACKAGE_kmod-lib-lzo
+            depends on KERNEL_ZRAM_BACKEND_LZO || LINUX_6_6
 
-    config ZRAM_DEF_COMP_LZ4
+    config KERNEL_ZRAM_DEF_COMP_LZ4
             bool "lz4"
-            select PACKAGE_kmod-lib-lz4
+            depends on KERNEL_ZRAM_BACKEND_LZ4 || LINUX_6_6
 
-    config ZRAM_DEF_COMP_LZ4HC
+    config KERNEL_ZRAM_DEF_COMP_LZ4HC
             bool "lz4-hc"
-            select PACKAGE_kmod-lib-lz4hc
+            depends on KERNEL_ZRAM_BACKEND_LZ4HC || LINUX_6_6
 
-    config ZRAM_DEF_COMP_ZSTD
+    config KERNEL_ZRAM_DEF_COMP_ZSTD
             bool "zstd"
-            select PACKAGE_kmod-lib-zstd
+            depends on KERNEL_ZRAM_BACKEND_ZSTD || LINUX_6_6
 
     endchoice
   endif


### PR DESCRIPTION
Cherry-Pick 了上游 https://github.com/openwrt/openwrt/commit/4708057e27532bb6be726b35788800db0109ca09 和 https://github.com/openwrt/openwrt/commit/c40840da3a03d9abdf849f9be653e137ced81b2f

修复了 ZRAM 编译失败

```
Package kmod-zram is missing dependencies for the following libraries:
lzo_compress.ko
lzo_decompress.ko
make[3]: *** [modules/other.mk:1024: /workspace/devices/openwrt/openwrt/bin/targets/rockchip/armv8/packages/kmod-zram_6.12.32-1_aarch64_generic.ipk] Error 1
make[3]: Leaving directory '/workspace/devices/openwrt/openwrt/package/kernel/linux'
time: package/kernel/linux/compile#7.83#11.43#17.07
    ERROR: package/kernel/linux failed to build.
```