### PR TITLE
support glinet_gl-mt5000

### DIFF
--- a/target/linux/mediatek/dts/mt7987a-gl-mt5000.dts
+++ b/target/linux/mediatek/dts/mt7987a-gl-mt5000.dts
@@ -1,0 +1,207 @@
+/* SPDX-License-Identifier: (GPL-2.0 OR MIT) */
+
+/dts-v1/;
+#include "mt7987a.dtsi"
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "GL.iNet GL-MT5000";
+	compatible = "glinet,gl-mt5000",
+				"mediatek,mt7987a", "mediatek,mt7987";
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n1 loglevel=8  \
+				earlycon=uart8250,mmio32,0x11000000 \
+				root=PARTLABEL=rootfs rootwait \
+			    rootfstype=squashfs,f2fs pci=pcie_bus_perf";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+			debounce-interval = <10>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		usb_power {
+			gpio-export,name = "usb_power";
+			gpio-export,output = <1>;
+			gpios = <&pio 9 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: led@0 {
+			label = "blue:run";
+			gpios = <&pio 44 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led@1 {
+			label = "white:system";
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led@2 {
+			label = "vpn";
+			gpios = <&pio 43 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	reg_1p8v: regulator-1p8v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-1.8V";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};	
+};
+
+&mmc0 {
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc_pins_default>;
+	pinctrl-1 = <&mmc_pins_uhs>;
+	bus-width = <8>;
+	max-frequency = <26000000>;
+	cap-mmc-highspeed;
+	vqmmc-supply = <&reg_3p3v>;
+	vmmc-supply = <&reg_3p3v>;
+	mmc-ddr-3_3v;
+	non-removable;
+	no-sd;
+	no-sdio;
+	status = "okay";
+
+	card@0 {
+		compatible = "mmc-card";
+		reg = <0>;
+
+		block {
+			compatible = "block-device";
+			partitions {
+				block-partition-env {
+					partname = "u-boot-env";
+
+					nvmem-layout {
+						compatible = "u-boot,env";
+					};
+				};
+
+				block-partition-factory {
+					partname = "factory";
+
+					nvmem-layout {
+						compatible = "fixed-layout";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						macaddr_base: macaddr@4000 {
+							compatible = "mac-base";
+							reg = <0x4000 0x6>;
+							#nvmem-cell-cells = <1>;
+						};
+					};
+
+				};
+			};
+		};
+	};
+};
+
+&gmac0 {
+	compatible = "mediatek,eth-mac";
+	reg = <0>;
+	mac-type = "gdm";
+	phy-mode = "2500base-x";
+	status = "okay";
+	nvmem-cells = <&macaddr_base 0>;
+	nvmem-cell-names = "mac-address";
+
+	fixed-link {
+		speed = <2500>;
+		full-duplex;
+		pause;
+	};
+};
+
+&gmac1 {
+	reg = <1>;
+	mac-type = "xgdm";
+	phy-mode = "internal";
+	phy-handle = <&phy15>;
+	status = "okay";
+	nvmem-cells = <&macaddr_base 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	reset-gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <10000>;
+
+	phy15: phy@f {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <15>;
+		pinctrl-names = "i2p5gbe-led";
+		pinctrl-0 = <&i2p5gbe_led0_pins>;
+		phy-mode = "internal";
+	};
+};
+
+&ssusb {
+	status = "okay";
+};
+
+&tphyu3port0 {
+	status = "okay";
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+	status = "okay";
+};
+
+&infra_bus_prot {
+	status = "okay";
+};
+
+&boottrap {
+	status = "okay";
+};
+
+&trng {
+	status = "okay";
+};
+
+&lvts {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -37,6 +37,7 @@ mediatek_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 sfp2" "eth1 wan"
 		;;
 	bananapi,bpi-r3-mini|\
+	glinet,gl-mt5000|\
 	huasifei,wh3000-emmc|\
 	huasifei,wh3000-pro)
 		ucidef_set_interfaces_lan_wan eth0 eth1

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -48,6 +48,7 @@ platform_do_upgrade() {
 	cmcc,rax3000m-emmc|\
 	cmcc,xr30-emmc|\
 	glinet,gl-mt2500|\
+	glinet,gl-mt5000|\
 	glinet,gl-mt6000|\
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\
@@ -110,6 +111,7 @@ platform_copy_config() {
 	cmcc,rax3000m-emmc|\
 	cmcc,xr30-emmc|\
 	glinet,gl-mt2500|\
+	glinet,gl-mt5000|\
 	glinet,gl-mt6000|\
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -536,6 +536,20 @@ define Device/glinet_gl-mt3000
 endef
 TARGET_DEVICES += glinet_gl-mt3000
 
+define Device/glinet_gl-mt5000
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := GL-MT5000
+  DEVICE_DTS := mt7987a-gl-mt5000
+  DEVICE_DTS_DIR := ../dts
+  SUPPORTED_DEVICES := glinet,gl-mt5000
+  DEVICE_PACKAGES := mkf2fs blkid blockdev kmod-fs-ext4 mt7987-2p5g-phy-firmware \
+                     kmod-mmc kmod-fs-f2fs kmod-fs-vfat
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to 32M | append-rootfs
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += glinet_gl-mt5000
+
 define Device/glinet_gl-mt6000
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-MT6000


### PR DESCRIPTION
This patch adds support for GL.iNet MT5000.

The GL.iNet MT5000 is a gateway device equipped with three 2.5G Ethernet ports, two of which are LAN ports and one is a WAN port. Currently, this submission does not support LAN-to-LAN communication; only WAN-to-LAN functionality is guaranteed to operate normally.

Hardware Specification:

- SoC: MediaTek MT7987A (Quad-core ARM Cortex-A53 2.0 GHz)
- RAM: 1024 MiB DDR4
- Flash: 8192 MiB EMMC
- Ethernet:
- - 2x 10/100/1000/2500 Mbps LAN (Realtek RTL8366ub Switch)
- - 1x 10/100/1000/2500 Mbps LAN (SoC internal PHY)
- Buttons: Reset,
- LEDs: 3x (Blue: Run, White: System, White: Vpn)
- UART: 115200 8n1 (VCC, RX, TX, GND)

Flash Layout:
- 0x0~0x4400 : GPT
- 0x400000~0x480000 : u-boot-env
- 0x480000~0x880000 : Factory
- 0x880000~0xa80000 : fip
- 0xa80000~0xc80000 : cfg
- 0xc80000~0xe80000 : log
- 0xe80000~0x2e80000 : kernel
- 0x2e80000~0x12a80000: rootfs

MAC Addresses (NVMEM):
- Base MAC located at Factory partition offset 0x4
- gmac1 (WAN) : Base - 2 (Label MAC)
- gmac0 (LAN) : Base - 1

Installation:

1. You can directly upgrade using the openwrt-mediatek-filogic-glinet_gl-mt5000-squashfs-sysupgrade.bin image on the official GL firmware upgrade page.

2. Access the device and use the sysupgrade command to upgrade.Note: When upgrading from official firmware, use the -n parameter to preserve no configuration.
