### PR TITLE
mpfr: import from packages feed

### DIFF
--- a/package/libs/mpfr/Makefile
+++ b/package/libs/mpfr/Makefile
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2023 Jeffery To
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=mpfr
+PKG_VERSION:=4.2.1
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=@GNU/mpfr http://www.mpfr.org/mpfr-$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
+PKG_HASH:=277807353a6726978996945af13e52829e3abd7a9a5b7fb2793894e18f1fcbb2
+
+PKG_LICENSE:=LGPL-3.0-or-later
+PKG_LICENSE_FILES:=COPYING.LESSER
+PKG_MAINTAINER:=Jeffery To <jeffery.to@gmail.com>
+PKG_CPE_ID:=cpe:/a:mpfr:gnu_mpfr
+
+PKG_BUILD_PARALLEL:=1
+PKG_FIXUP:=autoreconf
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/libmpfr
+  SECTION:=libs
+  CATEGORY:=Libraries
+  TITLE:=GNU MPFR library
+  URL:=https://www.mpfr.org/
+  DEPENDS:=+libgmp
+  ABI_VERSION:=6
+endef
+
+define Package/libmpfr/description
+MPFR is a portable library written in C for arbitrary precision
+arithmetic on floating-point numbers. It is based on the GNU MP library.
+It aims to provide a class of floating-point numbers with precise
+semantics.
+endef
+
+CONFIGURE_ARGS += \
+	--enable-thread-safe
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/mpf* $(1)/usr/include/
+
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmpfr.{a,so*} $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/mpfr.pc $(1)/usr/lib/pkgconfig/
+endef
+
+define Package/libmpfr/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libmpfr.so.* $(1)/usr/lib/
+endef
+
+$(eval $(call BuildPackage,libmpfr))

--- a/package/libs/mpfr/patches/001-only-src.patch
+++ b/package/libs/mpfr/patches/001-only-src.patch
@@ -1,0 +1,22 @@
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -38,7 +38,7 @@ AUTOMAKE_OPTIONS = gnu
+ # old Automake version.
+ ACLOCAL_AMFLAGS = -I m4
+ 
+-SUBDIRS = doc src tests tune tools/bench
++SUBDIRS = src
+ 
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = mpfr.pc
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -401,7 +401,7 @@ AUTOMAKE_OPTIONS = gnu
+ # libtoolize and in case some developer needs to switch back to an
+ # old Automake version.
+ ACLOCAL_AMFLAGS = -I m4
+-SUBDIRS = doc src tests tune tools/bench
++SUBDIRS = src
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = mpfr.pc
+ nobase_dist_doc_DATA = AUTHORS BUGS COPYING COPYING.LESSER NEWS TODO \


### PR DESCRIPTION
Import mpfr from the packages feed to the main OpenWrt repo, as gdb 14 requires mpfr.

上游：https://github.com/openwrt/openwrt/commit/309c2cd4fbd2876a144bb4423428363f36c67a3f