### PR TITLE
mediatek: add support for Huasifei WS3009 device

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-huasifei-ws3009.dts
+++ b/target/linux/mediatek/dts/mt7981b-huasifei-ws3009.dts
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7981.dtsi"
+
+/ {
+	model = "Huasifei WS3009";
+	compatible = "huasifei,ws3009", "mediatek,mt7981";
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_running;
+		led-upgrade = &led_status;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: led_status {
+			label = "red:status";
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		
+		led_running: running_led {
+			label = "green:running";
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			label = "blue:internet";
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			label = "green:network1";
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			label = "green:network2";
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			label = "green:network3";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		m2_reset_1 {
+			gpio-export,name = "m2_reset_1";
+			gpio-export,output = <0>;
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		m2_reset_2 {
+			gpio-export,name = "m2_reset_2";
+			gpio-export,output = <0>;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		m2_reset_3 {
+			gpio-export,name = "m2_reset_3";
+			gpio-export,output = <0>;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		modem_pwr {
+			gpio-export,name = "modem_pwr";
+			gpio-export,output = <1>;
+			gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		dual_sim {
+			gpio-export,name = "modem_pwr2";
+			gpio-export,output = <1>;
+			gpios = <&pio 13 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cells = <&macaddr_factory_4 1>;
+		nvmem-cell-names = "mac-address";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-handle = <&phy0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cells = <&macaddr_factory_4 2>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+
+	phy0: ethernet-phy@0 {
+		compatible = "ethernet-phy-id03a2.9461";
+		reg = <0>;
+		phy-mode = "gmii";
+		nvmem-cells = <&phy_calibration>;
+		nvmem-cell-names = "phy-cal-data";
+	};
+
+	phy1: ethernet-phy@1 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <1>;
+		phy-mode = "2500base-x";
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>; /* 1 MiB */
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>; /* 0.5 MiB */
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>; /* 2 MiB */
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>; /* 2 MiB */
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0xe600000>; /* 230 MiB */
+			};
+
+			partition@7380000 {
+				label = "config";
+				reg = <0x7380000 0x80000>; /* 0.5 MiB */
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan4";
+		};
+
+
+		port@6 {
+			reg = <6>;
+			label = "cpu";
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -67,6 +67,9 @@ mediatek_setup_interfaces()
 	huasifei,ws3006)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 eth1" "wan"
 		;;
+	huasifei,ws3009)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
+		;;
 	mediatek,mt7986a-rfb|\
 	mediatek,mt7986b-rfb)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3" eth1

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -62,7 +62,8 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;
-	huasifei,ws3006)
+	huasifei,ws3006\|\
+	huasifei,ws3009)
 		addr=$(mtd_get_mac_binary Factory 0x04)
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
 		;;

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -565,6 +565,21 @@ define Device/huasifei_ws3006
 endef
 TARGET_DEVICES += huasifei_ws3006
 
+define Device/huasifei_ws3009
+  DEVICE_VENDOR := Huasifei
+  DEVICE_MODEL := WS3009
+  DEVICE_DTS := mt7981b-huasifei-ws3009
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 112640k
+  KERNEL_IN_UBI := 1
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += huasifei_ws3009
+
 define Device/hf_m7986r1-emmc
   DEVICE_VENDOR := HF
   DEVICE_MODEL := M7986R1 (eMMC)


### PR DESCRIPTION

添加Huasifei WS3009支持，支持3组5G模组
闪存为spi nor 256M 
布局为
BL2 <0x0 0x100000>; /* 1 MiB */
u-boot-env <0x100000 0x80000>; /* 0.5 MiB */
Factory <0x180000 0x200000>; /* 2 MiB */
FIP <0x380000 0x200000>; /* 2 MiB */
ubi <0x580000 0xe600000>; /* 230 MiB */
config <0x7380000 0x80000>; /* 0.5 MiB */