### PR TITLE
toolchain: gcc: add support for GCC 15.2

### DIFF
--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -21,6 +21,9 @@ choice
 		
 	config GCC_USE_VERSION_14
 		bool "gcc 14.x"
+
+	config GCC_USE_VERSION_15
+		bool "gcc 15.x"
 endchoice
 
 config GCC_USE_GRAPHITE

--- a/toolchain/gcc/Config.version
+++ b/toolchain/gcc/Config.version
@@ -15,10 +15,15 @@ config GCC_VERSION_14
 	default y if GCC_USE_VERSION_14
 	bool
 
+config GCC_VERSION_15
+	default y if GCC_USE_VERSION_15
+	bool
+
 config GCC_VERSION
 	string
 	default "8.4.0"		if GCC_VERSION_8
 	default "11.3.0"	if GCC_VERSION_11
 	default "12.2.0"	if GCC_VERSION_12
 	default "14.3.0"	if GCC_VERSION_14
+	default "15.2.0"	if GCC_VERSION_15
 	default "13.3.0"

--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -49,6 +49,10 @@ ifeq ($(PKG_VERSION),14.3.0)
   PKG_HASH:=e0dc77297625631ac8e50fa92fffefe899a4eb702592da5c32ef04e2293aca3a
 endif
 
+ifeq ($(PKG_VERSION),15.2.0)
+  PKG_HASH:=438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e
+endif
+
 PATCH_DIR=../patches-$(GCC_MAJOR_VERSION).x
 
 BUGURL=http://bugs.openwrt.org/

