### PR TITLE
argp-standalone: add 'no-lto' symbol for PKG_BUILD_FLAGS

### DIFF
--- a/package/libs/argp-standalone/Makefile
+++ b/package/libs/argp-standalone/Makefile
@@ -18,6 +18,7 @@ PKG_MAINTAINER:=Ted Hess <thess@kitschensync.net>
 
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE:=Makefile.am
+PKG_BUILD_FLAGS:=no-lto
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/host-build.mk


### PR DESCRIPTION
<!--
# Pull Request 规则，创建时请删除

- 禁止有关 "GitHub Actions" 的提交
- 禁止使用 users.noreply.github.com 提交
--->
解决当设置CONFIG_USE_LTO=y时elfutils的依赖argp-standalone编译失败的问题。
参考：https://github.com/openwrt/openwrt/commit/9fe7cc62a6ca49e81e5656ace144e35c31a9a408

This resolves an issue where the elfutils dependency argp-standalone fails to compile when CONFIG_USE_LTO=y is set.
Reference: https://github.com/openwrt/openwrt/commit/9fe7cc62a6ca49e81e5656ace144e35c31a9a408