### PR TITLE
image: allow to specific ROOTFS_PARTSIZE

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -51,6 +51,7 @@ image:
 	make image EXTRA_IMAGE_NAME="<string>" # Add this to the output image filename (sanitized)
 	make image DISABLED_SERVICES="<svc1> [<svc2> [<svc3> ..]]" # Which services in /etc/init.d/ should be disabled
 	make image ADD_LOCAL_KEY=1 # store locally generated signing key in built images
+	make image ROOTFS_PARTSIZE="<size>" # override the default rootfs partition size in MegaBytes
 
 manifest:
 	List "all" packages which get installed into the image.
@@ -261,7 +262,8 @@ image:
 		$(if $(FILES),USER_FILES="$(FILES)") \
 		$(if $(PACKAGES),USER_PACKAGES="$(PACKAGES)") \
 		$(if $(BIN_DIR),BIN_DIR="$(BIN_DIR)") \
-		$(if $(DISABLED_SERVICES),DISABLED_SERVICES="$(DISABLED_SERVICES)"))
+		$(if $(DISABLED_SERVICES),DISABLED_SERVICES="$(DISABLED_SERVICES)") \
+		$(if $(ROOTFS_PARTSIZE),CONFIG_TARGET_ROOTFS_PARTSIZE="$(ROOTFS_PARTSIZE)"))
 
 manifest: FORCE
 	$(MAKE) -s _check_profile


### PR DESCRIPTION
This change enables setting CONFIG_TARGET_ROOTFS_PARTSIZE from an external environment variable (ROOTFS_PARTSIZE) when building images with the ImageBuilder.

Example usage:
    make image ROOTFS_PARTSIZE=512

If ROOTFS_PARTSIZE is unset, the default value from .config will be used. This allows customizing image builds without modifying .config directly.