--- a/toolchain/gcc/patches-15.x/002-case_insensitive.patch
+++ b/toolchain/gcc/patches-15.x/002-case_insensitive.patch
@@ -1,0 +1,24 @@
+commit 81cc26c706b2bc8c8c1eb1a322e5c5157900836e
+Author: Felix Fietkau <nbd@openwrt.org>
+Date:   Sun Oct 19 21:45:51 2014 +0000
+
+    gcc: do not assume that the Mac OS X filesystem is case insensitive
+    
+    Signed-off-by: Felix Fietkau <nbd@openwrt.org>
+    
+    SVN-Revision: 42973
+
+--- a/include/filenames.h
++++ b/include/filenames.h
+@@ -44,11 +44,6 @@ extern "C" {
+ #  define IS_DIR_SEPARATOR(c) IS_DOS_DIR_SEPARATOR (c)
+ #  define IS_ABSOLUTE_PATH(f) IS_DOS_ABSOLUTE_PATH (f)
+ #else /* not DOSish */
+-#  if defined(__APPLE__)
+-#    ifndef HAVE_CASE_INSENSITIVE_FILE_SYSTEM
+-#      define HAVE_CASE_INSENSITIVE_FILE_SYSTEM 1
+-#    endif
+-#  endif /* __APPLE__ */
+ #  define HAS_DRIVE_SPEC(f) (0)
+ #  define IS_DIR_SEPARATOR(c) IS_UNIX_DIR_SEPARATOR (c)
+ #  define IS_ABSOLUTE_PATH(f) IS_UNIX_ABSOLUTE_PATH (f)

--- a/toolchain/gcc/patches-15.x/003-dont-choke-when-building-32bit-on-64bit.patch
+++ b/toolchain/gcc/patches-15.x/003-dont-choke-when-building-32bit-on-64bit.patch
@@ -1,0 +1,13 @@
+--- a/gcc/real.h
++++ b/gcc/real.h
+@@ -77,8 +77,10 @@ struct GTY(()) real_value {
+    + (REAL_VALUE_TYPE_SIZE%HOST_BITS_PER_WIDE_INT ? 1 : 0)) /* round up */
+ 
+ /* Verify the guess.  */
++#ifndef __LP64__
+ extern char test_real_width
+   [sizeof (REAL_VALUE_TYPE) <= REAL_WIDTH * sizeof (HOST_WIDE_INT) ? 1 : -1];
++#endif
+ 
+ /* Calculate the format for CONST_DOUBLE.  We need as many slots as
+    are necessary to overlay a REAL_VALUE_TYPE on them.  This could be

--- a/toolchain/gcc/patches-15.x/010-documentation.patch
+++ b/toolchain/gcc/patches-15.x/010-documentation.patch
@@ -1,0 +1,35 @@
+commit 098bd91f5eae625c7d2ee621e10930fc4434e5e2
+Author: Luka Perkov <luka@openwrt.org>
+Date:   Tue Feb 26 16:16:33 2013 +0000
+
+    gcc: don't build documentation
+    
+    This closes #13039.
+    
+    Signed-off-by: Luka Perkov <luka@openwrt.org>
+    
+    SVN-Revision: 35807
+
+--- a/gcc/Makefile.in
++++ b/gcc/Makefile.in
+@@ -3747,18 +3747,10 @@ doc/gcc.info: $(TEXI_GCC_FILES)
+ doc/gccint.info: $(TEXI_GCCINT_FILES)
+ doc/cppinternals.info: $(TEXI_CPPINT_FILES)
+ 
+-doc/%.info: %.texi
+-	if [ x$(BUILD_INFO) = xinfo ]; then \
+-		$(MAKEINFO) $(MAKEINFOFLAGS) -I . -I $(gcc_docdir) \
+-			-I $(gcc_docdir)/include -o $@ $<; \
+-	fi
++doc/%.info:
+ 
+ # Duplicate entry to handle renaming of gccinstall.info
+-doc/gccinstall.info: $(TEXI_GCCINSTALL_FILES)
+-	if [ x$(BUILD_INFO) = xinfo ]; then \
+-		$(MAKEINFO) $(MAKEINFOFLAGS) -I $(gcc_docdir) \
+-			-I $(gcc_docdir)/include -o $@ $<; \
+-	fi
++doc/gccinstall.info:
+ 
+ doc/cpp.dvi: $(TEXI_CPP_FILES)
+ doc/gcc.dvi: $(TEXI_GCC_FILES)

--- a/toolchain/gcc/patches-15.x/110-Fix-MIPS-PR-84790.patch
+++ b/toolchain/gcc/patches-15.x/110-Fix-MIPS-PR-84790.patch
@@ -1,0 +1,20 @@
+Fix https://gcc.gnu.org/bugzilla/show_bug.cgi?id=84790.
+MIPS16 functions have a static assembler prologue which clobbers
+registers v0 and v1. Add these register clobbers to function call
+instructions.
+
+--- a/gcc/config/mips/mips.cc
++++ b/gcc/config/mips/mips.cc
+@@ -3293,6 +3293,12 @@ mips_emit_call_insn (rtx pattern, rtx or
+       emit_insn (gen_update_got_version ());
+     }
+ 
++  if (TARGET_MIPS16 && TARGET_USE_GOT)
++    {
++      clobber_reg (&CALL_INSN_FUNCTION_USAGE (insn), MIPS16_PIC_TEMP);
++      clobber_reg (&CALL_INSN_FUNCTION_USAGE (insn), MIPS_PROLOGUE_TEMP (word_mode));
++    }
++
+   if (TARGET_MIPS16
+       && TARGET_EXPLICIT_RELOCS
+       && TARGET_CALL_CLOBBERED_GP)

--- a/toolchain/gcc/patches-15.x/230-musl_libssp.patch
+++ b/toolchain/gcc/patches-15.x/230-musl_libssp.patch
@@ -1,0 +1,13 @@
+--- a/gcc/gcc.cc
++++ b/gcc/gcc.cc
+@@ -992,7 +992,9 @@ proper position among the other output f
+ #endif
+ 
+ #ifndef LINK_SSP_SPEC
+-#ifdef TARGET_LIBC_PROVIDES_SSP
++#if DEFAULT_LIBC == LIBC_MUSL
++#define LINK_SSP_SPEC "-lssp_nonshared"
++#elif defined(TARGET_LIBC_PROVIDES_SSP)
+ #define LINK_SSP_SPEC "%{fstack-protector|fstack-protector-all" \
+ 		       "|fstack-protector-strong|fstack-protector-explicit:}"
+ #else

--- a/toolchain/gcc/patches-15.x/300-mips_Os_cpu_rtx_cost_model.patch
+++ b/toolchain/gcc/patches-15.x/300-mips_Os_cpu_rtx_cost_model.patch
@@ -1,0 +1,21 @@
+commit ecf7671b769fe96f7b5134be442089f8bdba55d2
+Author: Felix Fietkau <nbd@nbd.name>
+Date:   Thu Aug 4 20:29:45 2016 +0200
+
+gcc: add a patch to generate better code with Os on mips
+
+Also happens to reduce compressed code size a bit
+
+Signed-off-by: Felix Fietkau <nbd@nbd.name>
+
+--- a/gcc/config/mips/mips.cc
++++ b/gcc/config/mips/mips.cc
+@@ -20605,7 +20605,7 @@ mips_option_override (void)
+     flag_pcc_struct_return = 0;
+ 
+   /* Decide which rtx_costs structure to use.  */
+-  if (optimize_size)
++  if (0 && optimize_size)
+     mips_cost = &mips_rtx_cost_optimize_size;
+   else
+     mips_cost = &mips_rtx_cost_data[mips_tune];

--- a/toolchain/gcc/patches-15.x/800-arm_v5te_no_ldrd_strd.patch
+++ b/toolchain/gcc/patches-15.x/800-arm_v5te_no_ldrd_strd.patch
@@ -1,0 +1,11 @@
+--- a/gcc/config/arm/arm.h
++++ b/gcc/config/arm/arm.h
+@@ -165,7 +165,7 @@ emission of floating point pcs attribute
+ /* Thumb-1 only.  */
+ #define TARGET_THUMB1_ONLY		(TARGET_THUMB1 && !arm_arch_notm)
+ 
+-#define TARGET_LDRD			(arm_arch5te && ARM_DOUBLEWORD_ALIGN \
++#define TARGET_LDRD			(arm_arch6 && ARM_DOUBLEWORD_ALIGN \
+                                          && !TARGET_THUMB1)
+ 
+ #define TARGET_CRC32			(arm_arch_crc)

