### PR TITLE
kernel: add kmod-hwmon-corsair-cpro

### DIFF
--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -94,6 +94,21 @@ endef
 $(eval $(call KernelPackage,hwmon-coretemp))
 
 
+define KernelPackage/hwmon-corsair-cpro
+  TITLE:=Corsair Commander Pro controller
+  KCONFIG:=CONFIG_SENSORS_CORSAIR_CPRO
+  FILES:=$(LINUX_DIR)/drivers/hwmon/corsair-cpro.ko
+  AUTOLOAD:=$(call AutoProbe,corsair-cpro)
+  $(call AddDepends/hwmon,+kmod-usb-hid)
+endef
+
+define KernelPackage/hwmon-corsair-cpro/description
+ Kernel module for the Corsair Commander Pro controller and Corsair 1000D
+endef
+
+$(eval $(call KernelPackage,hwmon-corsair-cpro))
+
+
 define KernelPackage/hwmon-dme1737
   TITLE:=SMSC DME1737 and compatible monitoring support
   KCONFIG:=CONFIG_SENSORS_DME1737


### PR DESCRIPTION
This module adds support for the Corsair Commander Pro and Corsair Commander Pro (1000D) fan and temperature monitoring controllers.

The Corsair Commander Pro is a PC fan controller, for which the kernel already provides a driver. I have built 2 simple hardware devices that act as Corsair Commander Pro-compatible devices, but with support for only a single fan.

PR AT openwrt: https://github.com/openwrt/openwrt/pull/23465

12V fan:
<img width="4096" height="3072" alt="IMG_20260521_123320" src="https://github.com/user-attachments/assets/a9274fb2-183a-43e9-8a81-4e47902e07e2" />

5V fan:
<img width="3072" height="4096" alt="IMG_20260521_123434" src="https://github.com/user-attachments/assets/fc0c7861-0d7e-49eb-9fcf-c2b31e2d2d9f" />
