### PR TITLE
u-boot.mk: add support for config customization

### DIFF
--- a/include/u-boot.mk
+++ b/include/u-boot.mk
@@ -83,6 +83,9 @@ endef
 
 define Build/Configure/U-Boot
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) $(UBOOT_CONFIGURE_VARS) $(UBOOT_CONFIG)_config
+	$(if $(strip $(UBOOT_CUSTOMIZE_CONFIG)),
+		$(PKG_BUILD_DIR)/scripts/config --file $(PKG_BUILD_DIR)/.config $(UBOOT_CUSTOMIZE_CONFIG)
+		+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) $(UBOOT_CONFIGURE_VARS) oldconfig)
 endef
 
 DTC=$(wildcard $(LINUX_DIR)/scripts/dtc/dtc)


### PR DESCRIPTION
### u-boot.mk

disable mkeficapsule for armsr due to a host-side GnuTLS dependency (fix #13566)

- [package/boot/uboot-armsr/Makefile](/coolsnowwolf/lede/blob/master/package/boot/uboot-armsr/Makefile)

```
# mkeficapsule host tool is disabled
# due to a host-side GnuTLS dependency
UBOOT_CUSTOMIZE_CONFIG := \
	--enable CMD_EFIDEBUG \
	--disable TOOLS_MKEFICAPSULE

$(eval $(call BuildPackage/U-Boot))
```

> **UBOOT_CUSTOMIZE_CONFIG** 没生效，u-boot.mk 很久没更新了 🤪🤪🤪