### PR TITLE
mediatek/filogic: update network script

### DIFF
--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -51,7 +51,6 @@ mediatek_setup_interfaces()
 		;;
 	cetron,ct3003*|\
 	cmcc,a10*|\
-	fzs,5gcpe-p3|\
 	jcg,q30-pro|\
 	qihoo,360t7|\
 	tenbay,wr3000k)
@@ -65,6 +64,9 @@ mediatek_setup_interfaces()
 	glinet,gl-xe3000|\
 	openembed,som7981)
 		ucidef_set_interfaces_lan_wan eth1 eth0
+		;;
+	fzs,5gcpe-p3)
+		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
 		;;
 	hf,m7986r1*)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "lan1 usb0"


### PR DESCRIPTION
This device only has three actual physical network ports, but it's being defined as having four. Therefore, i fixed it.