### PR TITLE
tools: gmp: fix compilation with GCC15

### DIFF
--- a/tools/gmp/patches/001-acinclude-m4-fix-std23.patch
+++ b/tools/gmp/patches/001-acinclude-m4-fix-std23.patch
@@ -1,0 +1,19 @@
+# HG changeset patch
+# User Marc Glisse <marc.glisse@inria.fr>
+# Date 1738186682 -3600
+#      Wed Jan 29 22:38:02 2025 +0100
+# Node ID 8e7bb4ae7a18b1405ea7f9cbcda450b7d920a901
+# Parent  e84c5c785bbe8ed8c3620194e50b65adfc2f5d83
+Complete function prototype in acinclude.m4 for C23 compatibility
+
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -609,7 +609,7 @@ GMP_PROG_CC_WORKS_PART([$1], [long long
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int,t1 const*,t1,t2,t1 const*,int){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}

--- a/tools/gmp/patches/002-acinclude-m4-add-parameter-names.patch
+++ b/tools/gmp/patches/002-acinclude-m4-add-parameter-names.patch
@@ -1,0 +1,22 @@
+# HG changeset patch
+# User Marc Glisse <marc.glisse@inria.fr>
+# Date 1743513946 -7200
+#      Tue Apr 01 15:25:46 2025 +0200
+# Node ID d66d66d82dbbe4f561920d28c1e1cbe6818452c7
+# Parent  1a2ad0e32507e842486c8ac9d5cdc772fd0c335e
+Add parameter names to function prototype
+
+ 2025-02-01  Marc Glisse <marc.glisse@inria.fr>
+ 
+ 	* longlong.h (loongarch64 umul_ppmm): __int128__ -> __int128.
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -609,7 +609,7 @@ GMP_PROG_CC_WORKS_PART([$1], [long long
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(int,t1 const*,t1,t2,t1 const*,int){}
++void g(int a,t1 const*b,t1 c,t2 d,t1 const*e,int f){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}


### PR DESCRIPTION
Fedora 42 updated to GCC15 which now defaults to GNU23 as the default instead of GNU17[1], and this breaks GMP compilation by failing to find a working compiler test.

Its been fixed upstream [2][3], so backport the fix to fix GCC15 compilation.

[1] https://gcc.gnu.org/gcc-15/porting_to.html#c23
[2] https://gmplib.org/repo/gmp/rev/8e7bb4ae7a18
[3] https://gmplib.org/repo/gmp/rev/d66d66d82dbb

Link: https://github.com/openwrt/openwrt/pull/18506
