### PR TITLE
Resolve conflict in 001-dts-s905d patch for kernel 6.6.144

### DIFF
--- a/target/linux/amlogic/patches-6.6/001-dts-s905d-fix-high-load.patch
+++ b/target/linux/amlogic/patches-6.6/001-dts-s905d-fix-high-load.patch
@@ -1,12 +1,9 @@
 --- a/arch/arm64/boot/dts/amlogic/meson-gxl-s905d-p230.dts
 +++ b/arch/arm64/boot/dts/amlogic/meson-gxl-s905d-p230.dts
-@@ -84,8 +84,7 @@
- 		reset-gpios = <&gpio GPIOZ_14 GPIO_ACTIVE_LOW>;
- 
+@@ -86,7 +86,6 @@
+
  		interrupt-parent = <&gpio_intc>;
--		interrupts = <29 IRQ_TYPE_LEVEL_LOW>;
+ 		interrupts = <25 IRQ_TYPE_LEVEL_LOW>;
 -		eee-broken-1000t;
-+		interrupts = <25 IRQ_TYPE_LEVEL_LOW>;
  	};
  };
- 


### PR DESCRIPTION
删除了6.6.144冲突部分的内容