### PR TITLE
Fix 502 Bad Gateway caused by print() in LuCI template

### DIFF
--- a/package/lean/mt/luci-app-mtwifi/luasrc/view/admin_mtk/mtk_wifi_dev_cfg.htm
+++ b/package/lean/mt/luci-app-mtwifi/luasrc/view/admin_mtk/mtk_wifi_dev_cfg.htm
@@ -386,12 +386,16 @@ if next(diff) ~= nil then
     <fieldset class="cbi-section">
         <legend> 无线参数（直接修改无线配置）</legend>
         <p> <span style="color: red"><b>警告</b></span> : 如果你不了解请不要修改!</p>
-        <textarea name="raw" id="raw" style="width:98%; height: 200px;"><%
+        <%
+            local raw = ""
             local fd = io.open(dev.profile)
-            for line in fd:lines() do
-                print(line)
+
+            if fd then
+                raw = fd:read("*a")
+                fd:close()
             end
-        %></textarea>
+        %>
+        <textarea name="raw" id="raw" style="width:98%; height: 200px;"><%=raw%></textarea>
     </fieldset>
     <div class="cbi-page-actions">
         <input class="cbi-button cbi-button-reset" value="重置" onclick="location.href='<%=luci.dispatcher.build_url("admin", "network", "wifi", "dev_cfg_view", devname)%>'" type="button" />


### PR DESCRIPTION
## Problem

The template renders the wireless profile into a `<textarea>` using Lua's `print()`:

```lua
for line in fd:lines() do
    print(line)
end
```

`print()` writes to stdout instead of the LuCI template output stream. On recent LuCI/uCode based systems, this corrupts the CGI response and causes:

```
502 Bad Gateway
The process did not produce any response
```

## Reason
Older LuCI environments tolerated or redirected `print()` differently, but recent LuCI/uCode based systems expose this issue because `print()` writes to the CGI stdout instead of the template output stream.

## Steps to reproduce:

1. Open Wireless Parameters (Raw Configuration)
2. The page returns:

```
502 Bad Gateway
The process did not produce any response
```

## Cause:
Lua `print()` is used inside a LuCI template, which writes to stdout and breaks the HTTP response.

## Fix

Instead of printing each line with `print()`, read the file into a string and render it using LuCI template output (`<%= ... %>`). This avoids writing directly to stdout and is compatible with both legacy and current LuCI implementations.