### PR TITLE
hostapd: Fix compile against mbedtsl 3.6

### DIFF
--- a/package/network/services/hostapd/patches/110-mbedtls-TLS-crypto-option-initial-port.patch
+++ b/package/network/services/hostapd/patches/110-mbedtls-TLS-crypto-option-initial-port.patch
@@ -6460,7 +6460,7 @@ Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>
 +{
 +  #if !defined(MBEDTLS_USE_PSA_CRYPTO) /* XXX: (not extracted for PSA crypto) */
 +  #if defined(MBEDTLS_SSL_PROTO_TLS1_3)
-+    if (tls_version == MBEDTLS_SSL_VERSION_TLS1_3)
++    if (mbedtls_ssl_get_version_number(ssl) == MBEDTLS_SSL_VERSION_TLS1_3)
 +        return 0; /* (calculation not extracted) */
 +  #endif /* MBEDTLS_SSL_PROTO_TLS1_3 */
 +


### PR DESCRIPTION
## hostapd
- Fix compile against mbedtsl `3.6`
- Fix compile of the mbedtls extension for hostapd.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>

## Reference

- [mbedtls: update to version 3.6.5](/coolsnowwolf/lede/commit/5656c258fddfcb41a0276699baa08baf0fcecf8f)

- [openwrt/hostapd](/openwrt/openwrt/commit/00a1671248399db056afdfd682f9bf4aeca7ce4f)