--- a/toolchain/gcc/patches-15.x/810-arm-softfloat-libgcc.patch
+++ b/toolchain/gcc/patches-15.x/810-arm-softfloat-libgcc.patch
@@ -1,0 +1,33 @@
+commit 8570c4be394cff7282f332f97da2ff569a927ddb
+Author: Imre Kaloz <kaloz@openwrt.org>
+Date:   Wed Feb 2 20:06:12 2011 +0000
+
+    fixup arm soft-float symbols
+    
+    SVN-Revision: 25325
+
+--- a/libgcc/config/arm/t-linux
++++ b/libgcc/config/arm/t-linux
+@@ -1,6 +1,10 @@
+ LIB1ASMSRC = arm/lib1funcs.S
+ LIB1ASMFUNCS = _udivsi3 _divsi3 _umodsi3 _modsi3 _dvmd_lnx _clzsi2 _clzdi2 \
+-	_ctzsi2 _arm_addsubdf3 _arm_addsubsf3
++	_ctzsi2 _arm_addsubdf3 _arm_addsubsf3 \
++	_arm_negdf2 _arm_muldivdf3 _arm_cmpdf2 _arm_unorddf2 \
++	_arm_fixdfsi _arm_fixunsdfsi _arm_truncdfsf2 \
++	_arm_negsf2 _arm_muldivsf3 _arm_cmpsf2 _arm_unordsf2 \
++	_arm_fixsfsi _arm_fixunssfsi
+ 
+ # Just for these, we omit the frame pointer since it makes such a big
+ # difference.
+--- a/gcc/config/arm/linux-elf.h
++++ b/gcc/config/arm/linux-elf.h
+@@ -58,8 +58,6 @@
+    %{shared:-lc} \
+    %{!shared:%{profile:-lc_p}%{!profile:-lc}}"
+ 
+-#define LIBGCC_SPEC "%{mfloat-abi=soft*:-lfloat} -lgcc"
+-
+ #define GLIBC_DYNAMIC_LINKER "/lib/ld-linux.so.2"
+ 
+ #define LINUX_TARGET_LINK_SPEC  "%{h*} \

--- a/toolchain/gcc/patches-15.x/820-libgcc_pic.patch
+++ b/toolchain/gcc/patches-15.x/820-libgcc_pic.patch
@@ -1,0 +1,44 @@
+commit c96312958c0621e72c9b32da5bc224ffe2161384
+Author: Felix Fietkau <nbd@openwrt.org>
+Date:   Mon Oct 19 23:26:09 2009 +0000
+
+    gcc: create a proper libgcc_pic.a static library for relinking (4.3.3+ for now, backport will follow)
+    
+    SVN-Revision: 18086
+
+--- a/libgcc/Makefile.in
++++ b/libgcc/Makefile.in
+@@ -944,11 +944,12 @@ $(libgcov-driver-objects): %$(objext): $
+ 
+ # Static libraries.
+ libgcc.a: $(libgcc-objects)
++libgcc_pic.a: $(libgcc-s-objects)
+ libgcov.a: $(libgcov-objects)
+ libunwind.a: $(libunwind-objects)
+ libgcc_eh.a: $(libgcc-eh-objects)
+ 
+-libgcc.a libgcov.a libunwind.a libgcc_eh.a:
++libgcc.a libgcov.a libunwind.a libgcc_eh.a libgcc_pic.a:
+ 	-rm -f $@
+ 
+ 	objects="$(objects)";					\
+@@ -972,7 +973,7 @@ all: libunwind.a
+ endif
+ 
+ ifeq ($(enable_shared),yes)
+-all: libgcc_eh.a libgcc_s$(SHLIB_EXT)
++all: libgcc_eh.a libgcc_pic.a libgcc_s$(SHLIB_EXT)
+ ifneq ($(LIBUNWIND),)
+ all: libunwind$(SHLIB_EXT)
+ libgcc_s$(SHLIB_EXT): libunwind$(SHLIB_EXT)
+@@ -1181,6 +1182,10 @@ install-shared:
+ 	chmod 644 $(DESTDIR)$(inst_libdir)/libgcc_eh.a
+ 	$(RANLIB) $(DESTDIR)$(inst_libdir)/libgcc_eh.a
+ 
++	$(INSTALL_DATA) libgcc_pic.a $(mapfile) $(DESTDIR)$(inst_libdir)/
++	chmod 644 $(DESTDIR)$(inst_libdir)/libgcc_pic.a
++	$(RANLIB) $(DESTDIR)$(inst_libdir)/libgcc_pic.a
++
+ 	$(subst @multilib_dir@,$(MULTIDIR),$(subst \
+ 		@shlib_base_name@,libgcc_s,$(subst \
+ 		@shlib_slibdir_qual@,$(MULTIOSSUBDIR),$(SHLIB_INSTALL))))

