### PR TITLE
Override the value of the PRG_ETH registers via device tree properties.

### DIFF
--- a/target/linux/amlogic/patches-6.12/100-Override-the-value-of-the-PRG_ETH-registers-via-device-tree-properties.patch
+++ b/target/linux/amlogic/patches-6.12/100-Override-the-value-of-the-PRG_ETH-registers-via-device-tree-properties.patch
@@ -1,0 +1,53 @@
+From 593a25111913a20198f337b691659860d94642af Mon Sep 17 00:00:00 2001
+From: retro98boy <retro98boy@qq.com>
+Date: Sun, 10 Aug 2025 13:29:24 +0800
+Subject: [PATCH] net: stmmac: meson8b: Override the value of the PRG_ETH
+ registers via device tree properties
+
+---
+ .../ethernet/stmicro/stmmac/dwmac-meson8b.c   | 25 +++++++++++++++++++
+ 1 file changed, 25 insertions(+)
+
+diff --git a/drivers/net/ethernet/stmicro/stmmac/dwmac-meson8b.c b/drivers/net/ethernet/stmicro/stmmac/dwmac-meson8b.c
+index b23944aa34..92cd78bcc7 100644
+--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-meson8b.c
++++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-meson8b.c
+@@ -389,6 +389,29 @@ static int meson8b_init_prg_eth(struct meson8b_dwmac *dwmac)
+ 	return 0;
+ }
+ 
++static int meson8b_prg_eth_override(struct meson8b_dwmac *dwmac)
++{
++	struct device_node *np = dwmac->dev->of_node;
++	u32 override[2] = { 0 };
++	int ret;
++
++	ret = of_property_read_u32_array(np, "amlogic,prg-eth-reg0", override,
++					 2);
++	if (!ret) {
++		meson8b_dwmac_mask_bits(dwmac, PRG_ETH0, override[0],
++					override[1]);
++	}
++
++	ret = of_property_read_u32_array(np, "amlogic,prg-eth-reg1", override,
++					 2);
++	if (!ret) {
++		meson8b_dwmac_mask_bits(dwmac, PRG_ETH1, override[0],
++					override[1]);
++	}
++
++	return 0;
++}
++
+ static int meson8b_dwmac_probe(struct platform_device *pdev)
+ {
+ 	struct plat_stmmacenet_data *plat_dat;
+@@ -473,6 +496,8 @@ static int meson8b_dwmac_probe(struct platform_device *pdev)
+ 	if (ret)
+ 		return ret;
+ 
++	meson8b_prg_eth_override(dwmac);
++
+ 	plat_dat->bsp_priv = dwmac;
+ 
+ 	return stmmac_dvr_probe(&pdev->dev, plat_dat, &stmmac_res);


### PR DESCRIPTION
override the values of the PRG_ETH registers via device tree properties.

refer https://github.com/unifreq/linux-6.12.y/commit/593a25111913a

通过这个补丁，可以在设备树中配置PRG_ETH，解决网心云oes/oesp设备某些批次存在的网络问题

参考 https://github.com/retro98boy/onethingcloud-oes-linux#%E4%B8%8D%E5%90%8C%E7%89%88%E6%9C%ACoes%E7%9A%84gbe%E9%97%AE%E9%A2%98




