### PR TITLE
autocore: fix RPS CPU mask on x86

### DIFF
--- a/package/lean/autocore/files/x86/autocore
+++ b/package/lean/autocore/files/x86/autocore
@@ -7,11 +7,12 @@ start()
 {
 	rfc=4096
 	cc=$(grep -c processor /proc/cpuinfo)
+	cpu_mask=$(printf '%x' "$(( (1 << cc) - 1 ))")
 	rsfe=$(echo $cc*$rfc | bc)
 	sysctl -w net.core.rps_sock_flow_entries=$rsfe >/dev/null
 	for fileRps in $(ls /sys/class/net/eth*/queues/rx-*/rps_cpus)
 	do
-		echo $cc > $fileRps
+		echo "$cpu_mask" > "$fileRps"
 	done
 
 	for fileRfc in $(ls /sys/class/net/eth*/queues/rx-*/rps_flow_cnt)


### PR DESCRIPTION
## Summary

Fix the RPS CPU mask generated by `autocore` on multicore x86 systems.

`/sys/class/net/*/queues/rx-*/rps_cpus` expects a hexadecimal CPU bitmap, but the current script writes the decimal CPU count directly. For example, on a 4-CPU system it writes `4` (mask `0x4`, CPU 2 only) instead of `f` (CPUs 0-3).

This change converts the all-CPU bitmap to hexadecimal before writing it, matching the behavior of OpenWrt's `packet-steering.sh`.

## Scope

- x86 `autocore` only
- no changes to RSS, IRQ affinity, RPS flow table sizing, startup order, or other architectures
- single-CPU behavior remains `1`

## Expected masks

| CPUs | Before | After |
| ---: | :---: | :---: |
| 1 | `1` | `1` |
| 2 | `2` | `3` |
| 4 | `4` | `f` |
| 8 | `8` | `ff` |

The earlier commit `88aed2924e52bda8a2aa29c675edb8a21da41441` explicitly states that x86 RPS/XPS should use all CPUs, so the current CPU-count write appears to be a long-standing mask conversion bug.