--- a/toolchain/gcc/patches-15.x/830-aarch64-libatomic.patch
+++ b/toolchain/gcc/patches-15.x/830-aarch64-libatomic.patch
@@ -1,0 +1,32 @@
+libatomic: Do not enforce march on aarch64
+
+Inspired by The Yocto Project [1].
+
+[1] https://github.com/yoctoproject/poky/blob/51192a79f1717786dda42776f916c3d97ada7971/meta/recipes-devtools/gcc/gcc/0022-libatomic-Do-not-enforce-march-on-aarch64.patch
+
+Signed-off-by: Konstantin Demin <rockdrilla@gmail.com>
+
+ libatomic/Makefile.am | 1 -
+ libatomic/Makefile.in | 1 -
+ 2 files changed, 2 deletions(-)
+
+--- a/libatomic/Makefile.am
++++ b/libatomic/Makefile.am
+@@ -128,7 +128,6 @@ libatomic_la_LIBADD = $(foreach s,$(SIZE
+ ## On a target-specific basis, include alternates to be selected by IFUNC.
+ if HAVE_IFUNC
+ if ARCH_AARCH64_LINUX
+-IFUNC_OPTIONS	     = -march=armv8-a+lse
+ libatomic_la_LIBADD += $(foreach s,$(SIZES),$(addsuffix _$(s)_1_.lo,$(SIZEOBJS)))
+ 
+ endif
+--- a/libatomic/Makefile.in
++++ b/libatomic/Makefile.in
+@@ -452,7 +452,6 @@ M_SRC = $(firstword $(filter %/$(M_FILE)
+ libatomic_la_LIBADD = $(foreach s,$(SIZES),$(addsuffix \
+ 	_$(s)_.lo,$(SIZEOBJS))) $(am__append_1) $(am__append_2) \
+ 	$(am__append_3) $(am__append_4)
+-@ARCH_AARCH64_LINUX_TRUE@@HAVE_IFUNC_TRUE@IFUNC_OPTIONS = -march=armv8-a+lse
+ @ARCH_ARM_LINUX_TRUE@@HAVE_IFUNC_TRUE@IFUNC_OPTIONS = -march=armv7-a+fp -DHAVE_KERNEL64
+ @ARCH_I386_TRUE@@HAVE_IFUNC_TRUE@IFUNC_OPTIONS = -march=i586
+ @ARCH_X86_64_TRUE@@HAVE_IFUNC_TRUE@IFUNC_OPTIONS = -mcx16 -mcx16

--- a/toolchain/gcc/patches-15.x/840-armv4_pass_fix-v4bx_to_ld.patch
+++ b/toolchain/gcc/patches-15.x/840-armv4_pass_fix-v4bx_to_ld.patch
@@ -1,0 +1,28 @@
+commit 7edc8ca5456d9743dd0075eb3cc5b04f4f24c8cc
+Author: Imre Kaloz <kaloz@openwrt.org>
+Date:   Wed Feb 2 19:34:36 2011 +0000
+
+    add armv4 fixup patches
+    
+    SVN-Revision: 25322
+
+
+--- a/gcc/config/arm/linux-eabi.h
++++ b/gcc/config/arm/linux-eabi.h
+@@ -91,10 +91,15 @@
+ #define MUSL_DYNAMIC_LINKER \
+   "/lib/ld-musl-arm" MUSL_DYNAMIC_LINKER_E "%{mfloat-abi=hard:hf}%{mfdpic:-fdpic}.so.1"
+ 
++/* For armv4 we pass --fix-v4bx to linker to support EABI */
++#undef TARGET_FIX_V4BX_SPEC
++#define TARGET_FIX_V4BX_SPEC " %{mcpu=arm8|mcpu=arm810|mcpu=strongarm*"\
++  "|march=armv4|mcpu=fa526|mcpu=fa626:--fix-v4bx}"
++
+ /* At this point, bpabi.h will have clobbered LINK_SPEC.  We want to
+    use the GNU/Linux version, not the generic BPABI version.  */
+ #undef  LINK_SPEC
+-#define LINK_SPEC EABI_LINK_SPEC					\
++#define LINK_SPEC EABI_LINK_SPEC TARGET_FIX_V4BX_SPEC			\
+   LINUX_OR_ANDROID_LD (LINUX_TARGET_LINK_SPEC,				\
+ 		       LINUX_TARGET_LINK_SPEC " " ANDROID_LINK_SPEC)
+ 

--- a/toolchain/gcc/patches-15.x/850-use_shared_libgcc.patch
+++ b/toolchain/gcc/patches-15.x/850-use_shared_libgcc.patch
@@ -1,0 +1,54 @@
+commit dcfc40358b5a3cae7320c17f8d1cebd5ad5540cd
+Author: Felix Fietkau <nbd@openwrt.org>
+Date:   Sun Feb 12 20:25:47 2012 +0000
+
+    gcc 4.6: port over the missing patch 850-use_shared_libgcc.patch to prevent libgcc crap from leaking into every single binary
+    
+    SVN-Revision: 30486
+--- a/gcc/config/arm/linux-eabi.h
++++ b/gcc/config/arm/linux-eabi.h
+@@ -132,10 +132,6 @@
+   "%{Ofast|ffast-math|funsafe-math-optimizations:%{!shared:crtfastmath.o%s}} "	\
+   LINUX_OR_ANDROID_LD (GNU_USER_TARGET_ENDFILE_SPEC, ANDROID_ENDFILE_SPEC)
+ 
+-/* Use the default LIBGCC_SPEC, not the version in linux-elf.h, as we
+-   do not use -lfloat.  */
+-#undef LIBGCC_SPEC
+-
+ /* Clear the instruction cache from `beg' to `end'.  This is
+    implemented in lib1funcs.S, so ensure an error if this definition
+    is used.  */
+--- a/gcc/config/linux.h
++++ b/gcc/config/linux.h
+@@ -58,6 +58,10 @@ see the files COPYING3 and COPYING.RUNTI
+ 	builtin_assert ("system=posix");			\
+     } while (0)
+ 
++#ifndef LIBGCC_SPEC
++#define LIBGCC_SPEC "%{static|static-libgcc:-lgcc}%{!static:%{!static-libgcc:-lgcc_s}}"
++#endif
++
+ /* Determine which dynamic linker to use depending on whether GLIBC or
+    uClibc or Bionic or musl is the default C library and whether
+    -muclibc or -mglibc or -mbionic or -mmusl has been passed to change
+--- a/libgcc/mkmap-symver.awk
++++ b/libgcc/mkmap-symver.awk
+@@ -136,5 +136,5 @@ function output(lib) {
+   else if (inherit[lib])
+     printf("} %s;\n", inherit[lib]);
+   else
+-    printf ("\n  local:\n\t*;\n};\n");
++    printf ("\n\t*;\n};\n");
+ }
+--- a/gcc/config/rs6000/linux.h
++++ b/gcc/config/rs6000/linux.h
+@@ -70,6 +70,9 @@
+ #undef	CPP_OS_DEFAULT_SPEC
+ #define CPP_OS_DEFAULT_SPEC "%(cpp_os_linux)"
+ 
++#undef LIBGCC_SPEC
++#define LIBGCC_SPEC "%{!static:%{!static-libgcc:-lgcc_s}} -lgcc"
++
+ #undef  LINK_SHLIB_SPEC
+ #define LINK_SHLIB_SPEC "%{shared:-shared} %{!shared: %{static:-static}} \
+   %{static-pie:-static -pie --no-dynamic-linker -z text}"

--- a/toolchain/gcc/patches-15.x/851-libgcc_no_compat.patch
+++ b/toolchain/gcc/patches-15.x/851-libgcc_no_compat.patch
@@ -1,0 +1,22 @@
+commit 64661de100da1ec1061ef3e5e400285dce115e6b
+Author: Felix Fietkau <nbd@openwrt.org>
+Date:   Sun May 10 13:16:35 2015 +0000
+
+    gcc: add some size optimization patches
+    
+    Signed-off-by: Felix Fietkau <nbd@openwrt.org>
+    
+    SVN-Revision: 45664
+
+--- a/libgcc/config/t-libunwind
++++ b/libgcc/config/t-libunwind
+@@ -2,8 +2,7 @@
+ 
+ HOST_LIBGCC2_CFLAGS += -DUSE_GAS_SYMVER
+ 
+-LIB2ADDEH = $(srcdir)/unwind-sjlj.c $(srcdir)/unwind-c.c \
+-  $(srcdir)/unwind-compat.c $(srcdir)/unwind-dw2-fde-compat.c
++LIB2ADDEH = $(srcdir)/unwind-sjlj.c $(srcdir)/unwind-c.c
+ LIB2ADDEHSTATIC = $(srcdir)/unwind-sjlj.c $(srcdir)/unwind-c.c
+ 
+ # Override the default value from t-slibgcc-elf-ver and mention -lunwind

--- a/toolchain/gcc/patches-15.x/870-ppc_no_crtsavres.patch
+++ b/toolchain/gcc/patches-15.x/870-ppc_no_crtsavres.patch
@@ -1,0 +1,11 @@
+--- a/gcc/config/rs6000/rs6000-logue.cc
++++ b/gcc/config/rs6000/rs6000-logue.cc
+@@ -344,7 +344,7 @@ rs6000_savres_strategy (rs6000_stack_t *
+   /* Define cutoff for using out-of-line functions to save registers.  */
+   if (DEFAULT_ABI == ABI_V4 || TARGET_ELF)
+     {
+-      if (!optimize_size)
++      if (1)
+ 	{
+ 	  strategy |= SAVE_INLINE_FPRS | REST_INLINE_FPRS;
+ 	  strategy |= SAVE_INLINE_GPRS | REST_INLINE_GPRS;

--- a/toolchain/gcc/patches-15.x/881-no_tm_section.patch
+++ b/toolchain/gcc/patches-15.x/881-no_tm_section.patch
@@ -1,0 +1,11 @@
+--- a/libgcc/crtstuff.c
++++ b/libgcc/crtstuff.c
+@@ -152,7 +152,7 @@ call_ ## FUNC (void)					\
+ #endif
+ 
+ #if !defined(USE_TM_CLONE_REGISTRY) && defined(OBJECT_FORMAT_ELF)
+-# define USE_TM_CLONE_REGISTRY 1
++# define USE_TM_CLONE_REGISTRY 0
+ #elif !defined(USE_TM_CLONE_REGISTRY)
+ # define USE_TM_CLONE_REGISTRY 0
+ #endif

--- a/toolchain/gcc/patches-15.x/900-bad-mips16-crt.patch
+++ b/toolchain/gcc/patches-15.x/900-bad-mips16-crt.patch
@@ -1,0 +1,9 @@
+--- a/libgcc/config/mips/t-mips16
++++ b/libgcc/config/mips/t-mips16
+@@ -42,3 +42,6 @@ SYNC_CFLAGS = -mno-mips16
+ 
+ # Version these symbols if building libgcc.so.
+ SHLIB_MAPFILES += $(srcdir)/config/mips/libgcc-mips16.ver
++
++CRTSTUFF_T_CFLAGS += -mno-mips16
++CRTSTUFF_T_CFLAGS_S += -mno-mips16

--- a/toolchain/gcc/patches-15.x/910-mbsd_multi.patch
+++ b/toolchain/gcc/patches-15.x/910-mbsd_multi.patch
@@ -1,0 +1,146 @@
+commit 99368862e44740ff4fd33760893f04e14f9dbdf1
+Author: Felix Fietkau <nbd@openwrt.org>
+Date:   Tue Jul 31 00:52:27 2007 +0000
+
+    Port the mbsd_multi patch from freewrt, which adds -fhonour-copts. This will emit warnings in packages that don't use our target cflags properly
+    
+    SVN-Revision: 8256
+
+	This patch brings over a feature from MirBSD:
+	* -fhonour-copts
+	  If this option is not given, it's warned (depending
+	  on environment variables). This is to catch errors
+	  of misbuilt packages which override CFLAGS themselves.
+
+	This patch was authored by Thorsten Glaser <tg at mirbsd.de>
+	with copyright assignment to the FSF in effect.
+
+--- a/gcc/c-family/c-opts.cc
++++ b/gcc/c-family/c-opts.cc
+@@ -109,6 +109,9 @@ static size_t include_cursor;
+ /* Whether any standard preincluded header has been preincluded.  */
+ static bool done_preinclude;
+ 
++/* Check if a port honours COPTS.  */
++static int honour_copts = 0;
++
+ static void handle_OPT_d (const char *);
+ static void set_std_cxx98 (int);
+ static void set_std_cxx11 (int);
+@@ -503,6 +506,12 @@ c_common_handle_option (size_t scode, co
+       flag_no_builtin = !value;
+       break;
+ 
++    case OPT_fhonour_copts:
++      if (c_language == clk_c) {
++        honour_copts++;
++      }
++      break;
++
+     case OPT_fconstant_string_class_:
+       constant_string_class_name = arg;
+       break;
+@@ -1361,6 +1370,47 @@ c_common_init (void)
+       return false;
+     }
+ 
++  if (c_language == clk_c) {
++    char *ev = getenv ("GCC_HONOUR_COPTS");
++    int evv;
++    if (ev == NULL)
++      evv = -1;
++    else if ((*ev == '0') || (*ev == '\0'))
++      evv = 0;
++    else if (*ev == '1')
++      evv = 1;
++    else if (*ev == '2')
++      evv = 2;
++    else if (*ev == 's')
++      evv = -1;
++    else {
++      warning (0, "unknown GCC_HONOUR_COPTS value, assuming 1");
++      evv = 1; /* maybe depend this on something like MIRBSD_NATIVE?  */
++    }
++    if (evv == 1) {
++      if (honour_copts == 0) {
++        error ("someone does not honour COPTS at all in lenient mode");
++        return false;
++      } else if (honour_copts != 1) {
++        warning (0, "someone does not honour COPTS correctly, passed %d times",
++         honour_copts);
++      }
++    } else if (evv == 2) {
++      if (honour_copts == 0) {
++        error ("someone does not honour COPTS at all in strict mode");
++        return false;
++      } else if (honour_copts != 1) {
++        error ("someone does not honour COPTS correctly, passed %d times",
++         honour_copts);
++        return false;
++      }
++    } else if (evv == 0) {
++      if (honour_copts != 1)
++        inform (UNKNOWN_LOCATION, "someone does not honour COPTS correctly, passed %d times",
++         honour_copts);
++    }
++  }
++
+   return true;
+ }
+ 
+--- a/gcc/c-family/c.opt
++++ b/gcc/c-family/c.opt
+@@ -2008,6 +2008,9 @@ C++ ObjC++ Optimization Alias(fexception
+ fhonor-std
+ C++ ObjC++ WarnRemoved
+ 
++fhonour-copts
++C ObjC C++ ObjC++ RejectNegative
++
+ fhosted
+ C ObjC
+ Assume normal C execution environment.
+--- a/gcc/common.opt
++++ b/gcc/common.opt
+@@ -1938,6 +1938,9 @@ Enum(hardcfr_check_noreturn_calls) Strin
+ EnumValue
+ Enum(hardcfr_check_noreturn_calls) String(always) Value(HCFRNR_ALWAYS)
+ 
++fhonour-copts
++Common RejectNegative
++
+ ; Nonzero means ignore `#ident' directives.  0 means handle them.
+ ; Generate position-independent code for executables if possible
+ ; On SVR4 targets, it also controls whether or not to emit a
+--- a/gcc/doc/invoke.texi
++++ b/gcc/doc/invoke.texi
+@@ -10897,6 +10897,17 @@ This option is only supported for C and
+ 
+ This warning is upgraded to an error by @option{-pedantic-errors}.
+ 
++@item -fhonour-copts
++@opindex fhonour-copts
++If @env{GCC_HONOUR_COPTS} is set to 1, abort if this option is not
++given at least once, and warn if it is given more than once.
++If @env{GCC_HONOUR_COPTS} is set to 2, abort if this option is not
++given exactly once.
++If @env{GCC_HONOUR_COPTS} is set to 0 or unset, warn if this option
++is not given exactly once.
++The warning is quelled if @env{GCC_HONOUR_COPTS} is set to @samp{s}.
++This flag and environment variable only affect the C language.
++
+ @opindex Wstack-protector
+ @opindex Wno-stack-protector
+ @item -Wstack-protector
+--- a/gcc/opts.cc
++++ b/gcc/opts.cc
+@@ -2867,6 +2867,9 @@ common_handle_option (struct gcc_options
+       add_comma_separated_to_vector (&opts->x_flag_ignored_attributes, arg);
+       break;
+ 
++    case OPT_fhonour_copts:
++      break;
++
+     case OPT_Werror:
+       dc->set_warning_as_error_requested (value);
+       break;

--- a/toolchain/gcc/patches-15.x/920-specs_nonfatal_getenv.patch
+++ b/toolchain/gcc/patches-15.x/920-specs_nonfatal_getenv.patch
@@ -1,0 +1,22 @@
+Author: Jo-Philipp Wich <jow@openwrt.org>
+Date:   Sat Apr 21 03:02:39 2012 +0000
+
+    gcc: add patch to make the getenv() spec function nonfatal if requested environment variable is unset
+    
+    SVN-Revision: 31390
+
+--- a/gcc/gcc.cc
++++ b/gcc/gcc.cc
+@@ -10357,8 +10357,10 @@ getenv_spec_function (int argc, const ch
+     }
+ 
+   if (!value)
+-    fatal_error (input_location,
+-		 "environment variable %qs not defined", varname);
++    {
++      warning (input_location, "environment variable %qs not defined", varname);
++      value = "";
++    }
+ 
+   /* We have to escape every character of the environment variable so
+      they are not interpreted as active spec characters.  A

--- a/toolchain/gcc/patches-15.x/960-gotools-fix-compilation-when-making-cross-compiler.patch
+++ b/toolchain/gcc/patches-15.x/960-gotools-fix-compilation-when-making-cross-compiler.patch
@@ -1,0 +1,67 @@
+From dda6b050cd74a352670787a294596a9c56c21327 Mon Sep 17 00:00:00 2001
+From: Yousong Zhou <yszhou4tech@gmail.com>
+Date: Fri, 4 May 2018 18:20:53 +0800
+Subject: [PATCH] gotools: fix compilation when making cross compiler
+
+libgo is "the runtime support library for the Go programming language.
+This library is intended for use with the Go frontend."
+
+gccgo will link target files with libgo.so which depends on libgcc_s.so.1, but
+the linker will complain that it cannot find it.  That's because shared libgcc
+is not present in the install directory yet.  libgo.so was made without problem
+because gcc will emit -lgcc_s when compiled with -shared option.  When gotools
+were being made, it was supplied with -static-libgcc thus no link option was
+provided.  Check LIBGO in gcc/go/gcc-spec.c for how gccgo make a builtin spec
+for linking with libgo.so
+
+- GccgoCrossCompilation, https://github.com/golang/go/wiki/GccgoCrossCompilation
+- Cross-building instructions, http://www.eglibc.org/archives/patches/msg00078.html
+
+When 3-pass GCC compilation is used, shared libgcc runtime libraries will be
+available after gcc pass2 completed and will meet the gotools link requirement
+at gcc pass3
+---
+ gotools/Makefile.am | 4 +++-
+ gotools/Makefile.in | 4 +++-
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+--- a/gotools/Makefile.am
++++ b/gotools/Makefile.am
+@@ -26,6 +26,7 @@ PWD_COMMAND = $${PWDCMD-pwd}
+ STAMP = echo timestamp >
+ 
+ libgodir = ../$(target_noncanonical)/libgo
++libgccdir = ../$(target_noncanonical)/libgcc
+ LIBGODEP = $(libgodir)/libgo.la
+ 
+ LIBGOTOOL = $(libgodir)/libgotool.a
+@@ -41,7 +42,8 @@ GOCFLAGS = $(CFLAGS_FOR_TARGET)
+ GOCOMPILE = $(GOCOMPILER) $(GOCFLAGS)
+ 
+ AM_GOCFLAGS = -I $(libgodir)
+-AM_LDFLAGS = -L $(libgodir) -L $(libgodir)/.libs
++AM_LDFLAGS = -L $(libgodir) -L $(libgodir)/.libs \
++	-L $(libgccdir) -L $(libgccdir)/.libs -lgcc_s
+ GOLINK = $(GOCOMPILER) $(GOCFLAGS) $(AM_GOCFLAGS) $(LDFLAGS) $(AM_LDFLAGS) -o $@
+ 
+ libgosrcdir = $(srcdir)/../libgo/go
+--- a/gotools/Makefile.in
++++ b/gotools/Makefile.in
+@@ -337,6 +337,7 @@ mkinstalldirs = $(SHELL) $(toplevel_srcd
+ PWD_COMMAND = $${PWDCMD-pwd}
+ STAMP = echo timestamp >
+ libgodir = ../$(target_noncanonical)/libgo
++libgccdir = ../$(target_noncanonical)/libgcc
+ LIBGODEP = $(libgodir)/libgo.la
+ LIBGOTOOL = $(libgodir)/libgotool.a
+ @NATIVE_FALSE@GOCOMPILER = $(GOC)
+@@ -346,7 +347,8 @@ LIBGOTOOL = $(libgodir)/libgotool.a
+ GOCFLAGS = $(CFLAGS_FOR_TARGET)
+ GOCOMPILE = $(GOCOMPILER) $(GOCFLAGS)
+ AM_GOCFLAGS = -I $(libgodir)
+-AM_LDFLAGS = -L $(libgodir) -L $(libgodir)/.libs
++AM_LDFLAGS = -L $(libgodir) -L $(libgodir)/.libs \
++	-L $(libgccdir) -L $(libgccdir)/.libs -lgcc_s
+ GOLINK = $(GOCOMPILER) $(GOCFLAGS) $(AM_GOCFLAGS) $(LDFLAGS) $(AM_LDFLAGS) -o $@
+ libgosrcdir = $(srcdir)/../libgo/go
+ cmdsrcdir = $(libgosrcdir)/cmd

--- a/toolchain/gcc/patches-15.x/970-macos_arm64-building-fix.patch
+++ b/toolchain/gcc/patches-15.x/970-macos_arm64-building-fix.patch
@@ -1,0 +1,45 @@
+commit 9c6e71079b46ad5433165feaa2001450f2017b56
+Author: Przemysław Buczkowski <prem@prem.moe>
+Date:   Mon Aug 16 13:16:21 2021 +0100
+
+    GCC: Patch for Apple Silicon compatibility
+    
+    This patch fixes a linker error occuring when compiling
+    the cross-compiler on macOS and ARM64 architecture.
+    
+    Adapted from:
+    https://github.com/richfelker/musl-cross-make/issues/116#issuecomment-823612404
+    
+    Change-Id: Ia3ee98a163bbb62689f42e2da83a5ef36beb0913
+    Reviewed-on: https://review.haiku-os.org/c/buildtools/+/4329
+    Reviewed-by: John Scipione <jscipione@gmail.com>
+    Reviewed-by: Adrien Destugues <pulkomandy@gmail.com>
+
+--- a/gcc/config/aarch64/aarch64.h
++++ b/gcc/config/aarch64/aarch64.h
+@@ -1469,7 +1469,7 @@ extern enum aarch64_code_model aarch64_c
+ 
+ /* Extra specs when building a native AArch64-hosted compiler.
+    Option rewriting rules based on host system.  */
+-#if defined(__aarch64__)
++#if defined(__aarch64__) && ! defined(__APPLE__)
+ extern const char *host_detect_local_cpu (int argc, const char **argv);
+ #define HAVE_LOCAL_CPU_DETECT
+ # define EXTRA_SPEC_FUNCTIONS                                           \
+--- a/gcc/config/host-darwin.cc
++++ b/gcc/config/host-darwin.cc
+@@ -23,6 +23,8 @@
+ #include "options.h"
+ #include "diagnostic-core.h"
+ #include "config/host-darwin.h"
++#include "hosthooks.h"
++#include "hosthooks-def.h"
+ #include <errno.h>
+ 
+ /* For Darwin (macOS only) platforms, without ASLR (PIE) enabled on the
+@@ -181,3 +183,5 @@ darwin_gt_pch_use_address (void *&addr,
+ 
+   return 1;
+ }
++
++const struct host_hooks host_hooks = HOST_HOOKS_INITIALIZER;

--- a/toolchain/gcc/patches-15.x/980-fix-build-error-with-Xcode-16.3.patch
+++ b/toolchain/gcc/patches-15.x/980-fix-build-error-with-Xcode-16.3.patch
@@ -1,0 +1,47 @@
+From 93954654b87552c4fe0273cab99d0f42f213f7f8 Mon Sep 17 00:00:00 2001
+From: Georgi Valkov <gvalkov@gmail.com>
+Date: Mon, 14 Apr 2025 15:45:59 +0300
+Subject: [PATCH] zlib: fix build error with Xcode 16.3
+
+Xcode 16.3 defines TARGET_OS_MAC, it was not defined in prior versions.
+zutil.h conditionally defines fdopen as NULL when this macro is defined,
+resulting in the following build error:
+
+/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:318:7: error: expected identifier or '('
+  318 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
+      |          ^
+./zutil.h:147:33: note: expanded from macro 'fdopen'
+  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
+
+In Xcode 16.2 and earlier, TARGET_OS_MAC was not defined so this entire
+block was ignored, gcc and gdb used to compile and work fine.
+
+This may have been used for compatibility with older versions of macOS,
+but is no longer needed. By pure luck, the build worked fine for a long
+time, because it did not properly detect macOS.
+Fixed by removing the check for TARGET_OS_MAC.
+
+Note that since Xcode 16.3, an entire set of TARGET_OS macros
+are now defined, most of which are set to 0:
+TARGET_OS_LINUX 0
+TARGET_OS_MAC 1
+TARGET_OS_OSX 1
+
+[1] https://github.com/openwrt/openwrt/pull/18467
+
+Signed-off-by: Georgi Valkov <gvalkov@gmail.com>
+---
+ zlib/zutil.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/zlib/zutil.h
++++ b/zlib/zutil.h
+@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]
+ #  endif
+ #endif
+ 
+-#if defined(MACOS) || defined(TARGET_OS_MAC)
++#if defined(MACOS)
+ #  define OS_CODE  7
+ #  ifndef Z_SOLO
+ #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os


### PR DESCRIPTION
patches copy from https://github.com/openwrt/openwrt/tree/main/toolchain/gcc/patches-15.x

The toolchain has been built and tested on the following platforms:

- amd64
- arm64
- riscv64

Preparing for compatibility with potential RISC-V processors and their instruction standards.
