### PR TITLE
rockchip: fix King3399 DDR initialization

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -109,6 +109,9 @@ define U-Boot/king3399-rk3399
   NAME:=Rongpin King3399
   BUILD_DEVICES:= \
     rongpin_king3399
+  DEPENDS:=+PACKAGE_u-boot-$(1):rkbin-rk3399
+  ATF:=rk3399_bl31_v1.36.elf
+  USE_RKBIN:=1
 endef
 
 define U-Boot/mpc1903-rk3399

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -632,7 +632,7 @@ define Device/rongpin_king3399
   DEVICE_MODEL := King3399
   SOC := rk3399
   UBOOT_DEVICE_NAME := king3399-rk3399
-  IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-img | gzip | append-metadata
+  IMAGE/sysupgrade.img.gz := boot-common | boot-script | pine64-bin | gzip | append-metadata
   DEVICE_PACKAGES := kmod-r8168 kmod-brcmfmac cypress-firmware-4356-sdio wpad-openssl
 endef
 TARGET_DEVICES += rongpin_king3399


### PR DESCRIPTION
Use the Rockchip rkbin DDR loader and miniloader boot flow for Rongpin King3399.

The open-source U-Boot TPL LPDDR initialization fails DRAM training on the board. The rkbin flow packages the vendor DDR loader at the Rockchip boot offset, followed by the board U-Boot image and trust image.

Validation: rebuilt `rkbin-rk3399`, `u-boot-king3399-rk3399`, and the King3399 sysupgrade image; verified the final image embeds the three boot components at the expected offsets.