### PR TITLE
build: Add compatibility to uutils

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -161,8 +161,8 @@ $(eval $(call SetupHostCommand,bzip2,Please install 'bzip2', \
 $(eval $(call SetupHostCommand,wget,Please install GNU 'wget', \
 	wget --version | grep GNU))
 
-$(eval $(call SetupHostCommand,install,Please install GNU 'install', \
-	install --version | grep GNU, \
+$(eval $(call SetupHostCommand,install,Please install 'install', \
+	install --version | grep GNU\|uutils', \
 	ginstall --version | grep GNU))
 
 $(eval $(call SetupHostCommand,perl,Please install Perl 5.x, \


### PR DESCRIPTION
Add compatibility to uutils' coreutils so it can be used instead of GNU coreutils.

Testing Details
build pass by: 
- **Version:SNAPSHOT**
- **Target/Subtarget:ramips/mt7621**
- **Device:Xiaomi Redmi Router AC2100**

Building Environment
- **OS:Ubuntu Resolute Raccoon (development branch) x86_64**
- **install Version:(uutils coreutils) 0.2.2**

