### PR TITLE
tools: elfutils: set -std=gnu17

### DIFF
--- a/tools/elfutils/Makefile
+++ b/tools/elfutils/Makefile
@@ -19,6 +19,8 @@ PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/host-build.mk
 
+HOST_CFLAGS += -Wno-error -fPIC -std=gnu17
+
 HOST_CONFIGURE_ARGS += \
 	--disable-debuginfod \
 	--disable-libdebuginfod \


### PR DESCRIPTION
Fedora 42 updated to GCC15 which now defaults to GNU23 as the default instead of GNU17[1], and this breaks m4 compilation.

This looks like a gnulib issue, so until that is updated/fixed lets simply set C language version back to GNU17.

[1] https://gcc.gnu.org/gcc-15/porting_to.html#c23

Link: https://github.com/openwrt/openwrt/pull/18506
